### PR TITLE
Use `core::ptr::write` for out params

### DIFF
--- a/crates/libs/windows/src/Windows/AI/MachineLearning/Preview/impl.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/Preview/impl.rs
@@ -17,7 +17,7 @@ impl ILearningModelVariableDescriptorPreview_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -29,7 +29,7 @@ impl ILearningModelVariableDescriptorPreview_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,7 +41,7 @@ impl ILearningModelVariableDescriptorPreview_Vtbl {
             let this = (*this).get_impl();
             match this.ModelFeatureKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -53,7 +53,7 @@ impl ILearningModelVariableDescriptorPreview_Vtbl {
             let this = (*this).get_impl();
             match this.IsRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/impl.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/impl.rs
@@ -14,7 +14,7 @@ impl ILearningModelFeatureDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -26,7 +26,7 @@ impl ILearningModelFeatureDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -38,7 +38,7 @@ impl ILearningModelFeatureDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -50,7 +50,7 @@ impl ILearningModelFeatureDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.IsRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -82,7 +82,7 @@ impl ILearningModelFeatureValue_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -124,7 +124,7 @@ impl ITensor_Vtbl {
             let this = (*this).get_impl();
             match this.TensorKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -136,7 +136,7 @@ impl ITensor_Vtbl {
             let this = (*this).get_impl();
             match this.Shape() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Activation/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Activation/impl.rs
@@ -13,7 +13,7 @@ impl IActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -25,7 +25,7 @@ impl IActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.PreviousExecutionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl IActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.SplashScreen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -71,7 +71,7 @@ impl IActivatedEventArgsWithUser_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -97,7 +97,7 @@ impl IApplicationViewActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentlyShownApplicationViewId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -126,7 +126,7 @@ impl IAppointmentsProviderActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Verb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -158,7 +158,7 @@ impl IAppointmentsProviderAddAppointmentActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.AddAppointmentOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -190,7 +190,7 @@ impl IAppointmentsProviderRemoveAppointmentActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.RemoveAppointmentOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -222,7 +222,7 @@ impl IAppointmentsProviderReplaceAppointmentActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ReplaceAppointmentOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -256,7 +256,7 @@ impl IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.InstanceStartDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -268,7 +268,7 @@ impl IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.LocalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -280,7 +280,7 @@ impl IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.RoamingId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -315,7 +315,7 @@ impl IAppointmentsProviderShowTimeFrameActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TimeToShow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -327,7 +327,7 @@ impl IAppointmentsProviderShowTimeFrameActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Duration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -360,7 +360,7 @@ impl IBackgroundActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TaskInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -389,7 +389,7 @@ impl IBarcodeScannerPreviewActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -421,7 +421,7 @@ impl ICachedFileUpdaterActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFileUpdaterUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -451,7 +451,7 @@ impl ICameraSettingsActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.VideoDeviceController() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -463,7 +463,7 @@ impl ICameraSettingsActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.VideoDeviceExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -493,7 +493,7 @@ impl ICommandLineActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Operation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -522,7 +522,7 @@ impl IContactActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Verb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -553,7 +553,7 @@ impl IContactCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -565,7 +565,7 @@ impl IContactCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceUserId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -577,7 +577,7 @@ impl IContactCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Contact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -612,7 +612,7 @@ impl IContactMapActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -624,7 +624,7 @@ impl IContactMapActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Contact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -659,7 +659,7 @@ impl IContactMessageActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -671,7 +671,7 @@ impl IContactMessageActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceUserId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -683,7 +683,7 @@ impl IContactMessageActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Contact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -718,7 +718,7 @@ impl IContactPanelActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ContactPanel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -730,7 +730,7 @@ impl IContactPanelActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Contact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -763,7 +763,7 @@ impl IContactPickerActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ContactPickerUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -797,7 +797,7 @@ impl IContactPostActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -809,7 +809,7 @@ impl IContactPostActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceUserId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -821,7 +821,7 @@ impl IContactPostActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Contact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -857,7 +857,7 @@ impl IContactVideoCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -869,7 +869,7 @@ impl IContactVideoCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceUserId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -881,7 +881,7 @@ impl IContactVideoCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Contact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -912,7 +912,7 @@ impl IContactsProviderActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Verb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -941,7 +941,7 @@ impl IContinuationActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ContinuationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -971,7 +971,7 @@ impl IDeviceActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceInformationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -983,7 +983,7 @@ impl IDeviceActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Verb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1016,7 +1016,7 @@ impl IDevicePairingActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1045,7 +1045,7 @@ impl IDialReceiverActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.AppName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1078,7 +1078,7 @@ impl IFileActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Files() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1090,7 +1090,7 @@ impl IFileActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Verb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1120,7 +1120,7 @@ impl IFileActivatedEventArgsWithCallerPackageFamilyName_Vtbl {
             let this = (*this).get_impl();
             match this.CallerPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1152,7 +1152,7 @@ impl IFileActivatedEventArgsWithNeighboringFiles_Vtbl {
             let this = (*this).get_impl();
             match this.NeighboringFilesQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1184,7 +1184,7 @@ impl IFileOpenPickerActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.FileOpenPickerUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1213,7 +1213,7 @@ impl IFileOpenPickerActivatedEventArgs2_Vtbl {
             let this = (*this).get_impl();
             match this.CallerPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1245,7 +1245,7 @@ impl IFileOpenPickerContinuationEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Files() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1277,7 +1277,7 @@ impl IFileSavePickerActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.FileSavePickerUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1307,7 +1307,7 @@ impl IFileSavePickerActivatedEventArgs2_Vtbl {
             let this = (*this).get_impl();
             match this.CallerPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1319,7 +1319,7 @@ impl IFileSavePickerActivatedEventArgs2_Vtbl {
             let this = (*this).get_impl();
             match this.EnterpriseId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1352,7 +1352,7 @@ impl IFileSavePickerContinuationEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.File() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1381,7 +1381,7 @@ impl IFolderPickerContinuationEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Folder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1411,7 +1411,7 @@ impl ILaunchActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Arguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1423,7 +1423,7 @@ impl ILaunchActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TileId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1453,7 +1453,7 @@ impl ILaunchActivatedEventArgs2_Vtbl {
             let this = (*this).get_impl();
             match this.TileActivatedInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1482,7 +1482,7 @@ impl ILockScreenActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Info() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1511,7 +1511,7 @@ impl ILockScreenCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CallUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1540,7 +1540,7 @@ impl IPhoneCallActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.LineId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1566,7 +1566,7 @@ impl IPickerReturnedActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.PickerOperationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1595,7 +1595,7 @@ impl IPrelaunchActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.PrelaunchActivated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1627,7 +1627,7 @@ impl IPrint3DWorkflowActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Workflow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1659,7 +1659,7 @@ impl IPrintTaskSettingsActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Configuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1691,7 +1691,7 @@ impl IProtocolActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Uri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1721,7 +1721,7 @@ impl IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData_Vtbl {
             let this = (*this).get_impl();
             match this.CallerPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1733,7 +1733,7 @@ impl IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1766,7 +1766,7 @@ impl IProtocolForResultsActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ProtocolForResultsOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1795,7 +1795,7 @@ impl IRestrictedLaunchActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.SharedContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1825,7 +1825,7 @@ impl ISearchActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.QueryText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1837,7 +1837,7 @@ impl ISearchActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1870,7 +1870,7 @@ impl ISearchActivatedEventArgsWithLinguisticDetails_Vtbl {
             let this = (*this).get_impl();
             match this.LinguisticDetails() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1902,7 +1902,7 @@ impl IShareTargetActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ShareOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1931,7 +1931,7 @@ impl IStartupTaskActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TaskId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1961,7 +1961,7 @@ impl IToastNotificationActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Argument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1973,7 +1973,7 @@ impl IToastNotificationActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.UserInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2006,7 +2006,7 @@ impl IUserDataAccountProviderActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Operation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2038,7 +2038,7 @@ impl IViewSwitcherProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ViewSwitcher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2070,7 +2070,7 @@ impl IVoiceCommandActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Result() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2101,7 +2101,7 @@ impl IWalletActionActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ItemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2113,7 +2113,7 @@ impl IWalletActionActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ActionKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2125,7 +2125,7 @@ impl IWalletActionActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ActionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2159,7 +2159,7 @@ impl IWebAccountProviderActivatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Operation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2191,7 +2191,7 @@ impl IWebAuthenticationBrokerContinuationEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.WebAuthenticationResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/impl.rs
@@ -14,7 +14,7 @@ impl IAppointmentParticipant_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -31,7 +31,7 @@ impl IAppointmentParticipant_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/impl.rs
@@ -53,7 +53,7 @@ impl IBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.InstanceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -65,7 +65,7 @@ impl IBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.Task() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -77,7 +77,7 @@ impl IBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.Progress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -94,7 +94,7 @@ impl IBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.TriggerDetails() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -106,7 +106,7 @@ impl IBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.Canceled(::core::mem::transmute(&cancelhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -123,7 +123,7 @@ impl IBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.SuspendedCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -135,7 +135,7 @@ impl IBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeferral() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -175,7 +175,7 @@ impl IBackgroundTaskInstance2_Vtbl {
             let this = (*this).get_impl();
             match this.GetThrottleCount(counter) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -207,7 +207,7 @@ impl IBackgroundTaskInstance4_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -242,7 +242,7 @@ impl IBackgroundTaskRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.TaskId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -254,7 +254,7 @@ impl IBackgroundTaskRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -266,7 +266,7 @@ impl IBackgroundTaskRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.Progress(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -283,7 +283,7 @@ impl IBackgroundTaskRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.Completed(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -331,7 +331,7 @@ impl IBackgroundTaskRegistration2_Vtbl {
             let this = (*this).get_impl();
             match this.Trigger() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -360,7 +360,7 @@ impl IBackgroundTaskRegistration3_Vtbl {
             let this = (*this).get_impl();
             match this.TaskGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Chat/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Chat/impl.rs
@@ -11,7 +11,7 @@ impl IChatItem_Vtbl {
             let this = (*this).get_impl();
             match this.ItemKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/impl.rs
@@ -14,7 +14,7 @@ impl IContactField_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -26,7 +26,7 @@ impl IContactField_Vtbl {
             let this = (*this).get_impl();
             match this.Category() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -38,7 +38,7 @@ impl IContactField_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -50,7 +50,7 @@ impl IContactField_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -84,7 +84,7 @@ impl IContactFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateField_Default(::core::mem::transmute(&value), r#type) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -96,7 +96,7 @@ impl IContactFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateField_Category(::core::mem::transmute(&value), r#type, category) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -108,7 +108,7 @@ impl IContactFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateField_Custom(::core::mem::transmute(&name), ::core::mem::transmute(&value), r#type, category) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -144,7 +144,7 @@ impl IContactInstantMessageFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstantMessage_Default(::core::mem::transmute(&username)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -156,7 +156,7 @@ impl IContactInstantMessageFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstantMessage_Category(::core::mem::transmute(&username), category) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -168,7 +168,7 @@ impl IContactInstantMessageFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstantMessage_All(::core::mem::transmute(&username), category, ::core::mem::transmute(&service), ::core::mem::transmute(&displaytext), ::core::mem::transmute(&verb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -201,7 +201,7 @@ impl IContactLocationFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLocation_Default(::core::mem::transmute(&unstructuredaddress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -213,7 +213,7 @@ impl IContactLocationFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLocation_Category(::core::mem::transmute(&unstructuredaddress), category) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -225,7 +225,7 @@ impl IContactLocationFieldFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLocation_All(::core::mem::transmute(&unstructuredaddress), category, ::core::mem::transmute(&street), ::core::mem::transmute(&city), ::core::mem::transmute(&region), ::core::mem::transmute(&country), ::core::mem::transmute(&postalcode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Core/impl.rs
@@ -15,7 +15,7 @@ impl ICoreApplicationUnhandledError_Vtbl {
             let this = (*this).get_impl();
             match this.UnhandledErrorDetected(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -103,7 +103,7 @@ impl IFrameworkViewSource_Vtbl {
             let this = (*this).get_impl();
             match this.CreateView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/impl.rs
@@ -17,7 +17,7 @@ impl ICoreDropOperationTarget_Vtbl {
             let this = (*this).get_impl();
             match this.EnterAsync(::core::mem::transmute(&draginfo), ::core::mem::transmute(&draguioverride)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -29,7 +29,7 @@ impl ICoreDropOperationTarget_Vtbl {
             let this = (*this).get_impl();
             match this.OverAsync(::core::mem::transmute(&draginfo), ::core::mem::transmute(&draguioverride)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,7 +41,7 @@ impl ICoreDropOperationTarget_Vtbl {
             let this = (*this).get_impl();
             match this.LeaveAsync(::core::mem::transmute(&draginfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -53,7 +53,7 @@ impl ICoreDropOperationTarget_Vtbl {
             let this = (*this).get_impl();
             match this.DropAsync(::core::mem::transmute(&draginfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/impl.rs
@@ -16,7 +16,7 @@ impl ISearchPaneQueryChangedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.QueryText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -28,7 +28,7 @@ impl ISearchPaneQueryChangedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -40,7 +40,7 @@ impl ISearchPaneQueryChangedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.LinguisticDetails() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/impl.rs
@@ -11,7 +11,7 @@ impl IUserActivityContentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ToJson() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/impl.rs
@@ -11,7 +11,7 @@ impl IUserDataAccountProviderOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/impl.rs
@@ -14,7 +14,7 @@ impl IEnteredBackgroundEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeferral() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -46,7 +46,7 @@ impl ILeavingBackgroundEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeferral() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -94,7 +94,7 @@ impl ISuspendingEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.SuspendingOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -127,7 +127,7 @@ impl ISuspendingOperation_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeferral() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -139,7 +139,7 @@ impl ISuspendingOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Deadline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Data/Json/impl.rs
+++ b/crates/libs/windows/src/Windows/Data/Json/impl.rs
@@ -17,7 +17,7 @@ impl IJsonValue_Vtbl {
             let this = (*this).get_impl();
             match this.ValueType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -29,7 +29,7 @@ impl IJsonValue_Vtbl {
             let this = (*this).get_impl();
             match this.Stringify() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,7 +41,7 @@ impl IJsonValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -53,7 +53,7 @@ impl IJsonValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -65,7 +65,7 @@ impl IJsonValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoolean() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -77,7 +77,7 @@ impl IJsonValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetArray() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -89,7 +89,7 @@ impl IJsonValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Data/Xml/Dom/impl.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Dom/impl.rs
@@ -18,7 +18,7 @@ impl IXmlCharacterData_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -35,7 +35,7 @@ impl IXmlCharacterData_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -47,7 +47,7 @@ impl IXmlCharacterData_Vtbl {
             let this = (*this).get_impl();
             match this.SubstringData(offset, count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -125,7 +125,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.NodeValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -142,7 +142,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.NodeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -154,7 +154,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.NodeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -166,7 +166,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.ParentNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -178,7 +178,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.ChildNodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -190,7 +190,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.FirstChild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -202,7 +202,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.LastChild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -214,7 +214,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.PreviousSibling() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -226,7 +226,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.NextSibling() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -238,7 +238,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.Attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -250,7 +250,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.HasChildNodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -262,7 +262,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -274,7 +274,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.InsertBefore(::core::mem::transmute(&newchild), ::core::mem::transmute(&referencechild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -286,7 +286,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.ReplaceChild(::core::mem::transmute(&newchild), ::core::mem::transmute(&referencechild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -298,7 +298,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.RemoveChild(::core::mem::transmute(&childnode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -310,7 +310,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.AppendChild(::core::mem::transmute(&newchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -322,7 +322,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.CloneNode(deep) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -334,7 +334,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.NamespaceUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -346,7 +346,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.LocalName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -358,7 +358,7 @@ impl IXmlNode_Vtbl {
             let this = (*this).get_impl();
             match this.Prefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -422,7 +422,7 @@ impl IXmlNodeSelector_Vtbl {
             let this = (*this).get_impl();
             match this.SelectSingleNode(::core::mem::transmute(&xpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -434,7 +434,7 @@ impl IXmlNodeSelector_Vtbl {
             let this = (*this).get_impl();
             match this.SelectNodes(::core::mem::transmute(&xpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -446,7 +446,7 @@ impl IXmlNodeSelector_Vtbl {
             let this = (*this).get_impl();
             match this.SelectSingleNodeNS(::core::mem::transmute(&xpath), ::core::mem::transmute(&namespaces)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -458,7 +458,7 @@ impl IXmlNodeSelector_Vtbl {
             let this = (*this).get_impl();
             match this.SelectNodesNS(::core::mem::transmute(&xpath), ::core::mem::transmute(&namespaces)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -492,7 +492,7 @@ impl IXmlNodeSerializer_Vtbl {
             let this = (*this).get_impl();
             match this.GetXml() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -504,7 +504,7 @@ impl IXmlNodeSerializer_Vtbl {
             let this = (*this).get_impl();
             match this.InnerText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -540,7 +540,7 @@ impl IXmlText_Vtbl {
             let this = (*this).get_impl();
             match this.SplitText(offset) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Adc/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/Provider/impl.rs
@@ -20,7 +20,7 @@ impl IAdcControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -32,7 +32,7 @@ impl IAdcControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ResolutionInBits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -44,7 +44,7 @@ impl IAdcControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MinValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -56,7 +56,7 @@ impl IAdcControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MaxValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -68,7 +68,7 @@ impl IAdcControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ChannelMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -85,7 +85,7 @@ impl IAdcControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsChannelModeSupported(channelmode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -107,7 +107,7 @@ impl IAdcControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ReadValue(channelnumber) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -148,7 +148,7 @@ impl IAdcProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetControllers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Custom/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Custom/impl.rs
@@ -15,7 +15,7 @@ impl IIOControlCode_Vtbl {
             let this = (*this).get_impl();
             match this.AccessMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -27,7 +27,7 @@ impl IIOControlCode_Vtbl {
             let this = (*this).get_impl();
             match this.BufferingMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -39,7 +39,7 @@ impl IIOControlCode_Vtbl {
             let this = (*this).get_impl();
             match this.Function() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -51,7 +51,7 @@ impl IIOControlCode_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl IIOControlCode_Vtbl {
             let this = (*this).get_impl();
             match this.ControlCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/impl.rs
@@ -13,7 +13,7 @@ impl IGeoshape_Vtbl {
             let this = (*this).get_impl();
             match this.GeoshapeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -25,7 +25,7 @@ impl IGeoshape_Vtbl {
             let this = (*this).get_impl();
             match this.SpatialReferenceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl IGeoshape_Vtbl {
             let this = (*this).get_impl();
             match this.AltitudeReferenceSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Gpio/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/Provider/impl.rs
@@ -12,7 +12,7 @@ impl IGpioControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.PinCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -24,7 +24,7 @@ impl IGpioControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.OpenPinProvider(pin, sharingmode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -67,7 +67,7 @@ impl IGpioPinProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ValueChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -84,7 +84,7 @@ impl IGpioPinProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DebounceTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -101,7 +101,7 @@ impl IGpioPinProvider_Vtbl {
             let this = (*this).get_impl();
             match this.PinNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -113,7 +113,7 @@ impl IGpioPinProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SharingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -125,7 +125,7 @@ impl IGpioPinProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsDriveModeSupported(drivemode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -137,7 +137,7 @@ impl IGpioPinProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDriveMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -159,7 +159,7 @@ impl IGpioPinProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Read() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -201,7 +201,7 @@ impl IGpioProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetControllers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/impl.rs
@@ -11,7 +11,7 @@ impl II2cControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceProvider(::core::mem::transmute(&settings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -49,7 +49,7 @@ impl II2cDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl II2cDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.WritePartial(::core::slice::from_raw_parts(::core::mem::transmute_copy(&buffer), buffer_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -83,7 +83,7 @@ impl II2cDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ReadPartial(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&buffer), buffer_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -100,7 +100,7 @@ impl II2cDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.WriteReadPartial(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as _), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -138,7 +138,7 @@ impl II2cProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetControllersAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/I2c/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/impl.rs
@@ -16,7 +16,7 @@ impl II2cDeviceStatics_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceSelector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -28,7 +28,7 @@ impl II2cDeviceStatics_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceSelectorFromFriendlyName(::core::mem::transmute(&friendlyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -40,7 +40,7 @@ impl II2cDeviceStatics_Vtbl {
             let this = (*this).get_impl();
             match this.FromIdAsync(::core::mem::transmute(&deviceid), ::core::mem::transmute(&settings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Lights/Effects/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/Effects/impl.rs
@@ -12,7 +12,7 @@ impl ILampArrayEffect_Vtbl {
             let this = (*this).get_impl();
             match this.ZIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Midi/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Midi/impl.rs
@@ -16,7 +16,7 @@ impl IMidiMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Timestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -28,7 +28,7 @@ impl IMidiMessage_Vtbl {
             let this = (*this).get_impl();
             match this.RawData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -40,7 +40,7 @@ impl IMidiMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -86,7 +86,7 @@ impl IMidiOutPort_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Perception/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Perception/Provider/impl.rs
@@ -19,7 +19,7 @@ impl IPerceptionFrameProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FrameProviderInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -31,7 +31,7 @@ impl IPerceptionFrameProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Available() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -43,7 +43,7 @@ impl IPerceptionFrameProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -95,7 +95,7 @@ impl IPerceptionFrameProviderManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameProvider(::core::mem::transmute(&frameproviderinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Perception/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Perception/Provider/mod.rs
@@ -1841,7 +1841,7 @@ impl<F: FnMut(&::core::option::Option<PerceptionFaceAuthenticationGroup>) -> ::w
         let this = this as *mut ::windows::core::RawPtr as *mut Self;
         match ((*this).invoke)(::core::mem::transmute(&sender)) {
             ::core::result::Result::Ok(ok__) => {
-                *result__ = ::core::mem::transmute_copy(&ok__);
+                ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                 ::core::mem::forget(ok__);
                 ::windows::core::HRESULT(0)
             }

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/impl.rs
@@ -11,7 +11,7 @@ impl ICashDrawerEventSourceEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CashDrawer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.CharactersPerLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -80,7 +80,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.LineHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -97,7 +97,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.LineSpacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -109,7 +109,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.LineWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -126,7 +126,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsLetterQuality() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -138,7 +138,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsPaperNearEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -155,7 +155,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.ColorCartridge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -167,7 +167,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsCoverOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -179,7 +179,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsCartridgeRemoved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -191,7 +191,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsCartridgeEmpty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -203,7 +203,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsHeadCleaning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -215,7 +215,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsPaperEmpty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -227,7 +227,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadyToPrint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -239,7 +239,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
             let this = (*this).get_impl();
             match this.ValidateData(::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -301,7 +301,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsPrinterPresent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -313,7 +313,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsDualColorSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -325,7 +325,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.ColorCartridgeCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -337,7 +337,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.CartridgeSensors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -349,7 +349,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsBoldSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -361,7 +361,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsItalicSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -373,7 +373,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsUnderlineSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -385,7 +385,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsDoubleHighPrintSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -397,7 +397,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsDoubleWidePrintSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -409,7 +409,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsDoubleHighDoubleWidePrintSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -421,7 +421,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsPaperEmptySensorSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -433,7 +433,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsPaperNearEndSensorSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -445,7 +445,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedCharactersPerLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -497,7 +497,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsBarcodeSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -509,7 +509,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsBitmapSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -521,7 +521,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsLeft90RotationSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -533,7 +533,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsRight90RotationSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -545,7 +545,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.Is180RotationSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -557,7 +557,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsPrintAreaSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -569,7 +569,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.RuledLineCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -581,7 +581,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedBarcodeRotations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -593,7 +593,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedBitmapRotations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -651,7 +651,7 @@ impl IPosPrinterJob_Vtbl {
             let this = (*this).get_impl();
             match this.ExecuteAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Pwm/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Pwm/Provider/impl.rs
@@ -20,7 +20,7 @@ impl IPwmControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.PinCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -32,7 +32,7 @@ impl IPwmControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ActualFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -44,7 +44,7 @@ impl IPwmControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SetDesiredFrequency(frequency) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -56,7 +56,7 @@ impl IPwmControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MaxFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -68,7 +68,7 @@ impl IPwmControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MinFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -134,7 +134,7 @@ impl IPwmProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetControllers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Scanners/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Scanners/impl.rs
@@ -14,7 +14,7 @@ impl IImageScannerFormatConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -26,7 +26,7 @@ impl IImageScannerFormatConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.Format() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -43,7 +43,7 @@ impl IImageScannerFormatConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.IsFormatSupported(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -106,7 +106,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MinScanArea() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -118,7 +118,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MaxScanArea() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -130,7 +130,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedScanRegion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -147,7 +147,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.AutoCroppingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -164,7 +164,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.IsAutoCroppingModeSupported(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -176,7 +176,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MinResolution() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -188,7 +188,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MaxResolution() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -200,7 +200,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.OpticalResolution() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -212,7 +212,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredResolution() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -229,7 +229,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ActualResolution() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -241,7 +241,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultColorMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -253,7 +253,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ColorMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -270,7 +270,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.IsColorModeSupported(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -282,7 +282,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MinBrightness() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -294,7 +294,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MaxBrightness() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -306,7 +306,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.BrightnessStep() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -318,7 +318,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultBrightness() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -330,7 +330,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.Brightness() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -347,7 +347,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MinContrast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -359,7 +359,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MaxContrast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -371,7 +371,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ContrastStep() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -383,7 +383,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultContrast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -395,7 +395,7 @@ impl IImageScannerSourceConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.Contrast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Sms/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/impl.rs
@@ -17,7 +17,7 @@ impl ISmsBinaryMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Format() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -35,8 +35,8 @@ impl ISmsBinaryMessage_Vtbl {
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -84,7 +84,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.SendMessageAsync(::core::mem::transmute(&message)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -96,7 +96,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CalculateLength(::core::mem::transmute(&message)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -108,7 +108,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.AccountPhoneNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -120,7 +120,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CellularClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -132,7 +132,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.MessageStore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -144,7 +144,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -156,7 +156,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.SmsMessageReceived(::core::mem::transmute(&eventhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -173,7 +173,7 @@ impl ISmsDevice_Vtbl {
             let this = (*this).get_impl();
             match this.SmsDeviceStatusChanged(::core::mem::transmute(&eventhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -217,7 +217,7 @@ impl ISmsMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -229,7 +229,7 @@ impl ISmsMessage_Vtbl {
             let this = (*this).get_impl();
             match this.MessageClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -263,7 +263,7 @@ impl ISmsMessageBase_Vtbl {
             let this = (*this).get_impl();
             match this.MessageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -275,7 +275,7 @@ impl ISmsMessageBase_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -287,7 +287,7 @@ impl ISmsMessageBase_Vtbl {
             let this = (*this).get_impl();
             match this.CellularClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -299,7 +299,7 @@ impl ISmsMessageBase_Vtbl {
             let this = (*this).get_impl();
             match this.MessageClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -311,7 +311,7 @@ impl ISmsMessageBase_Vtbl {
             let this = (*this).get_impl();
             match this.SimIccId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -359,7 +359,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Timestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -371,7 +371,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.PartReferenceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -383,7 +383,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.PartNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -395,7 +395,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.PartCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -407,7 +407,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.To() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -424,7 +424,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.From() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -441,7 +441,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Body() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -458,7 +458,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Encoding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -475,7 +475,7 @@ impl ISmsTextMessage_Vtbl {
             let this = (*this).get_impl();
             match this.ToBinaryMessages(format) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Spi/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/Provider/impl.rs
@@ -11,7 +11,7 @@ impl ISpiControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceProvider(::core::mem::transmute(&settings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -48,7 +48,7 @@ impl ISpiDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -60,7 +60,7 @@ impl ISpiDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -117,7 +117,7 @@ impl ISpiProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetControllersAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/Spi/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/impl.rs
@@ -17,7 +17,7 @@ impl ISpiDeviceStatics_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceSelector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -29,7 +29,7 @@ impl ISpiDeviceStatics_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceSelectorFromFriendlyName(::core::mem::transmute(&friendlyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,7 +41,7 @@ impl ISpiDeviceStatics_Vtbl {
             let this = (*this).get_impl();
             match this.GetBusInfo(::core::mem::transmute(&busid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -53,7 +53,7 @@ impl ISpiDeviceStatics_Vtbl {
             let this = (*this).get_impl();
             match this.FromIdAsync(::core::mem::transmute(&busid), ::core::mem::transmute(&settings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Devices/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/impl.rs
@@ -18,7 +18,7 @@ impl ILowLevelDevicesAggregateProvider_Vtbl {
             let this = (*this).get_impl();
             match this.AdcControllerProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -30,7 +30,7 @@ impl ILowLevelDevicesAggregateProvider_Vtbl {
             let this = (*this).get_impl();
             match this.PwmControllerProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -42,7 +42,7 @@ impl ILowLevelDevicesAggregateProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GpioControllerProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -54,7 +54,7 @@ impl ILowLevelDevicesAggregateProvider_Vtbl {
             let this = (*this).get_impl();
             match this.I2cControllerProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl ILowLevelDevicesAggregateProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SpiControllerProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
@@ -14,7 +14,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IIterable_Vtbl<T> {
             let this = (*this).get_impl();
             match this.First() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -50,7 +50,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IIterator_Vtbl<T> {
             let this = (*this).get_impl();
             match this.Current() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -62,7 +62,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IIterator_Vtbl<T> {
             let this = (*this).get_impl();
             match this.HasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -74,7 +74,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IIterator_Vtbl<T> {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -86,7 +86,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IIterator_Vtbl<T> {
             let this = (*this).get_impl();
             match this.GetMany(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -124,7 +124,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.Key() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -136,7 +136,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -178,7 +178,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.Lookup(::core::mem::transmute(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -190,7 +190,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -202,7 +202,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.HasKey(::core::mem::transmute(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -214,7 +214,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.GetView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -226,7 +226,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.Insert(::core::mem::transmute(&key), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -277,7 +277,7 @@ impl<K: ::windows::core::RuntimeType + 'static> IMapChangedEventArgs_Vtbl<K> {
             let this = (*this).get_impl();
             match this.CollectionChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -289,7 +289,7 @@ impl<K: ::windows::core::RuntimeType + 'static> IMapChangedEventArgs_Vtbl<K> {
             let this = (*this).get_impl();
             match this.Key() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -327,7 +327,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.Lookup(::core::mem::transmute(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -339,7 +339,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -351,7 +351,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.HasKey(::core::mem::transmute(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -395,7 +395,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
             let this = (*this).get_impl();
             match this.MapChanged(::core::mem::transmute(&vhnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -436,7 +436,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IObservableVector_Vtbl<T> {
             let this = (*this).get_impl();
             match this.VectorChanged(::core::mem::transmute(&vhnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -498,7 +498,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVector_Vtbl<T> {
             let this = (*this).get_impl();
             match this.GetAt(index) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -510,7 +510,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVector_Vtbl<T> {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -522,7 +522,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVector_Vtbl<T> {
             let this = (*this).get_impl();
             match this.GetView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -534,7 +534,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVector_Vtbl<T> {
             let this = (*this).get_impl();
             match this.IndexOf(::core::mem::transmute(&value), ::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -576,7 +576,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVector_Vtbl<T> {
             let this = (*this).get_impl();
             match this.GetMany(startindex, ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -623,7 +623,7 @@ impl IVectorChangedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CollectionChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -635,7 +635,7 @@ impl IVectorChangedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Index() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -671,7 +671,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVectorView_Vtbl<T> {
             let this = (*this).get_impl();
             match this.GetAt(index) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -683,7 +683,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVectorView_Vtbl<T> {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -695,7 +695,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVectorView_Vtbl<T> {
             let this = (*this).get_impl();
             match this.IndexOf(::core::mem::transmute(&value), ::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -707,7 +707,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVectorView_Vtbl<T> {
             let this = (*this).get_impl();
             match this.GetMany(startindex, ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/impl.rs
@@ -17,7 +17,7 @@ impl IErrorReportingSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -56,7 +56,7 @@ impl IFileLoggingSession_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -83,7 +83,7 @@ impl IFileLoggingSession_Vtbl {
             let this = (*this).get_impl();
             match this.CloseAndSaveToFileAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -95,7 +95,7 @@ impl IFileLoggingSession_Vtbl {
             let this = (*this).get_impl();
             match this.LogFileGenerated(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -143,7 +143,7 @@ impl ILoggingChannel_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -155,7 +155,7 @@ impl ILoggingChannel_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -167,7 +167,7 @@ impl ILoggingChannel_Vtbl {
             let this = (*this).get_impl();
             match this.Level() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -199,7 +199,7 @@ impl ILoggingChannel_Vtbl {
             let this = (*this).get_impl();
             match this.LoggingEnabled(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -248,7 +248,7 @@ impl ILoggingSession_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -260,7 +260,7 @@ impl ILoggingSession_Vtbl {
             let this = (*this).get_impl();
             match this.SaveToFileAsync(::core::mem::transmute(&folder), ::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -318,7 +318,7 @@ impl ILoggingTarget_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -330,7 +330,7 @@ impl ILoggingTarget_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabledWithLevel(level) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -342,7 +342,7 @@ impl ILoggingTarget_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabledWithLevelAndKeywords(level, keywords) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -374,7 +374,7 @@ impl ILoggingTarget_Vtbl {
             let this = (*this).get_impl();
             match this.StartActivity(::core::mem::transmute(&starteventname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -386,7 +386,7 @@ impl ILoggingTarget_Vtbl {
             let this = (*this).get_impl();
             match this.StartActivityWithFields(::core::mem::transmute(&starteventname), ::core::mem::transmute(&fields)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -398,7 +398,7 @@ impl ILoggingTarget_Vtbl {
             let this = (*this).get_impl();
             match this.StartActivityWithFieldsAndLevel(::core::mem::transmute(&starteventname), ::core::mem::transmute(&fields), level) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -410,7 +410,7 @@ impl ILoggingTarget_Vtbl {
             let this = (*this).get_impl();
             match this.StartActivityWithFieldsAndOptions(::core::mem::transmute(&starteventname), ::core::mem::transmute(&fields), level, ::core::mem::transmute(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Foundation/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/impl.rs
@@ -18,7 +18,7 @@ impl IAsyncAction_Vtbl {
             let this = (*this).get_impl();
             match this.Completed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl<TProgress: ::windows::core::RuntimeType + 'static> IAsyncActionWithProgress
             let this = (*this).get_impl();
             match this.Progress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -83,7 +83,7 @@ impl<TProgress: ::windows::core::RuntimeType + 'static> IAsyncActionWithProgress
             let this = (*this).get_impl();
             match this.Completed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -126,7 +126,7 @@ impl IAsyncInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -138,7 +138,7 @@ impl IAsyncInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -150,7 +150,7 @@ impl IAsyncInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -203,7 +203,7 @@ impl<TResult: ::windows::core::RuntimeType + 'static> IAsyncOperation_Vtbl<TResu
             let this = (*this).get_impl();
             match this.Completed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -215,7 +215,7 @@ impl<TResult: ::windows::core::RuntimeType + 'static> IAsyncOperation_Vtbl<TResu
             let this = (*this).get_impl();
             match this.GetResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -260,7 +260,7 @@ impl<TResult: ::windows::core::RuntimeType + 'static, TProgress: ::windows::core
             let this = (*this).get_impl();
             match this.Progress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -277,7 +277,7 @@ impl<TResult: ::windows::core::RuntimeType + 'static, TProgress: ::windows::core
             let this = (*this).get_impl();
             match this.Completed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -289,7 +289,7 @@ impl<TResult: ::windows::core::RuntimeType + 'static, TProgress: ::windows::core
             let this = (*this).get_impl();
             match this.GetResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -343,7 +343,7 @@ impl IGetActivationFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivationFactory(::core::mem::transmute(&activatableclassid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -372,7 +372,7 @@ impl IMemoryBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -400,7 +400,7 @@ impl IMemoryBufferReference_Vtbl {
             let this = (*this).get_impl();
             match this.Capacity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -412,7 +412,7 @@ impl IMemoryBufferReference_Vtbl {
             let this = (*this).get_impl();
             match this.Closed(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -486,7 +486,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -498,7 +498,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.IsNumericScalar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -510,7 +510,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetUInt8() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -522,7 +522,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetInt16() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -534,7 +534,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetUInt16() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -546,7 +546,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetInt32() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -558,7 +558,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetUInt32() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -570,7 +570,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetInt64() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -582,7 +582,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetUInt64() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -594,7 +594,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetSingle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -606,7 +606,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetDouble() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -618,7 +618,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetChar16() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -630,7 +630,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoolean() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -642,7 +642,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -654,7 +654,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -666,7 +666,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetDateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -678,7 +678,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -690,7 +690,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -702,7 +702,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -714,7 +714,7 @@ impl IPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.GetRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -879,7 +879,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IReference_Vtbl<T> {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -913,8 +913,8 @@ impl<T: ::windows::core::RuntimeType + 'static> IReferenceArray_Vtbl<T> {
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl IStringable_Vtbl {
             let this = (*this).get_impl();
             match this.ToString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -970,7 +970,7 @@ impl IWwwFormUrlDecoderEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -982,7 +982,7 @@ impl IWwwFormUrlDecoderEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/impl.rs
@@ -13,7 +13,7 @@ impl ICustomGameControllerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGameController(::core::mem::transmute(&provider)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -87,7 +87,7 @@ impl IGameControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FirmwareVersionInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -99,7 +99,7 @@ impl IGameControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HardwareProductId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -111,7 +111,7 @@ impl IGameControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HardwareVendorId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -123,7 +123,7 @@ impl IGameControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HardwareVersionInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -135,7 +135,7 @@ impl IGameControllerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/impl.rs
@@ -15,7 +15,7 @@ impl IForceFeedbackEffect_Vtbl {
             let this = (*this).get_impl();
             match this.Gain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -32,7 +32,7 @@ impl IForceFeedbackEffect_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Gaming/Input/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/impl.rs
@@ -22,7 +22,7 @@ impl IGameController_Vtbl {
             let this = (*this).get_impl();
             match this.HeadsetConnected(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -39,7 +39,7 @@ impl IGameController_Vtbl {
             let this = (*this).get_impl();
             match this.HeadsetDisconnected(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -56,7 +56,7 @@ impl IGameController_Vtbl {
             let this = (*this).get_impl();
             match this.UserChanged(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -73,7 +73,7 @@ impl IGameController_Vtbl {
             let this = (*this).get_impl();
             match this.Headset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -85,7 +85,7 @@ impl IGameController_Vtbl {
             let this = (*this).get_impl();
             match this.IsWireless() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -97,7 +97,7 @@ impl IGameController_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -137,7 +137,7 @@ impl IGameControllerBatteryInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TryGetBatteryReport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/impl.rs
@@ -18,7 +18,7 @@ impl IGameListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -30,7 +30,7 @@ impl IGameListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.LaunchAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -42,7 +42,7 @@ impl IGameListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Category() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -54,7 +54,7 @@ impl IGameListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl IGameListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.SetCategoryAsync(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Globalization/NumberFormatting/impl.rs
+++ b/crates/libs/windows/src/Windows/Globalization/NumberFormatting/impl.rs
@@ -13,7 +13,7 @@ impl INumberFormatter_Vtbl {
             let this = (*this).get_impl();
             match this.FormatInt(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -25,7 +25,7 @@ impl INumberFormatter_Vtbl {
             let this = (*this).get_impl();
             match this.FormatUInt(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl INumberFormatter_Vtbl {
             let this = (*this).get_impl();
             match this.FormatDouble(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -70,7 +70,7 @@ impl INumberFormatter2_Vtbl {
             let this = (*this).get_impl();
             match this.FormatInt(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -82,7 +82,7 @@ impl INumberFormatter2_Vtbl {
             let this = (*this).get_impl();
             match this.FormatUInt(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -94,7 +94,7 @@ impl INumberFormatter2_Vtbl {
             let this = (*this).get_impl();
             match this.FormatDouble(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -141,7 +141,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.Languages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -153,7 +153,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GeographicRegion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -165,7 +165,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.IntegerDigits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -182,7 +182,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.FractionDigits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -199,7 +199,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.IsGrouped() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -216,7 +216,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.IsDecimalPointAlwaysDisplayed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -233,7 +233,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.NumeralSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -250,7 +250,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.ResolvedLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -262,7 +262,7 @@ impl INumberFormatterOptions_Vtbl {
             let this = (*this).get_impl();
             match this.ResolvedGeographicRegion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -309,7 +309,7 @@ impl INumberParser_Vtbl {
             let this = (*this).get_impl();
             match this.ParseInt(::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -321,7 +321,7 @@ impl INumberParser_Vtbl {
             let this = (*this).get_impl();
             match this.ParseUInt(::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -333,7 +333,7 @@ impl INumberParser_Vtbl {
             let this = (*this).get_impl();
             match this.ParseDouble(::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -369,7 +369,7 @@ impl INumberRounder_Vtbl {
             let this = (*this).get_impl();
             match this.RoundInt32(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -381,7 +381,7 @@ impl INumberRounder_Vtbl {
             let this = (*this).get_impl();
             match this.RoundUInt32(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -393,7 +393,7 @@ impl INumberRounder_Vtbl {
             let this = (*this).get_impl();
             match this.RoundInt64(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -405,7 +405,7 @@ impl INumberRounder_Vtbl {
             let this = (*this).get_impl();
             match this.RoundUInt64(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -417,7 +417,7 @@ impl INumberRounder_Vtbl {
             let this = (*this).get_impl();
             match this.RoundSingle(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -429,7 +429,7 @@ impl INumberRounder_Vtbl {
             let this = (*this).get_impl();
             match this.RoundDouble(value) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -464,7 +464,7 @@ impl INumberRounderOption_Vtbl {
             let this = (*this).get_impl();
             match this.NumberRounder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -500,7 +500,7 @@ impl ISignedZeroOption_Vtbl {
             let this = (*this).get_impl();
             match this.IsZeroSigned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -536,7 +536,7 @@ impl ISignificantDigitsOption_Vtbl {
             let this = (*this).get_impl();
             match this.SignificantDigits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/impl.rs
@@ -36,7 +36,7 @@ impl IDirect3DSurface_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Graphics/Effects/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Effects/impl.rs
@@ -12,7 +12,7 @@ impl IGraphicsEffect_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Imaging/impl.rs
@@ -25,7 +25,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnailAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.BitmapProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -49,7 +49,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.BitmapPixelFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -61,7 +61,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.BitmapAlphaMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -73,7 +73,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.DpiX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -85,7 +85,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.DpiY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -97,7 +97,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.PixelWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -109,7 +109,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.PixelHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -121,7 +121,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.OrientedPixelWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -133,7 +133,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.OrientedPixelHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -145,7 +145,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelDataAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -157,7 +157,7 @@ impl IBitmapFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelDataTransformedAsync(pixelformat, alphamode, ::core::mem::transmute(&transform), exiforientationmode, colormanagementmode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -202,7 +202,7 @@ impl IBitmapFrameWithSoftwareBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetSoftwareBitmapAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -214,7 +214,7 @@ impl IBitmapFrameWithSoftwareBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetSoftwareBitmapConvertedAsync(pixelformat, alphamode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -226,7 +226,7 @@ impl IBitmapFrameWithSoftwareBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetSoftwareBitmapTransformedAsync(pixelformat, alphamode, ::core::mem::transmute(&transform), exiforientationmode, colormanagementmode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -260,7 +260,7 @@ impl IBitmapPropertiesView_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertiesAsync(::core::mem::transmute(&propertiestoretrieve)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/impl.rs
@@ -17,7 +17,7 @@ impl IPrintCustomOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -50,7 +50,7 @@ impl IPrintItemListOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.Items() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -77,7 +77,7 @@ impl IPrintNumberOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.MinValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -89,7 +89,7 @@ impl IPrintNumberOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.MaxValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -126,7 +126,7 @@ impl IPrintOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.OptionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -138,7 +138,7 @@ impl IPrintOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.OptionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -155,7 +155,7 @@ impl IPrintOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -172,7 +172,7 @@ impl IPrintOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -184,7 +184,7 @@ impl IPrintOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -196,7 +196,7 @@ impl IPrintOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.TrySetValue(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -232,7 +232,7 @@ impl IPrintTextOptionDetails_Vtbl {
             let this = (*this).get_impl();
             match this.MaxCharacters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Graphics/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/impl.rs
@@ -26,7 +26,7 @@ impl IPrintTaskOptionsCore_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageDescription(jobpagenumber) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -83,7 +83,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.MediaSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -100,7 +100,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -117,7 +117,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Orientation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -134,7 +134,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.PrintQuality() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -151,7 +151,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.ColorMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -168,7 +168,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Duplex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -185,7 +185,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Collation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -202,7 +202,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Staple() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -219,7 +219,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.HolePunch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -236,7 +236,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Binding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -248,7 +248,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.MinCopies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -260,7 +260,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.MaxCopies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -277,7 +277,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfCopies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -332,7 +332,7 @@ impl IPrintTaskOptionsCoreUIConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayedOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/Audio/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/impl.rs
@@ -17,7 +17,7 @@ impl IAudioInputNode_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -67,7 +67,7 @@ impl IAudioInputNode2_Vtbl {
             let this = (*this).get_impl();
             match this.Emitter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -106,7 +106,7 @@ impl IAudioNode_Vtbl {
             let this = (*this).get_impl();
             match this.EffectDefinitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -123,7 +123,7 @@ impl IAudioNode_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingGain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -135,7 +135,7 @@ impl IAudioNode_Vtbl {
             let this = (*this).get_impl();
             match this.EncodingProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -147,7 +147,7 @@ impl IAudioNode_Vtbl {
             let this = (*this).get_impl();
             match this.ConsumeInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -225,7 +225,7 @@ impl IAudioNodeWithListener_Vtbl {
             let this = (*this).get_impl();
             match this.Listener() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/impl.rs
@@ -24,7 +24,7 @@ impl IMediaCue_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,7 +41,7 @@ impl IMediaCue_Vtbl {
             let this = (*this).get_impl();
             match this.Duration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -58,7 +58,7 @@ impl IMediaCue_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -108,7 +108,7 @@ impl IMediaStreamDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.IsSelected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -125,7 +125,7 @@ impl IMediaStreamDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -142,7 +142,7 @@ impl IMediaStreamDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -181,7 +181,7 @@ impl IMediaStreamDescriptor2_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -215,7 +215,7 @@ impl IMediaTrack_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -227,7 +227,7 @@ impl IMediaTrack_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -239,7 +239,7 @@ impl IMediaTrack_Vtbl {
             let this = (*this).get_impl();
             match this.TrackKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -256,7 +256,7 @@ impl IMediaTrack_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -295,7 +295,7 @@ impl ISingleSelectMediaTrackList_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedIndexChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -317,7 +317,7 @@ impl ISingleSelectMediaTrackList_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -352,7 +352,7 @@ impl ITimedMetadataTrackProvider_Vtbl {
             let this = (*this).get_impl();
             match this.TimedMetadataTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/Devices/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/impl.rs
@@ -12,7 +12,7 @@ impl IDefaultAudioDeviceChangedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -24,7 +24,7 @@ impl IDefaultAudioDeviceChangedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Role() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -59,7 +59,7 @@ impl IMediaDeviceController_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableMediaStreamProperties(mediastreamtype) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -71,7 +71,7 @@ impl IMediaDeviceController_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaStreamProperties(mediastreamtype) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -83,7 +83,7 @@ impl IMediaDeviceController_Vtbl {
             let this = (*this).get_impl();
             match this.SetMediaStreamPropertiesAsync(mediastreamtype, ::core::mem::transmute(&mediaencodingproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/Effects/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Effects/impl.rs
@@ -15,7 +15,7 @@ impl IAudioEffectDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.ActivatableClassId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -27,7 +27,7 @@ impl IAudioEffectDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -65,7 +65,7 @@ impl IBasicAudioEffect_Vtbl {
             let this = (*this).get_impl();
             match this.UseInputFrameForOutput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -77,7 +77,7 @@ impl IBasicAudioEffect_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedEncodingProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -141,7 +141,7 @@ impl IBasicVideoEffect_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -153,7 +153,7 @@ impl IBasicVideoEffect_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedMemoryTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -165,7 +165,7 @@ impl IBasicVideoEffect_Vtbl {
             let this = (*this).get_impl();
             match this.TimeIndependent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -177,7 +177,7 @@ impl IBasicVideoEffect_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedEncodingProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -240,7 +240,7 @@ impl IVideoCompositor_Vtbl {
             let this = (*this).get_impl();
             match this.TimeIndependent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -297,7 +297,7 @@ impl IVideoCompositorDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.ActivatableClassId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -309,7 +309,7 @@ impl IVideoCompositorDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -343,7 +343,7 @@ impl IVideoEffectDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.ActivatableClassId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -355,7 +355,7 @@ impl IVideoEffectDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/impl.rs
@@ -17,7 +17,7 @@ impl IMediaEncodingProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -29,7 +29,7 @@ impl IMediaEncodingProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -46,7 +46,7 @@ impl IMediaEncodingProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Subtype() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/Playback/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Playback/impl.rs
@@ -15,7 +15,7 @@ impl IMediaEnginePlaybackSource_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/Protection/PlayReady/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/PlayReady/impl.rs
@@ -16,7 +16,7 @@ impl INDClosedCaptionDataReceivedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ClosedCaptionDataFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -28,7 +28,7 @@ impl INDClosedCaptionDataReceivedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.PresentationTimestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,8 +41,8 @@ impl INDClosedCaptionDataReceivedEventArgs_Vtbl {
             match this.ClosedCaptionData() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -77,8 +77,8 @@ impl INDCustomData_Vtbl {
             match this.CustomDataTypeID() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -90,8 +90,8 @@ impl INDCustomData_Vtbl {
             match this.CustomData() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -156,7 +156,7 @@ impl INDDownloadEngine_Vtbl {
             let this = (*this).get_impl();
             match this.CanSeek() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -168,7 +168,7 @@ impl INDDownloadEngine_Vtbl {
             let this = (*this).get_impl();
             match this.BufferFullMinThresholdInSamples() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -180,7 +180,7 @@ impl INDDownloadEngine_Vtbl {
             let this = (*this).get_impl();
             match this.BufferFullMaxThresholdInSamples() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -192,7 +192,7 @@ impl INDDownloadEngine_Vtbl {
             let this = (*this).get_impl();
             match this.Notifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -292,7 +292,7 @@ impl INDLicenseFetchCompletedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseCustomData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -327,7 +327,7 @@ impl INDLicenseFetchDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.ContentIDType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -340,8 +340,8 @@ impl INDLicenseFetchDescriptor_Vtbl {
             match this.ContentID() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -352,7 +352,7 @@ impl INDLicenseFetchDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.LicenseFetchChallengeCustomData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -392,7 +392,7 @@ impl INDLicenseFetchResult_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseCustomData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -427,7 +427,7 @@ impl INDMessenger_Vtbl {
             let this = (*this).get_impl();
             match this.SendRegistrationRequestAsync(::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -439,7 +439,7 @@ impl INDMessenger_Vtbl {
             let this = (*this).get_impl();
             match this.SendProximityDetectionStartAsync(pdtype, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&transmitterchannelbytes), transmitterChannelBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -451,7 +451,7 @@ impl INDMessenger_Vtbl {
             let this = (*this).get_impl();
             match this.SendProximityDetectionResponseAsync(pdtype, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&transmitterchannelbytes), transmitterChannelBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&responsedatabytes), responseDataBytes_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -463,7 +463,7 @@ impl INDMessenger_Vtbl {
             let this = (*this).get_impl();
             match this.SendLicenseFetchRequestAsync(::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -498,7 +498,7 @@ impl INDProximityDetectionCompletedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ProximityDetectionRetryCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -533,7 +533,7 @@ impl INDRegistrationCompletedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseCustomData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -545,7 +545,7 @@ impl INDRegistrationCompletedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TransmitterProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -557,7 +557,7 @@ impl INDRegistrationCompletedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TransmitterCertificateAccepted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -598,8 +598,8 @@ impl INDSendResult_Vtbl {
             match this.Response() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -627,7 +627,7 @@ impl INDStartResult_Vtbl {
             let this = (*this).get_impl();
             match this.MediaStreamSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -659,7 +659,7 @@ impl INDStorageFileHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileURLs(::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -697,7 +697,7 @@ impl INDStreamParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamInformation(::core::mem::transmute(&descriptor), ::core::mem::transmute_copy(&streamtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -719,7 +719,7 @@ impl INDStreamParser_Vtbl {
             let this = (*this).get_impl();
             match this.Notifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -811,7 +811,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.CertificateType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -823,7 +823,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.PlatformIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -836,8 +836,8 @@ impl INDTransmitterProperties_Vtbl {
             match this.SupportedFeatures() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -848,7 +848,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.SecurityLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -860,7 +860,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.SecurityVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -872,7 +872,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.ExpirationDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -885,8 +885,8 @@ impl INDTransmitterProperties_Vtbl {
             match this.ClientID() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -898,8 +898,8 @@ impl INDTransmitterProperties_Vtbl {
             match this.ModelDigest() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -910,7 +910,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.ModelManufacturerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -922,7 +922,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.ModelName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -934,7 +934,7 @@ impl INDTransmitterProperties_Vtbl {
             let this = (*this).get_impl();
             match this.ModelNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -980,7 +980,7 @@ impl IPlayReadyDomain_Vtbl {
             let this = (*this).get_impl();
             match this.AccountId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -992,7 +992,7 @@ impl IPlayReadyDomain_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1004,7 +1004,7 @@ impl IPlayReadyDomain_Vtbl {
             let this = (*this).get_impl();
             match this.Revision() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1016,7 +1016,7 @@ impl IPlayReadyDomain_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1028,7 +1028,7 @@ impl IPlayReadyDomain_Vtbl {
             let this = (*this).get_impl();
             match this.DomainJoinUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1070,7 +1070,7 @@ impl IPlayReadyLicense_Vtbl {
             let this = (*this).get_impl();
             match this.FullyEvaluated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1082,7 +1082,7 @@ impl IPlayReadyLicense_Vtbl {
             let this = (*this).get_impl();
             match this.UsableForPlay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1094,7 +1094,7 @@ impl IPlayReadyLicense_Vtbl {
             let this = (*this).get_impl();
             match this.ExpirationDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1106,7 +1106,7 @@ impl IPlayReadyLicense_Vtbl {
             let this = (*this).get_impl();
             match this.ExpireAfterFirstPlay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1118,7 +1118,7 @@ impl IPlayReadyLicense_Vtbl {
             let this = (*this).get_impl();
             match this.DomainAccountID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1130,7 +1130,7 @@ impl IPlayReadyLicense_Vtbl {
             let this = (*this).get_impl();
             match this.ChainDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1142,7 +1142,7 @@ impl IPlayReadyLicense_Vtbl {
             let this = (*this).get_impl();
             match this.GetKIDAtChainDepth(chaindepth) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1183,7 +1183,7 @@ impl IPlayReadyLicenseAcquisitionServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ContentHeader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1200,7 +1200,7 @@ impl IPlayReadyLicenseAcquisitionServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.DomainServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1238,7 +1238,7 @@ impl IPlayReadyLicenseSession_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLAServiceRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1276,7 +1276,7 @@ impl IPlayReadyLicenseSession2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLicenseIterable(::core::mem::transmute(&contentheader), fullyevaluated) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1312,7 +1312,7 @@ impl IPlayReadySecureStopServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.SessionID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1324,7 +1324,7 @@ impl IPlayReadySecureStopServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1336,7 +1336,7 @@ impl IPlayReadySecureStopServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1348,7 +1348,7 @@ impl IPlayReadySecureStopServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Stopped() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1361,8 +1361,8 @@ impl IPlayReadySecureStopServiceRequest_Vtbl {
             match this.PublisherCertificate() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1405,7 +1405,7 @@ impl IPlayReadyServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Uri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1422,7 +1422,7 @@ impl IPlayReadyServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseCustomData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1434,7 +1434,7 @@ impl IPlayReadyServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ChallengeCustomData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1451,7 +1451,7 @@ impl IPlayReadyServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.BeginServiceRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1463,7 +1463,7 @@ impl IPlayReadyServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.NextServiceRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1475,7 +1475,7 @@ impl IPlayReadyServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateManualEnablingChallenge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1487,7 +1487,7 @@ impl IPlayReadyServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessManualEnablingResponse(::core::slice::from_raw_parts(::core::mem::transmute_copy(&responsebytes), responseBytes_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/Protection/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/impl.rs
@@ -12,7 +12,7 @@ impl IMediaProtectionServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ProtectionSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -24,7 +24,7 @@ impl IMediaProtectionServiceRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/SpeechRecognition/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechRecognition/impl.rs
@@ -17,7 +17,7 @@ impl ISpeechRecognitionConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -34,7 +34,7 @@ impl ISpeechRecognitionConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.Tag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -51,7 +51,7 @@ impl ISpeechRecognitionConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl ISpeechRecognitionConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.Probability() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/impl.rs
@@ -46,7 +46,7 @@ impl IMediaFrame_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -58,7 +58,7 @@ impl IMediaFrame_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -75,7 +75,7 @@ impl IMediaFrame_Vtbl {
             let this = (*this).get_impl();
             match this.RelativeTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -92,7 +92,7 @@ impl IMediaFrame_Vtbl {
             let this = (*this).get_impl();
             match this.SystemRelativeTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -109,7 +109,7 @@ impl IMediaFrame_Vtbl {
             let this = (*this).get_impl();
             match this.Duration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -126,7 +126,7 @@ impl IMediaFrame_Vtbl {
             let this = (*this).get_impl();
             match this.IsDiscontinuous() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -138,7 +138,7 @@ impl IMediaFrame_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -182,7 +182,7 @@ impl IMediaMarker_Vtbl {
             let this = (*this).get_impl();
             match this.Time() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -194,7 +194,7 @@ impl IMediaMarker_Vtbl {
             let this = (*this).get_impl();
             match this.MediaMarkerType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -206,7 +206,7 @@ impl IMediaMarker_Vtbl {
             let this = (*this).get_impl();
             match this.Text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -240,7 +240,7 @@ impl IMediaMarkers_Vtbl {
             let this = (*this).get_impl();
             match this.Markers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/impl.rs
+++ b/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/impl.rs
@@ -29,7 +29,7 @@ impl IBackgroundTransferBase_Vtbl {
             let this = (*this).get_impl();
             match this.ServerCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -46,7 +46,7 @@ impl IBackgroundTransferBase_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl IBackgroundTransferBase_Vtbl {
             let this = (*this).get_impl();
             match this.Method() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -80,7 +80,7 @@ impl IBackgroundTransferBase_Vtbl {
             let this = (*this).get_impl();
             match this.Group() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -97,7 +97,7 @@ impl IBackgroundTransferBase_Vtbl {
             let this = (*this).get_impl();
             match this.CostPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -142,7 +142,7 @@ impl IBackgroundTransferContentPartFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateWithName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -154,7 +154,7 @@ impl IBackgroundTransferContentPartFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateWithNameAndFileName(::core::mem::transmute(&name), ::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -194,7 +194,7 @@ impl IBackgroundTransferOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -206,7 +206,7 @@ impl IBackgroundTransferOperation_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -218,7 +218,7 @@ impl IBackgroundTransferOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Method() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -230,7 +230,7 @@ impl IBackgroundTransferOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Group() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -242,7 +242,7 @@ impl IBackgroundTransferOperation_Vtbl {
             let this = (*this).get_impl();
             match this.CostPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -259,7 +259,7 @@ impl IBackgroundTransferOperation_Vtbl {
             let this = (*this).get_impl();
             match this.GetResultStreamAt(position) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -271,7 +271,7 @@ impl IBackgroundTransferOperation_Vtbl {
             let this = (*this).get_impl();
             match this.GetResponseInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -308,7 +308,7 @@ impl IBackgroundTransferOperationPriority_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Networking/Sockets/impl.rs
+++ b/crates/libs/windows/src/Windows/Networking/Sockets/impl.rs
@@ -11,7 +11,7 @@ impl IControlChannelTriggerEventDetails_Vtbl {
             let this = (*this).get_impl();
             match this.ControlChannelTrigger() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -42,7 +42,7 @@ impl IControlChannelTriggerResetEventDetails_Vtbl {
             let this = (*this).get_impl();
             match this.ResetReason() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -54,7 +54,7 @@ impl IControlChannelTriggerResetEventDetails_Vtbl {
             let this = (*this).get_impl();
             match this.HardwareSlotReset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl IControlChannelTriggerResetEventDetails_Vtbl {
             let this = (*this).get_impl();
             match this.SoftwareSlotReset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -105,7 +105,7 @@ impl IWebSocket_Vtbl {
             let this = (*this).get_impl();
             match this.OutputStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -117,7 +117,7 @@ impl IWebSocket_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectAsync(::core::mem::transmute(&uri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -134,7 +134,7 @@ impl IWebSocket_Vtbl {
             let this = (*this).get_impl();
             match this.Closed(::core::mem::transmute(&eventhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -187,7 +187,7 @@ impl IWebSocketControl_Vtbl {
             let this = (*this).get_impl();
             match this.OutboundBufferSizeInBytes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -204,7 +204,7 @@ impl IWebSocketControl_Vtbl {
             let this = (*this).get_impl();
             match this.ServerCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -221,7 +221,7 @@ impl IWebSocketControl_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -238,7 +238,7 @@ impl IWebSocketControl_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedProtocols() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -276,7 +276,7 @@ impl IWebSocketControl2_Vtbl {
             let this = (*this).get_impl();
             match this.IgnorableServerCertificateErrors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -307,7 +307,7 @@ impl IWebSocketInformation_Vtbl {
             let this = (*this).get_impl();
             match this.LocalAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -319,7 +319,7 @@ impl IWebSocketInformation_Vtbl {
             let this = (*this).get_impl();
             match this.BandwidthStatistics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -331,7 +331,7 @@ impl IWebSocketInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Protocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -368,7 +368,7 @@ impl IWebSocketInformation2_Vtbl {
             let this = (*this).get_impl();
             match this.ServerCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -380,7 +380,7 @@ impl IWebSocketInformation2_Vtbl {
             let this = (*this).get_impl();
             match this.ServerCertificateErrorSeverity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -392,7 +392,7 @@ impl IWebSocketInformation2_Vtbl {
             let this = (*this).get_impl();
             match this.ServerCertificateErrors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -404,7 +404,7 @@ impl IWebSocketInformation2_Vtbl {
             let this = (*this).get_impl();
             match this.ServerIntermediateCertificates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Networking/Vpn/impl.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/impl.rs
@@ -39,7 +39,7 @@ impl IVpnCredential_Vtbl {
             let this = (*this).get_impl();
             match this.PasskeyCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -51,7 +51,7 @@ impl IVpnCredential_Vtbl {
             let this = (*this).get_impl();
             match this.CertificateCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl IVpnCredential_Vtbl {
             let this = (*this).get_impl();
             match this.AdditionalPin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -75,7 +75,7 @@ impl IVpnCredential_Vtbl {
             let this = (*this).get_impl();
             match this.OldPasswordCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -117,7 +117,7 @@ impl IVpnCustomPrompt_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -134,7 +134,7 @@ impl IVpnCustomPrompt_Vtbl {
             let this = (*this).get_impl();
             match this.Compulsory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -151,7 +151,7 @@ impl IVpnCustomPrompt_Vtbl {
             let this = (*this).get_impl();
             match this.Bordered() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -195,7 +195,7 @@ impl IVpnCustomPromptElement_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -212,7 +212,7 @@ impl IVpnCustomPromptElement_Vtbl {
             let this = (*this).get_impl();
             match this.Compulsory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -229,7 +229,7 @@ impl IVpnCustomPromptElement_Vtbl {
             let this = (*this).get_impl();
             match this.Emphasized() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -266,7 +266,7 @@ impl IVpnDomainNameInfoFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVpnDomainNameInfo(::core::mem::transmute(&name), nametype, ::core::mem::transmute(&dnsserverlist), ::core::mem::transmute(&proxyserverlist)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -295,7 +295,7 @@ impl IVpnInterfaceIdFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVpnInterfaceId(::core::slice::from_raw_parts(::core::mem::transmute_copy(&address), address_array_size as _)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -327,7 +327,7 @@ impl IVpnNamespaceInfoFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVpnNamespaceInfo(::core::mem::transmute(&name), ::core::mem::transmute(&dnsserverlist), ::core::mem::transmute(&proxyserverlist)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -356,7 +356,7 @@ impl IVpnPacketBufferFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVpnPacketBuffer(::core::mem::transmute(&parentbuffer), offset, length) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -447,7 +447,7 @@ impl IVpnProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ProfileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -464,7 +464,7 @@ impl IVpnProfile_Vtbl {
             let this = (*this).get_impl();
             match this.AppTriggers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -476,7 +476,7 @@ impl IVpnProfile_Vtbl {
             let this = (*this).get_impl();
             match this.Routes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -488,7 +488,7 @@ impl IVpnProfile_Vtbl {
             let this = (*this).get_impl();
             match this.DomainNameInfoList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -500,7 +500,7 @@ impl IVpnProfile_Vtbl {
             let this = (*this).get_impl();
             match this.TrafficFilters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -512,7 +512,7 @@ impl IVpnProfile_Vtbl {
             let this = (*this).get_impl();
             match this.RememberCredentials() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -529,7 +529,7 @@ impl IVpnProfile_Vtbl {
             let this = (*this).get_impl();
             match this.AlwaysOn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -572,7 +572,7 @@ impl IVpnRouteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVpnRoute(::core::mem::transmute(&address), prefixsize) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Phone/Notification/Management/impl.rs
+++ b/crates/libs/windows/src/Windows/Phone/Notification/Management/impl.rs
@@ -19,7 +19,7 @@ impl IAccessoryNotificationTriggerDetails_Vtbl {
             let this = (*this).get_impl();
             match this.TimeCreated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -31,7 +31,7 @@ impl IAccessoryNotificationTriggerDetails_Vtbl {
             let this = (*this).get_impl();
             match this.AppDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -43,7 +43,7 @@ impl IAccessoryNotificationTriggerDetails_Vtbl {
             let this = (*this).get_impl();
             match this.AppId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -55,7 +55,7 @@ impl IAccessoryNotificationTriggerDetails_Vtbl {
             let this = (*this).get_impl();
             match this.AccessoryNotificationType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -67,7 +67,7 @@ impl IAccessoryNotificationTriggerDetails_Vtbl {
             let this = (*this).get_impl();
             match this.StartedProcessing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Phone/PersonalInformation/impl.rs
+++ b/crates/libs/windows/src/Windows/Phone/PersonalInformation/impl.rs
@@ -29,7 +29,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -46,7 +46,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.FamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GivenName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -80,7 +80,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.HonorificPrefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -97,7 +97,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.HonorificSuffix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -114,7 +114,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayPictureAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -126,7 +126,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.SetDisplayPictureAsync(::core::mem::transmute(&stream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -138,7 +138,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayPicture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -150,7 +150,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertiesAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -162,7 +162,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ToVcardAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -174,7 +174,7 @@ impl IContactInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ToVcardWithOptionsAsync(format) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -222,7 +222,7 @@ impl IContactInformation2_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayPictureDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Phone/StartScreen/impl.rs
+++ b/crates/libs/windows/src/Windows/Phone/StartScreen/impl.rs
@@ -14,7 +14,7 @@ impl IToastNotificationManagerStatics3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateToastNotifierForSecondaryTile(::core::mem::transmute(&tileid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/impl.rs
@@ -43,7 +43,7 @@ impl IWebAccountProviderOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -101,7 +101,7 @@ impl IWebAccountProviderTokenObjects_Vtbl {
             let this = (*this).get_impl();
             match this.Operation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -133,7 +133,7 @@ impl IWebAccountProviderTokenObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -165,7 +165,7 @@ impl IWebAccountProviderTokenOperation_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -177,7 +177,7 @@ impl IWebAccountProviderTokenOperation_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderResponses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -194,7 +194,7 @@ impl IWebAccountProviderTokenOperation_Vtbl {
             let this = (*this).get_impl();
             match this.CacheExpirationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Security/Credentials/impl.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/impl.rs
@@ -13,7 +13,7 @@ impl IWebAccount_Vtbl {
             let this = (*this).get_impl();
             match this.WebAccountProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -25,7 +25,7 @@ impl IWebAccount_Vtbl {
             let this = (*this).get_impl();
             match this.UserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl IWebAccount_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/impl.rs
@@ -29,7 +29,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.AddOverloadDefaultMetadata(::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,7 +41,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&file), ::core::mem::transmute(&metadata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemAsync(::core::mem::transmute(&token)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -75,7 +75,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileAsync(::core::mem::transmute(&token)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -87,7 +87,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderAsync(::core::mem::transmute(&token)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -99,7 +99,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemWithOptionsAsync(::core::mem::transmute(&token), options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -111,7 +111,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileWithOptionsAsync(::core::mem::transmute(&token), options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -123,7 +123,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderWithOptionsAsync(::core::mem::transmute(&token), options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -140,7 +140,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.ContainsItem(::core::mem::transmute(&token)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -157,7 +157,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.CheckAccess(::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -169,7 +169,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.Entries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -181,7 +181,7 @@ impl IStorageItemAccessList_Vtbl {
             let this = (*this).get_impl();
             match this.MaximumItemsAllowed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Storage/BulkAccess/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/BulkAccess/impl.rs
@@ -23,7 +23,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.MusicProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -35,7 +35,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.VideoProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -47,7 +47,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ImageProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -59,7 +59,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -71,7 +71,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.BasicProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -83,7 +83,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Thumbnail() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -95,7 +95,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ThumbnailUpdated(::core::mem::transmute(&changedhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -112,7 +112,7 @@ impl IStorageItemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.PropertiesUpdated(::core::mem::transmute(&changedhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/impl.rs
@@ -16,7 +16,7 @@ impl IStorageItemExtraProperties_Vtbl {
             let this = (*this).get_impl();
             match this.RetrievePropertiesAsync(::core::mem::transmute(&propertiestoretrieve)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -28,7 +28,7 @@ impl IStorageItemExtraProperties_Vtbl {
             let this = (*this).get_impl();
             match this.SavePropertiesAsync(::core::mem::transmute(&propertiestosave)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -40,7 +40,7 @@ impl IStorageItemExtraProperties_Vtbl {
             let this = (*this).get_impl();
             match this.SavePropertiesAsyncOverloadDefault() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Storage/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/impl.rs
@@ -11,7 +11,7 @@ impl IStorageProviderHandlerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatusSource(::core::mem::transmute(&syncrootid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -43,7 +43,7 @@ impl IStorageProviderItemPropertySource_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemProperties(::core::mem::transmute(&itempath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -72,7 +72,7 @@ impl IStorageProviderPropertyCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.IsPropertySupported(::core::mem::transmute(&propertycanonicalname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -106,7 +106,7 @@ impl IStorageProviderStatusSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -118,7 +118,7 @@ impl IStorageProviderStatusSource_Vtbl {
             let this = (*this).get_impl();
             match this.Changed(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Storage/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/Search/impl.rs
@@ -20,7 +20,7 @@ impl IIndexableContent_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl IIndexableContent_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -49,7 +49,7 @@ impl IIndexableContent_Vtbl {
             let this = (*this).get_impl();
             match this.Stream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl IIndexableContent_Vtbl {
             let this = (*this).get_impl();
             match this.StreamContentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -125,7 +125,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexedStateAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -137,7 +137,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileQueryOverloadDefault() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -149,7 +149,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileQuery(query) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -161,7 +161,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileQueryWithOptions(::core::mem::transmute(&queryoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -173,7 +173,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolderQueryOverloadDefault() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -185,7 +185,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolderQuery(query) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -197,7 +197,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolderQueryWithOptions(::core::mem::transmute(&queryoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -209,7 +209,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItemQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -221,7 +221,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItemQueryWithOptions(::core::mem::transmute(&queryoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -233,7 +233,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilesAsync(query, startindex, maxitemstoretrieve) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -245,7 +245,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilesAsyncOverloadDefaultStartAndCount(query) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -257,7 +257,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.GetFoldersAsync(query, startindex, maxitemstoretrieve) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -269,7 +269,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.GetFoldersAsyncOverloadDefaultStartAndCount(query) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -281,7 +281,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemsAsync(startindex, maxitemstoretrieve) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -293,7 +293,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.AreQueryOptionsSupported(::core::mem::transmute(&queryoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -305,7 +305,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.IsCommonFolderQuerySupported(query) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -317,7 +317,7 @@ impl IStorageFolderQueryOperations_Vtbl {
             let this = (*this).get_impl();
             match this.IsCommonFileQuerySupported(query) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -373,7 +373,7 @@ impl IStorageQueryResultBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemCountAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -385,7 +385,7 @@ impl IStorageQueryResultBase_Vtbl {
             let this = (*this).get_impl();
             match this.Folder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -397,7 +397,7 @@ impl IStorageQueryResultBase_Vtbl {
             let this = (*this).get_impl();
             match this.ContentsChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -414,7 +414,7 @@ impl IStorageQueryResultBase_Vtbl {
             let this = (*this).get_impl();
             match this.OptionsChanged(::core::mem::transmute(&changedhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -431,7 +431,7 @@ impl IStorageQueryResultBase_Vtbl {
             let this = (*this).get_impl();
             match this.FindStartIndexAsync(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -443,7 +443,7 @@ impl IStorageQueryResultBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentQueryOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Storage/Streams/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/impl.rs
@@ -13,7 +13,7 @@ impl IBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Capacity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -25,7 +25,7 @@ impl IBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -61,7 +61,7 @@ impl IContentTypeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ContentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -115,7 +115,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.UnconsumedBufferLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -127,7 +127,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.UnicodeEncoding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -144,7 +144,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ByteOrder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -161,7 +161,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.InputStreamOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -178,7 +178,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadByte() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -195,7 +195,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadBuffer(length) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -207,7 +207,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadBoolean() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -219,7 +219,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -231,7 +231,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadInt16() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -243,7 +243,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadInt32() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -255,7 +255,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadInt64() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -267,7 +267,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadUInt16() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -279,7 +279,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadUInt32() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -291,7 +291,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadUInt64() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -303,7 +303,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadSingle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -315,7 +315,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadDouble() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -327,7 +327,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadString(codeunitcount) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -339,7 +339,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadDateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -351,7 +351,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadTimeSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -363,7 +363,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.LoadAsync(count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -375,7 +375,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.DetachBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -387,7 +387,7 @@ impl IDataReader_Vtbl {
             let this = (*this).get_impl();
             match this.DetachStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -470,7 +470,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.UnstoredBufferLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -482,7 +482,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.UnicodeEncoding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -499,7 +499,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.ByteOrder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -596,7 +596,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.WriteString(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -608,7 +608,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.MeasureString(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -620,7 +620,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.StoreAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -632,7 +632,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.FlushAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -644,7 +644,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.DetachBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -656,7 +656,7 @@ impl IDataWriter_Vtbl {
             let this = (*this).get_impl();
             match this.DetachStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -714,7 +714,7 @@ impl IInputStream_Vtbl {
             let this = (*this).get_impl();
             match this.ReadAsync(::core::mem::transmute(&buffer), count, options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -743,7 +743,7 @@ impl IInputStreamReference_Vtbl {
             let this = (*this).get_impl();
             match this.OpenSequentialReadAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -776,7 +776,7 @@ impl IOutputStream_Vtbl {
             let this = (*this).get_impl();
             match this.WriteAsync(::core::mem::transmute(&buffer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -788,7 +788,7 @@ impl IOutputStream_Vtbl {
             let this = (*this).get_impl();
             match this.FlushAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -822,7 +822,7 @@ impl IPropertySetSerializer_Vtbl {
             let this = (*this).get_impl();
             match this.Serialize(::core::mem::transmute(&propertyset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -868,7 +868,7 @@ impl IRandomAccessStream_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -885,7 +885,7 @@ impl IRandomAccessStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStreamAt(position) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -897,7 +897,7 @@ impl IRandomAccessStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamAt(position) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -909,7 +909,7 @@ impl IRandomAccessStream_Vtbl {
             let this = (*this).get_impl();
             match this.Position() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -926,7 +926,7 @@ impl IRandomAccessStream_Vtbl {
             let this = (*this).get_impl();
             match this.CloneStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -938,7 +938,7 @@ impl IRandomAccessStream_Vtbl {
             let this = (*this).get_impl();
             match this.CanRead() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -950,7 +950,7 @@ impl IRandomAccessStream_Vtbl {
             let this = (*this).get_impl();
             match this.CanWrite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -990,7 +990,7 @@ impl IRandomAccessStreamReference_Vtbl {
             let this = (*this).get_impl();
             match this.OpenReadAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Storage/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/impl.rs
@@ -25,7 +25,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.FileType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.ContentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -49,7 +49,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.OpenAsync(accessmode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -61,7 +61,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.OpenTransactedWriteAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -73,7 +73,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.CopyOverloadDefaultNameAndOptions(::core::mem::transmute(&destinationfolder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -85,7 +85,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.CopyOverloadDefaultOptions(::core::mem::transmute(&destinationfolder), ::core::mem::transmute(&desirednewname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -97,7 +97,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.CopyOverload(::core::mem::transmute(&destinationfolder), ::core::mem::transmute(&desirednewname), option) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -109,7 +109,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.CopyAndReplaceAsync(::core::mem::transmute(&filetoreplace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -121,7 +121,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.MoveOverloadDefaultNameAndOptions(::core::mem::transmute(&destinationfolder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -133,7 +133,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.MoveOverloadDefaultOptions(::core::mem::transmute(&destinationfolder), ::core::mem::transmute(&desirednewname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -145,7 +145,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.MoveOverload(::core::mem::transmute(&destinationfolder), ::core::mem::transmute(&desirednewname), option) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -157,7 +157,7 @@ impl IStorageFile_Vtbl {
             let this = (*this).get_impl();
             match this.MoveAndReplaceAsync(::core::mem::transmute(&filetoreplace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -201,7 +201,7 @@ impl IStorageFile2_Vtbl {
             let this = (*this).get_impl();
             match this.OpenWithOptionsAsync(accessmode, options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -213,7 +213,7 @@ impl IStorageFile2_Vtbl {
             let this = (*this).get_impl();
             match this.OpenTransactedWriteWithOptionsAsync(options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -243,7 +243,7 @@ impl IStorageFilePropertiesWithAvailability_Vtbl {
             let this = (*this).get_impl();
             match this.IsAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -284,7 +284,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileAsyncOverloadDefaultOptions(::core::mem::transmute(&desiredname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -296,7 +296,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileAsync(::core::mem::transmute(&desiredname), options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -308,7 +308,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolderAsyncOverloadDefaultOptions(::core::mem::transmute(&desiredname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -320,7 +320,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolderAsync(::core::mem::transmute(&desiredname), options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -332,7 +332,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileAsync(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -344,7 +344,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderAsync(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -356,7 +356,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemAsync(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -368,7 +368,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilesAsyncOverloadDefaultOptionsStartAndCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -380,7 +380,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFoldersAsyncOverloadDefaultOptionsStartAndCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -392,7 +392,7 @@ impl IStorageFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemsAsyncOverloadDefaultStartAndCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -433,7 +433,7 @@ impl IStorageFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.TryGetItemAsync(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -474,7 +474,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.RenameAsyncOverloadDefaultOptions(::core::mem::transmute(&desiredname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -486,7 +486,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.RenameAsync(::core::mem::transmute(&desiredname), option) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -498,7 +498,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.DeleteAsyncOverloadDefaultOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -510,7 +510,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.DeleteAsync(option) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -522,7 +522,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetBasicPropertiesAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -534,7 +534,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -546,7 +546,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -558,7 +558,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.Attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -570,7 +570,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.DateCreated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -582,7 +582,7 @@ impl IStorageItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsOfType(r#type) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -624,7 +624,7 @@ impl IStorageItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -636,7 +636,7 @@ impl IStorageItem2_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -675,7 +675,7 @@ impl IStorageItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -687,7 +687,7 @@ impl IStorageItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnailAsyncOverloadDefaultOptions(mode, requestedsize) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -699,7 +699,7 @@ impl IStorageItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnailAsync(mode, requestedsize, options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -711,7 +711,7 @@ impl IStorageItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -723,7 +723,7 @@ impl IStorageItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -735,7 +735,7 @@ impl IStorageItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.FolderRelativeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -747,7 +747,7 @@ impl IStorageItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -787,7 +787,7 @@ impl IStorageItemProperties2_Vtbl {
             let this = (*this).get_impl();
             match this.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -799,7 +799,7 @@ impl IStorageItemProperties2_Vtbl {
             let this = (*this).get_impl();
             match this.GetScaledImageAsThumbnailAsyncOverloadDefaultOptions(mode, requestedsize) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -811,7 +811,7 @@ impl IStorageItemProperties2_Vtbl {
             let this = (*this).get_impl();
             match this.GetScaledImageAsThumbnailAsync(mode, requestedsize, options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -845,7 +845,7 @@ impl IStorageItemPropertiesWithProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Provider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/impl.rs
+++ b/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/impl.rs
@@ -15,7 +15,7 @@ impl ISysStorageProviderEventSource_Vtbl {
             let this = (*this).get_impl();
             match this.EventReceived(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -51,7 +51,7 @@ impl ISysStorageProviderHandlerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetHttpRequestProvider(::core::mem::transmute(&syncrootid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl ISysStorageProviderHandlerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventSource(::core::mem::transmute(&syncrootid), ::core::mem::transmute(&eventname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -96,7 +96,7 @@ impl ISysStorageProviderHttpRequestProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SendRequestAsync(::core::mem::transmute(&request)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -231,7 +231,7 @@ impl<F: FnMut(&[u8]) -> ::windows::core::Result<bool> + ::core::marker::Send + '
         let this = this as *mut ::windows::core::RawPtr as *mut Self;
         match ((*this).invoke)(::core::slice::from_raw_parts(::core::mem::transmute_copy(&pdudata), pduData_array_size as _)) {
             ::core::result::Result::Ok(ok__) => {
-                *result__ = ::core::mem::transmute_copy(&ok__);
+                ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                 ::core::mem::forget(ok__);
                 ::windows::core::HRESULT(0)
             }

--- a/crates/libs/windows/src/Windows/System/impl.rs
+++ b/crates/libs/windows/src/Windows/System/impl.rs
@@ -15,7 +15,7 @@ impl ILauncherViewOptions_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredRemainingView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Composition/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/impl.rs
@@ -46,7 +46,7 @@ impl ICompositionSupportsSystemBackdrop_Vtbl {
             let this = (*this).get_impl();
             match this.SystemBackdrop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -93,7 +93,7 @@ impl ICompositionSurfaceFacade_Vtbl {
             let this = (*this).get_impl();
             match this.GetRealSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -134,7 +134,7 @@ impl IVisualElement2_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisualInternal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/impl.rs
@@ -18,7 +18,7 @@ impl IPropertyAnimation_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -30,7 +30,7 @@ impl IPropertyAnimation_Vtbl {
             let this = (*this).get_impl();
             match this.Delay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -42,7 +42,7 @@ impl IPropertyAnimation_Vtbl {
             let this = (*this).get_impl();
             match this.Duration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -54,7 +54,7 @@ impl IPropertyAnimation_Vtbl {
             let this = (*this).get_impl();
             match this.Control1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl IPropertyAnimation_Vtbl {
             let this = (*this).get_impl();
             match this.Control2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/impl.rs
@@ -15,7 +15,7 @@ impl ICoreAcceleratorKeys_Vtbl {
             let this = (*this).get_impl();
             match this.AcceleratorKeyActivated(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -57,7 +57,7 @@ impl ICoreInputSourceBase_Vtbl {
             let this = (*this).get_impl();
             match this.Dispatcher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -69,7 +69,7 @@ impl ICoreInputSourceBase_Vtbl {
             let this = (*this).get_impl();
             match this.IsInputEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -86,7 +86,7 @@ impl ICoreInputSourceBase_Vtbl {
             let this = (*this).get_impl();
             match this.InputEnabled(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -156,7 +156,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.HasCapture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -168,7 +168,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -180,7 +180,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerCursor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -197,7 +197,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerCaptureLost(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -214,7 +214,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerEntered(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -231,7 +231,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerExited(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -248,7 +248,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerMoved(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -265,7 +265,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerPressed(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -282,7 +282,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerReleased(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -299,7 +299,7 @@ impl ICorePointerInputSource_Vtbl {
             let this = (*this).get_impl();
             match this.PointerWheelChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -355,7 +355,7 @@ impl ICorePointerInputSource2_Vtbl {
             let this = (*this).get_impl();
             match this.DispatcherQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -392,7 +392,7 @@ impl ICorePointerRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.PointerRoutedAway(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -409,7 +409,7 @@ impl ICorePointerRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.PointerRoutedTo(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -426,7 +426,7 @@ impl ICorePointerRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.PointerRoutedReleased(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -519,7 +519,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.AutomationHostProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -531,7 +531,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Bounds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -543,7 +543,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.CustomProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -555,7 +555,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Dispatcher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -567,7 +567,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.FlowDirection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -584,7 +584,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.IsInputEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -601,7 +601,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerCursor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -618,7 +618,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -630,7 +630,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -652,7 +652,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.GetAsyncKeyState(virtualkey) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -664,7 +664,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyState(virtualkey) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -686,7 +686,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Activated(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -703,7 +703,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.AutomationProviderRequested(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -720,7 +720,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.CharacterReceived(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -737,7 +737,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Closed(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -754,7 +754,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.InputEnabled(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -771,7 +771,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.KeyDown(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -788,7 +788,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.KeyUp(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -805,7 +805,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerCaptureLost(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -822,7 +822,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerEntered(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -839,7 +839,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerExited(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -856,7 +856,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerMoved(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -873,7 +873,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerPressed(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -890,7 +890,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerReleased(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -907,7 +907,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.TouchHitTesting(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -924,7 +924,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.PointerWheelChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -941,7 +941,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.SizeChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -958,7 +958,7 @@ impl ICoreWindow_Vtbl {
             let this = (*this).get_impl();
             match this.VisibilityChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1044,7 +1044,7 @@ impl ICoreWindowEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Handled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/impl.rs
@@ -20,7 +20,7 @@ impl IInkAnalysisNode_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -32,7 +32,7 @@ impl IInkAnalysisNode_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -44,7 +44,7 @@ impl IInkAnalysisNode_Vtbl {
             let this = (*this).get_impl();
             match this.BoundingRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -56,7 +56,7 @@ impl IInkAnalysisNode_Vtbl {
             let this = (*this).get_impl();
             match this.RotatedBoundingRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -68,7 +68,7 @@ impl IInkAnalysisNode_Vtbl {
             let this = (*this).get_impl();
             match this.Children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -80,7 +80,7 @@ impl IInkAnalysisNode_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -92,7 +92,7 @@ impl IInkAnalysisNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeIds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -127,7 +127,7 @@ impl IInkAnalyzerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAnalyzer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/impl.rs
@@ -14,7 +14,7 @@ impl IInkPointFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInkPoint(::core::mem::transmute(&position), pressure) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -40,7 +40,7 @@ impl IInkPresenterRulerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&inkpresenter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -77,7 +77,7 @@ impl IInkPresenterStencil_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -89,7 +89,7 @@ impl IInkPresenterStencil_Vtbl {
             let this = (*this).get_impl();
             match this.IsVisible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -106,7 +106,7 @@ impl IInkPresenterStencil_Vtbl {
             let this = (*this).get_impl();
             match this.BackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -123,7 +123,7 @@ impl IInkPresenterStencil_Vtbl {
             let this = (*this).get_impl();
             match this.ForegroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -140,7 +140,7 @@ impl IInkPresenterStencil_Vtbl {
             let this = (*this).get_impl();
             match this.Transform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -192,7 +192,7 @@ impl IInkRecognizerContainer_Vtbl {
             let this = (*this).get_impl();
             match this.RecognizeAsync(::core::mem::transmute(&strokecollection), recognitiontarget) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -204,7 +204,7 @@ impl IInkRecognizerContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecognizers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -251,7 +251,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.BoundingRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -268,7 +268,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.DeleteSelected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -280,7 +280,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.MoveSelected(::core::mem::transmute(&translation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -292,7 +292,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.SelectWithPolyLine(::core::mem::transmute(&polyline)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -304,7 +304,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.SelectWithLine(::core::mem::transmute(&from), ::core::mem::transmute(&to)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -321,7 +321,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.PasteFromClipboard(::core::mem::transmute(&position)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -333,7 +333,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.CanPasteFromClipboard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -345,7 +345,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.LoadAsync(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -357,7 +357,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.SaveAsync(::core::mem::transmute(&outputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -374,7 +374,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -386,7 +386,7 @@ impl IInkStrokeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecognitionResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Input/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/impl.rs
@@ -16,7 +16,7 @@ impl IPointerPointTransform_Vtbl {
             let this = (*this).get_impl();
             match this.Inverse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -28,7 +28,7 @@ impl IPointerPointTransform_Vtbl {
             let this = (*this).get_impl();
             match this.TryTransform(::core::mem::transmute(&inpoint), ::core::mem::transmute_copy(&outpoint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -40,7 +40,7 @@ impl IPointerPointTransform_Vtbl {
             let this = (*this).get_impl();
             match this.TransformBounds(::core::mem::transmute(&rect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Notifications/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/impl.rs
@@ -15,7 +15,7 @@ impl IAdaptiveNotificationContent_Vtbl {
             let this = (*this).get_impl();
             match this.Kind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -27,7 +27,7 @@ impl IAdaptiveNotificationContent_Vtbl {
             let this = (*this).get_impl();
             match this.Hints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Popups/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/impl.rs
@@ -16,7 +16,7 @@ impl IUICommand_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -33,7 +33,7 @@ impl IUICommand_Vtbl {
             let this = (*this).get_impl();
             match this.Invoked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -50,7 +50,7 @@ impl IUICommand_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Shell/impl.rs
@@ -11,7 +11,7 @@ impl IAdaptiveCard_Vtbl {
             let this = (*this).get_impl();
             match this.ToJson() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -37,7 +37,7 @@ impl IAdaptiveCardBuilderStatics_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAdaptiveCardFromJson(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Text/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/impl.rs
@@ -60,7 +60,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.AllCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -77,7 +77,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.BackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -94,7 +94,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Bold() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -111,7 +111,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.FontStretch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -128,7 +128,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.FontStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -145,7 +145,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ForegroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -162,7 +162,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Hidden() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -179,7 +179,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Italic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -196,7 +196,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Kerning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -213,7 +213,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -230,7 +230,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.LinkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -242,7 +242,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -259,7 +259,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Outline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -276,7 +276,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Position() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -293,7 +293,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ProtectedText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -310,7 +310,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -327,7 +327,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.SmallCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -344,7 +344,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Spacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -361,7 +361,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Strikethrough() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -378,7 +378,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Subscript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -395,7 +395,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Superscript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -412,7 +412,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.TextScript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -429,7 +429,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Underline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -446,7 +446,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Weight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -468,7 +468,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.GetClone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -480,7 +480,7 @@ impl ITextCharacterFormat_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -587,7 +587,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CaretType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -604,7 +604,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultTabStop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -621,7 +621,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Selection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -633,7 +633,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.UndoLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -650,7 +650,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CanCopy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -662,7 +662,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CanPaste() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -674,7 +674,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CanRedo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -686,7 +686,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CanUndo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -698,7 +698,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.ApplyDisplayUpdates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -710,7 +710,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.BatchDisplayUpdates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -732,7 +732,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultCharacterFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -744,7 +744,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultParagraphFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -756,7 +756,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetRange(startposition, endposition) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -768,7 +768,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetRangeFromPoint(::core::mem::transmute(&point), options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -910,7 +910,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Alignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -927,7 +927,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.FirstLineIndent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -939,7 +939,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.KeepTogether() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -956,7 +956,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.KeepWithNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -973,7 +973,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.LeftIndent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -985,7 +985,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.LineSpacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -997,7 +997,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.LineSpacingRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1009,7 +1009,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ListAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1026,7 +1026,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ListLevelIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1043,7 +1043,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ListStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1060,7 +1060,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ListStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1077,7 +1077,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ListTab() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1094,7 +1094,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.ListType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1111,7 +1111,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.NoLineNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1128,7 +1128,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.PageBreakBefore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1145,7 +1145,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.RightIndent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1162,7 +1162,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.RightToLeft() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1179,7 +1179,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Style() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1196,7 +1196,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.SpaceAfter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1213,7 +1213,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.SpaceBefore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1230,7 +1230,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.WidowControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1247,7 +1247,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.TabCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1274,7 +1274,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.GetClone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1291,7 +1291,7 @@ impl ITextParagraphFormat_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1436,7 +1436,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Character() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1453,7 +1453,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.CharacterFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1470,7 +1470,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.FormattedText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1487,7 +1487,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.EndPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1504,7 +1504,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Gravity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1521,7 +1521,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1533,7 +1533,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Link() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1550,7 +1550,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.ParagraphFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1567,7 +1567,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.StartPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1584,7 +1584,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.StoryLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1596,7 +1596,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1613,7 +1613,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.CanPaste(format) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1645,7 +1645,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Delete(unit, count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1657,7 +1657,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.EndOf(unit, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1669,7 +1669,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Expand(unit) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1681,7 +1681,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.FindText(::core::mem::transmute(&value), scanlength, options) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1698,7 +1698,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetClone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1710,7 +1710,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndex(unit) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1742,7 +1742,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.InRange(::core::mem::transmute(&range)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1759,7 +1759,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.InStory(::core::mem::transmute(&range)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1771,7 +1771,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&range)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1783,7 +1783,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Move(unit, count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1795,7 +1795,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveEnd(unit, count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1807,7 +1807,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveStart(unit, count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1859,7 +1859,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.StartOf(unit, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1951,7 +1951,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.Options() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1968,7 +1968,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1980,7 +1980,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.EndKey(unit, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1992,7 +1992,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.HomeKey(unit, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2004,7 +2004,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveDown(unit, count, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2016,7 +2016,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveLeft(unit, count, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2028,7 +2028,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveRight(unit, count, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2040,7 +2040,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveUp(unit, count, extend) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/impl.rs
@@ -11,7 +11,7 @@ impl ICoreAutomationConnectionBoundObjectProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsComThreadingRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -46,7 +46,7 @@ impl ICoreAutomationRemoteOperationExtensionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsExtensionSupported(::core::mem::transmute(&extensionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/WebUI/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/impl.rs
@@ -11,7 +11,7 @@ impl IActivatedEventArgsDeferral_Vtbl {
             let this = (*this).get_impl();
             match this.ActivatedOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -41,7 +41,7 @@ impl IWebUIBackgroundTaskInstance_Vtbl {
             let this = (*this).get_impl();
             match this.Succeeded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -76,7 +76,7 @@ impl IWebUINavigatedEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.NavigatedOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Automation/Peers/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Automation/Peers/impl.rs
@@ -42,7 +42,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetPatternCore(patterninterface) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -54,7 +54,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetAcceleratorKeyCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccessKeyCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -78,7 +78,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutomationControlTypeCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -90,7 +90,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutomationIdCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -102,7 +102,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoundingRectangleCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -114,7 +114,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildrenCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -126,7 +126,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetClassNameCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -138,7 +138,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetClickablePointCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -150,7 +150,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelpTextCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -162,7 +162,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemStatusCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -174,7 +174,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemTypeCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -186,7 +186,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetLabeledByCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -198,7 +198,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalizedControlTypeCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -210,7 +210,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -222,7 +222,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetOrientationCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -234,7 +234,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.HasKeyboardFocusCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -246,7 +246,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsContentElementCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -258,7 +258,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsControlElementCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -270,7 +270,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabledCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -282,7 +282,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsKeyboardFocusableCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -294,7 +294,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsOffscreenCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -306,7 +306,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsPasswordCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -318,7 +318,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsRequiredForFormCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -335,7 +335,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetPeerFromPointCore(::core::mem::transmute(&point)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -347,7 +347,7 @@ impl IAutomationPeerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetLiveSettingCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -413,7 +413,7 @@ impl IAutomationPeerOverrides2_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlledPeersCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -452,7 +452,7 @@ impl IAutomationPeerOverrides3_Vtbl {
             let this = (*this).get_impl();
             match this.NavigateCore(direction) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -464,7 +464,7 @@ impl IAutomationPeerOverrides3_Vtbl {
             let this = (*this).get_impl();
             match this.GetElementFromPointCore(::core::mem::transmute(&pointinwindowcoordinates)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -476,7 +476,7 @@ impl IAutomationPeerOverrides3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocusedElementCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -488,7 +488,7 @@ impl IAutomationPeerOverrides3_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnnotationsCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -500,7 +500,7 @@ impl IAutomationPeerOverrides3_Vtbl {
             let this = (*this).get_impl();
             match this.GetPositionInSetCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -512,7 +512,7 @@ impl IAutomationPeerOverrides3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSizeOfSetCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -524,7 +524,7 @@ impl IAutomationPeerOverrides3_Vtbl {
             let this = (*this).get_impl();
             match this.GetLevelCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -560,7 +560,7 @@ impl IAutomationPeerOverrides4_Vtbl {
             let this = (*this).get_impl();
             match this.GetLandmarkTypeCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -572,7 +572,7 @@ impl IAutomationPeerOverrides4_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalizedLandmarkTypeCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -610,7 +610,7 @@ impl IAutomationPeerOverrides5_Vtbl {
             let this = (*this).get_impl();
             match this.IsPeripheralCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -622,7 +622,7 @@ impl IAutomationPeerOverrides5_Vtbl {
             let this = (*this).get_impl();
             match this.IsDataValidForFormCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -634,7 +634,7 @@ impl IAutomationPeerOverrides5_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullDescriptionCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -646,7 +646,7 @@ impl IAutomationPeerOverrides5_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescribedByCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -658,7 +658,7 @@ impl IAutomationPeerOverrides5_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlowsToCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -670,7 +670,7 @@ impl IAutomationPeerOverrides5_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlowsFromCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -704,7 +704,7 @@ impl IAutomationPeerOverrides6_Vtbl {
             let this = (*this).get_impl();
             match this.GetCultureCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -733,7 +733,7 @@ impl IAutomationPeerOverrides8_Vtbl {
             let this = (*this).get_impl();
             match this.GetHeadingLevelCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -762,7 +762,7 @@ impl IAutomationPeerOverrides9_Vtbl {
             let this = (*this).get_impl();
             match this.IsDialogCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -791,7 +791,7 @@ impl IItemsControlAutomationPeerOverrides2_Vtbl {
             let this = (*this).get_impl();
             match this.OnCreateItemAutomationPeer(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Automation/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Automation/Provider/impl.rs
@@ -15,7 +15,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.AnnotationTypeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -27,7 +27,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.AnnotationTypeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -39,7 +39,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Author() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -51,7 +51,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Target() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -99,7 +99,7 @@ impl ICustomNavigationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.NavigateCustom(direction) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -129,7 +129,7 @@ impl IDockProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DockPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -167,7 +167,7 @@ impl IDragProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsGrabbed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -179,7 +179,7 @@ impl IDragProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DropEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -192,8 +192,8 @@ impl IDragProvider_Vtbl {
             match this.DropEffects() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -205,8 +205,8 @@ impl IDragProvider_Vtbl {
             match this.GetGrabbedItems() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -238,7 +238,7 @@ impl IDropTargetProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DropEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -251,8 +251,8 @@ impl IDropTargetProvider_Vtbl {
             match this.DropEffects() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -283,7 +283,7 @@ impl IExpandCollapseProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ExpandCollapseState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -328,7 +328,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Column() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -340,7 +340,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ColumnSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -352,7 +352,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ContainingGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -364,7 +364,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Row() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -376,7 +376,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RowSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -411,7 +411,7 @@ impl IGridProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ColumnCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -423,7 +423,7 @@ impl IGridProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RowCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -435,7 +435,7 @@ impl IGridProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(row, column) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -485,7 +485,7 @@ impl IItemContainerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemByProperty(::core::mem::transmute(&startafter), ::core::mem::transmute(&automationproperty), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -517,7 +517,7 @@ impl IMultipleViewProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -530,8 +530,8 @@ impl IMultipleViewProvider_Vtbl {
             match this.GetSupportedViews() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -542,7 +542,7 @@ impl IMultipleViewProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewName(viewid) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -579,7 +579,7 @@ impl IObjectModelProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnderlyingObjectModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -614,7 +614,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -626,7 +626,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.LargeChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -638,7 +638,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Maximum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -650,7 +650,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Minimum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -662,7 +662,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SmallChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -674,7 +674,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -743,7 +743,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -755,7 +755,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -767,7 +767,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -779,7 +779,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.VerticallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -791,7 +791,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.VerticalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -803,7 +803,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.VerticalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -853,7 +853,7 @@ impl ISelectionItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsSelected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -865,7 +865,7 @@ impl ISelectionItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SelectionContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -915,7 +915,7 @@ impl ISelectionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanSelectMultiple() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -927,7 +927,7 @@ impl ISelectionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsSelectionRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -940,8 +940,8 @@ impl ISelectionProvider_Vtbl {
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -973,7 +973,7 @@ impl ISpreadsheetItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Formula() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -986,8 +986,8 @@ impl ISpreadsheetItemProvider_Vtbl {
             match this.GetAnnotationObjects() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -999,8 +999,8 @@ impl ISpreadsheetItemProvider_Vtbl {
             match this.GetAnnotationTypes() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1030,7 +1030,7 @@ impl ISpreadsheetProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1065,7 +1065,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1077,7 +1077,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FillColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1089,7 +1089,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FillPatternColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1101,7 +1101,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FillPatternStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1113,7 +1113,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Shape() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1125,7 +1125,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.StyleId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1137,7 +1137,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.StyleName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1203,8 +1203,8 @@ impl ITableItemProvider_Vtbl {
             match this.GetColumnHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1216,8 +1216,8 @@ impl ITableItemProvider_Vtbl {
             match this.GetRowHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1248,7 +1248,7 @@ impl ITableProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RowOrColumnMajor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1261,8 +1261,8 @@ impl ITableProvider_Vtbl {
             match this.GetColumnHeaders() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1274,8 +1274,8 @@ impl ITableProvider_Vtbl {
             match this.GetRowHeaders() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1306,7 +1306,7 @@ impl ITextChildProvider_Vtbl {
             let this = (*this).get_impl();
             match this.TextContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1318,7 +1318,7 @@ impl ITextChildProvider_Vtbl {
             let this = (*this).get_impl();
             match this.TextRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1352,7 +1352,7 @@ impl ITextEditProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveComposition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1364,7 +1364,7 @@ impl ITextEditProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetConversionTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1402,7 +1402,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1414,7 +1414,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedTextSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1427,8 +1427,8 @@ impl ITextProvider_Vtbl {
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1440,8 +1440,8 @@ impl ITextProvider_Vtbl {
             match this.GetVisibleRanges() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1452,7 +1452,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromChild(::core::mem::transmute(&childelement)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1464,7 +1464,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromPoint(::core::mem::transmute(&screenlocation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1502,7 +1502,7 @@ impl ITextProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromAnnotation(::core::mem::transmute(&annotationelement)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1514,7 +1514,7 @@ impl ITextProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaretRange(::core::mem::transmute_copy(&isactive)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1564,7 +1564,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1576,7 +1576,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute(&textrangeprovider)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1588,7 +1588,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CompareEndpoints(endpoint, ::core::mem::transmute(&textrangeprovider), targetendpoint) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1605,7 +1605,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindAttribute(attributeid, ::core::mem::transmute(&value), backward) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1617,7 +1617,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindText(::core::mem::transmute(&text), backward, ignorecase) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1629,7 +1629,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeValue(attributeid) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1646,7 +1646,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnclosingElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1658,7 +1658,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetText(maxlength) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1670,7 +1670,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Move(unit, count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1682,7 +1682,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MoveEndpointByUnit(endpoint, unit, count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1720,8 +1720,8 @@ impl ITextRangeProvider_Vtbl {
             match this.GetChildren() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1792,7 +1792,7 @@ impl IToggleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ToggleState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1832,7 +1832,7 @@ impl ITransformProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanMove() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1844,7 +1844,7 @@ impl ITransformProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanResize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1856,7 +1856,7 @@ impl ITransformProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanRotate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1910,7 +1910,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.CanZoom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1922,7 +1922,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.ZoomLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1934,7 +1934,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.MaxZoom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1946,7 +1946,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.MinZoom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1992,7 +1992,7 @@ impl IValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2004,7 +2004,7 @@ impl IValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2067,7 +2067,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsModal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2079,7 +2079,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsTopmost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2091,7 +2091,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Maximizable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2103,7 +2103,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Minimizable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2115,7 +2115,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.InteractionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2127,7 +2127,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.VisualState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -2149,7 +2149,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForInputIdle(milliseconds) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Controls/Primitives/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Controls/Primitives/impl.rs
@@ -11,7 +11,7 @@ impl IFlyoutBaseOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePresenter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -75,7 +75,7 @@ impl IPickerFlyoutBaseOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.ShouldShowConfirmationButtons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -157,7 +157,7 @@ impl IScrollSnapPointsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AreHorizontalSnapPointsRegular() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -169,7 +169,7 @@ impl IScrollSnapPointsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AreVerticalSnapPointsRegular() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -181,7 +181,7 @@ impl IScrollSnapPointsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontalSnapPointsChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -198,7 +198,7 @@ impl IScrollSnapPointsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.VerticalSnapPointsChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -215,7 +215,7 @@ impl IScrollSnapPointsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetIrregularSnapPoints(orientation, alignment) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -227,7 +227,7 @@ impl IScrollSnapPointsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegularSnapPoints(orientation, alignment, ::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Controls/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Controls/impl.rs
@@ -111,7 +111,7 @@ impl ICommandBarElement_Vtbl {
             let this = (*this).get_impl();
             match this.IsCompact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -148,7 +148,7 @@ impl ICommandBarElement2_Vtbl {
             let this = (*this).get_impl();
             match this.IsInOverflow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -160,7 +160,7 @@ impl ICommandBarElement2_Vtbl {
             let this = (*this).get_impl();
             match this.DynamicOverflowOrder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -559,7 +559,7 @@ impl IDataTemplateSelectorOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.SelectTemplateCore(::core::mem::transmute(&item), ::core::mem::transmute(&container)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -588,7 +588,7 @@ impl IDataTemplateSelectorOverrides2_Vtbl {
             let this = (*this).get_impl();
             match this.SelectTemplateForItemCore(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -617,7 +617,7 @@ impl IGroupStyleSelectorOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.SelectGroupStyleCore(::core::mem::transmute(&group), level) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -649,7 +649,7 @@ impl IInkToolbarCustomPenOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInkDrawingAttributesCore(::core::mem::transmute(&brush), strokewidth) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -706,7 +706,7 @@ impl IItemContainerMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ItemFromContainer(::core::mem::transmute(&container)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -718,7 +718,7 @@ impl IItemContainerMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ContainerFromItem(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -730,7 +730,7 @@ impl IItemContainerMapping_Vtbl {
             let this = (*this).get_impl();
             match this.IndexFromContainer(::core::mem::transmute(&container)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -742,7 +742,7 @@ impl IItemContainerMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ContainerFromIndex(index) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -799,7 +799,7 @@ impl IItemsControlOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.IsItemItsOwnContainerOverride(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -811,7 +811,7 @@ impl IItemsControlOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerForItemOverride() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -892,7 +892,7 @@ impl INavigate_Vtbl {
             let this = (*this).get_impl();
             match this.Navigate(::core::mem::transmute(&sourcepagetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -965,7 +965,7 @@ impl IScrollAnchorProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAnchor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1018,7 +1018,7 @@ impl ISemanticZoomInformation_Vtbl {
             let this = (*this).get_impl();
             match this.SemanticZoomOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1035,7 +1035,7 @@ impl ISemanticZoomInformation_Vtbl {
             let this = (*this).get_impl();
             match this.IsActiveView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1052,7 +1052,7 @@ impl ISemanticZoomInformation_Vtbl {
             let this = (*this).get_impl();
             match this.IsZoomedInView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -1133,7 +1133,7 @@ impl IStyleSelectorOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.SelectStyleCore(::core::mem::transmute(&item), ::core::mem::transmute(&container)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Data/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Data/impl.rs
@@ -30,7 +30,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -42,7 +42,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -54,7 +54,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.IsCurrentAfterLast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -66,7 +66,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.IsCurrentBeforeFirst() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -78,7 +78,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.CollectionGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -90,7 +90,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.HasMoreItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -102,7 +102,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -119,7 +119,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentChanging(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -136,7 +136,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.MoveCurrentTo(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -148,7 +148,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.MoveCurrentToPosition(index) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -160,7 +160,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.MoveCurrentToFirst() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -172,7 +172,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.MoveCurrentToLast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -184,7 +184,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.MoveCurrentToNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -196,7 +196,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.MoveCurrentToPrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -208,7 +208,7 @@ impl ICollectionView_Vtbl {
             let this = (*this).get_impl();
             match this.LoadMoreItemsAsync(count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -253,7 +253,7 @@ impl ICollectionViewFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -283,7 +283,7 @@ impl ICollectionViewGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Group() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -295,7 +295,7 @@ impl ICollectionViewGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GroupItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -335,7 +335,7 @@ impl ICustomProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -347,7 +347,7 @@ impl ICustomProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -359,7 +359,7 @@ impl ICustomProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&target)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -376,7 +376,7 @@ impl ICustomProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexedValue(::core::mem::transmute(&target), ::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -393,7 +393,7 @@ impl ICustomProperty_Vtbl {
             let this = (*this).get_impl();
             match this.CanWrite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -405,7 +405,7 @@ impl ICustomProperty_Vtbl {
             let this = (*this).get_impl();
             match this.CanRead() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -447,7 +447,7 @@ impl ICustomPropertyProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomProperty(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -459,7 +459,7 @@ impl ICustomPropertyProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexedProperty(::core::mem::transmute(&name), ::core::mem::transmute(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -471,7 +471,7 @@ impl ICustomPropertyProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringRepresentation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -483,7 +483,7 @@ impl ICustomPropertyProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -541,7 +541,7 @@ impl INotifyPropertyChanged_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -592,7 +592,7 @@ impl ISelectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsSelected(index) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -604,7 +604,7 @@ impl ISelectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedRanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -640,7 +640,7 @@ impl ISupportIncrementalLoading_Vtbl {
             let this = (*this).get_impl();
             match this.LoadMoreItemsAsync(count) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -652,7 +652,7 @@ impl ISupportIncrementalLoading_Vtbl {
             let this = (*this).get_impl();
             match this.HasMoreItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -686,7 +686,7 @@ impl IValueConverter_Vtbl {
             let this = (*this).get_impl();
             match this.Convert(::core::mem::transmute(&value), ::core::mem::transmute(&targettype), ::core::mem::transmute(&parameter), ::core::mem::transmute(&language)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -698,7 +698,7 @@ impl IValueConverter_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertBack(::core::mem::transmute(&value), ::core::mem::transmute(&targettype), ::core::mem::transmute(&parameter), ::core::mem::transmute(&language)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Hosting/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Hosting/impl.rs
@@ -11,7 +11,7 @@ impl IXamlUIPresenterHost_Vtbl {
             let this = (*this).get_impl();
             match this.ResolveFileResource(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -40,7 +40,7 @@ impl IXamlUIPresenterHost2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGenericXamlFilePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -69,7 +69,7 @@ impl IXamlUIPresenterHost3_Vtbl {
             let this = (*this).get_impl();
             match this.ResolveDictionaryResource(::core::mem::transmute(&dictionary), ::core::mem::transmute(&dictionarykey), ::core::mem::transmute(&suggestedvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Input/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Input/impl.rs
@@ -17,7 +17,7 @@ impl ICommand_Vtbl {
             let this = (*this).get_impl();
             match this.CanExecuteChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -34,7 +34,7 @@ impl ICommand_Vtbl {
             let this = (*this).get_impl();
             match this.CanExecute(::core::mem::transmute(&parameter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Interop/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Interop/impl.rs
@@ -11,7 +11,7 @@ impl IBindableIterable_Vtbl {
             let this = (*this).get_impl();
             match this.First() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -39,7 +39,7 @@ impl IBindableIterator_Vtbl {
             let this = (*this).get_impl();
             match this.Current() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -51,7 +51,7 @@ impl IBindableIterator_Vtbl {
             let this = (*this).get_impl();
             match this.HasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -63,7 +63,7 @@ impl IBindableIterator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -98,7 +98,7 @@ impl IBindableObservableVector_Vtbl {
             let this = (*this).get_impl();
             match this.VectorChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -142,7 +142,7 @@ impl IBindableVector_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(index) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -154,7 +154,7 @@ impl IBindableVector_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -166,7 +166,7 @@ impl IBindableVector_Vtbl {
             let this = (*this).get_impl();
             match this.GetView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -178,7 +178,7 @@ impl IBindableVector_Vtbl {
             let this = (*this).get_impl();
             match this.IndexOf(::core::mem::transmute(&value), ::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -248,7 +248,7 @@ impl IBindableVectorView_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(index) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -260,7 +260,7 @@ impl IBindableVectorView_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -272,7 +272,7 @@ impl IBindableVectorView_Vtbl {
             let this = (*this).get_impl();
             match this.IndexOf(::core::mem::transmute(&value), ::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -307,7 +307,7 @@ impl INotifyCollectionChanged_Vtbl {
             let this = (*this).get_impl();
             match this.CollectionChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Markup/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Markup/impl.rs
@@ -30,7 +30,7 @@ impl IComponentConnector2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBindingConnector(connectionid, ::core::mem::transmute(&target)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -88,7 +88,7 @@ impl IMarkupExtensionOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.ProvideValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -143,7 +143,7 @@ impl IXamlMember_Vtbl {
             let this = (*this).get_impl();
             match this.IsAttachable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -155,7 +155,7 @@ impl IXamlMember_Vtbl {
             let this = (*this).get_impl();
             match this.IsDependencyProperty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -167,7 +167,7 @@ impl IXamlMember_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -179,7 +179,7 @@ impl IXamlMember_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -191,7 +191,7 @@ impl IXamlMember_Vtbl {
             let this = (*this).get_impl();
             match this.TargetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -203,7 +203,7 @@ impl IXamlMember_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -215,7 +215,7 @@ impl IXamlMember_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&instance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -261,7 +261,7 @@ impl IXamlMetadataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetXamlType(::core::mem::transmute(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -273,7 +273,7 @@ impl IXamlMetadataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetXamlTypeByFullName(::core::mem::transmute(&fullname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -286,8 +286,8 @@ impl IXamlMetadataProvider_Vtbl {
             match this.GetXmlnsDefinitions() {
                 ::core::result::Result::Ok(ok__) => {
                     let (ok_data__, ok_data_len__) = ok__.into_abi();
-                    *result__ = ok_data__;
-                    *result_size__ = ok_data_len__;
+                    ::core::ptr::write(result__, ok_data__);
+                    ::core::ptr::write(result_size__, ok_data_len__);
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -337,7 +337,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.BaseType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -349,7 +349,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.ContentProperty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -361,7 +361,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.FullName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -373,7 +373,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.IsArray() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -385,7 +385,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.IsCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -397,7 +397,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.IsConstructible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -409,7 +409,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.IsDictionary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -421,7 +421,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.IsMarkupExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -433,7 +433,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.IsBindable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -445,7 +445,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.ItemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -457,7 +457,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.KeyType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -469,7 +469,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.UnderlyingType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -481,7 +481,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -493,7 +493,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFromString(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -505,7 +505,7 @@ impl IXamlType_Vtbl {
             let this = (*this).get_impl();
             match this.GetMember(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -569,7 +569,7 @@ impl IXamlType2_Vtbl {
             let this = (*this).get_impl();
             match this.BoxedType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Media/Animation/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Media/Animation/impl.rs
@@ -14,7 +14,7 @@ impl INavigationTransitionInfoOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetNavigationStateCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Media/impl.rs
@@ -43,7 +43,7 @@ impl IGeneralTransformOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.InverseCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -55,7 +55,7 @@ impl IGeneralTransformOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.TryTransformCore(::core::mem::transmute(&inpoint), ::core::mem::transmute_copy(&outpoint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -67,7 +67,7 @@ impl IGeneralTransformOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.TransformBoundsCore(::core::mem::transmute(&rect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -137,7 +137,7 @@ impl IXamlLightOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/Resources/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Resources/impl.rs
@@ -11,7 +11,7 @@ impl ICustomXamlResourceLoaderOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GetResource(::core::mem::transmute(&resourceid), ::core::mem::transmute(&objecttype), ::core::mem::transmute(&propertyname), ::core::mem::transmute(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/impl.rs
@@ -147,7 +147,7 @@ impl IDataTemplateExtension_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessBinding(phase) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -159,7 +159,7 @@ impl IDataTemplateExtension_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessBindings(::core::mem::transmute(&arg)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -191,7 +191,7 @@ impl IElementFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetElement(::core::mem::transmute(&args)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -233,7 +233,7 @@ impl IFrameworkElementOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.MeasureOverride(::core::mem::transmute(&availablesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -245,7 +245,7 @@ impl IFrameworkElementOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.ArrangeOverride(::core::mem::transmute(&finalsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -281,7 +281,7 @@ impl IFrameworkElementOverrides2_Vtbl {
             let this = (*this).get_impl();
             match this.GoToElementStateCore(::core::mem::transmute(&statename), usetransitions) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -317,7 +317,7 @@ impl IUIElementOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.OnCreateAutomationPeer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -334,7 +334,7 @@ impl IUIElementOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.FindSubElementsForTouchTargeting(::core::mem::transmute(&point), ::core::mem::transmute(&boundingrect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -371,7 +371,7 @@ impl IUIElementOverrides7_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildrenInTabFocusOrder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -472,7 +472,7 @@ impl IVisualStateManagerOverrides_Vtbl {
             let this = (*this).get_impl();
             match this.GoToStateCore(::core::mem::transmute(&control), ::core::mem::transmute(&templateroot), ::core::mem::transmute(&statename), ::core::mem::transmute(&group), ::core::mem::transmute(&state), usetransitions) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/UI/Xaml/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/mod.rs
@@ -2352,7 +2352,7 @@ impl<F: FnMut() -> ::windows::core::Result<::windows::core::IInspectable> + ::co
         let this = this as *mut ::windows::core::RawPtr as *mut Self;
         match ((*this).invoke)() {
             ::core::result::Result::Ok(ok__) => {
-                *result__ = ::core::mem::transmute_copy(&ok__);
+                ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                 ::core::mem::forget(ok__);
                 ::windows::core::HRESULT(0)
             }

--- a/crates/libs/windows/src/Windows/Web/Http/Filters/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Filters/impl.rs
@@ -14,7 +14,7 @@ impl IHttpFilter_Vtbl {
             let this = (*this).get_impl();
             match this.SendRequestAsync(::core::mem::transmute(&request)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Web/Http/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/impl.rs
@@ -20,7 +20,7 @@ impl IHttpContent_Vtbl {
             let this = (*this).get_impl();
             match this.Headers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -32,7 +32,7 @@ impl IHttpContent_Vtbl {
             let this = (*this).get_impl();
             match this.BufferAllAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -44,7 +44,7 @@ impl IHttpContent_Vtbl {
             let this = (*this).get_impl();
             match this.ReadAsBufferAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -56,7 +56,7 @@ impl IHttpContent_Vtbl {
             let this = (*this).get_impl();
             match this.ReadAsInputStreamAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -68,7 +68,7 @@ impl IHttpContent_Vtbl {
             let this = (*this).get_impl();
             match this.ReadAsStringAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -80,7 +80,7 @@ impl IHttpContent_Vtbl {
             let this = (*this).get_impl();
             match this.TryComputeLength(::core::mem::transmute_copy(&length)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -92,7 +92,7 @@ impl IHttpContent_Vtbl {
             let this = (*this).get_impl();
             match this.WriteToStreamAsync(::core::mem::transmute(&outputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Web/Syndication/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/Syndication/impl.rs
@@ -25,7 +25,7 @@ impl ISyndicationClient_Vtbl {
             let this = (*this).get_impl();
             match this.ServerCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -42,7 +42,7 @@ impl ISyndicationClient_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyCredential() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -59,7 +59,7 @@ impl ISyndicationClient_Vtbl {
             let this = (*this).get_impl();
             match this.MaxResponseBufferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -76,7 +76,7 @@ impl ISyndicationClient_Vtbl {
             let this = (*this).get_impl();
             match this.Timeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -93,7 +93,7 @@ impl ISyndicationClient_Vtbl {
             let this = (*this).get_impl();
             match this.BypassCacheOnRetrieve() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -115,7 +115,7 @@ impl ISyndicationClient_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveFeedAsync(::core::mem::transmute(&uri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -170,7 +170,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.NodeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -187,7 +187,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.NodeNamespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -204,7 +204,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.NodeValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -221,7 +221,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -238,7 +238,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.BaseUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -255,7 +255,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.AttributeExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -267,7 +267,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.ElementExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -279,7 +279,7 @@ impl ISyndicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetXmlDocument(format) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -328,7 +328,7 @@ impl ISyndicationText_Vtbl {
             let this = (*this).get_impl();
             match this.Text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -345,7 +345,7 @@ impl ISyndicationText_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -362,7 +362,7 @@ impl ISyndicationText_Vtbl {
             let this = (*this).get_impl();
             match this.Xml() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Web/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/impl.rs
@@ -70,7 +70,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.Source() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -87,7 +87,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentTitle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -99,7 +99,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.CanGoBack() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -111,7 +111,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.CanGoForward() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -128,7 +128,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultBackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -140,7 +140,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.ContainsFullScreenElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -152,7 +152,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.Settings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -164,7 +164,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.DeferredPermissionRequests() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -216,7 +216,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.InvokeScriptAsync(::core::mem::transmute(&scriptname), ::core::mem::transmute(&arguments)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -228,7 +228,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.CapturePreviewToStreamAsync(::core::mem::transmute(&stream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -240,7 +240,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.CaptureSelectedContentToDataPackageAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -252,7 +252,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.BuildLocalStreamUri(::core::mem::transmute(&contentidentifier), ::core::mem::transmute(&relativepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -269,7 +269,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.NavigationStarting(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -286,7 +286,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.ContentLoading(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -303,7 +303,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.DOMContentLoaded(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -320,7 +320,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.NavigationCompleted(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -337,7 +337,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.FrameNavigationStarting(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -354,7 +354,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.FrameContentLoading(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -371,7 +371,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.FrameDOMContentLoaded(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -388,7 +388,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.FrameNavigationCompleted(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -405,7 +405,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.ScriptNotify(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -422,7 +422,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.LongRunningScriptDetected(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -439,7 +439,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.UnsafeContentWarningDisplaying(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -456,7 +456,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.UnviewableContentIdentified(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -473,7 +473,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.PermissionRequested(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -490,7 +490,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.UnsupportedUriSchemeIdentified(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -507,7 +507,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.NewWindowRequested(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -524,7 +524,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.ContainsFullScreenElementChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }
@@ -541,7 +541,7 @@ impl IWebViewControl_Vtbl {
             let this = (*this).get_impl();
             match this.WebResourceRequested(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Web/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/impl.rs
@@ -14,7 +14,7 @@ impl IUriToStreamResolver_Vtbl {
             let this = (*this).get_impl();
             match this.UriToStreamAsync(::core::mem::transmute(&uri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result__ = ::core::mem::transmute_copy(&ok__);
+                    ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
                     ::windows::core::HRESULT(0)
                 }

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
@@ -12,7 +12,7 @@ impl IMLOperatorAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeElementCount(::core::mem::transmute(&name), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *elementcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(elementcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28,7 +28,7 @@ impl IMLOperatorAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringAttributeElementLength(::core::mem::transmute(&name), ::core::mem::transmute_copy(&elementindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributeelementbytesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributeelementbytesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -83,7 +83,7 @@ impl IMLOperatorKernelContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputTensor(::core::mem::transmute_copy(&inputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tensor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tensor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -94,7 +94,7 @@ impl IMLOperatorKernelContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputTensor(::core::mem::transmute_copy(&outputindex), ::core::mem::transmute_copy(&dimensioncount), ::core::mem::transmute_copy(&dimensionsizes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tensor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tensor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -105,7 +105,7 @@ impl IMLOperatorKernelContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputTensor2(::core::mem::transmute_copy(&outputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tensor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tensor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -116,7 +116,7 @@ impl IMLOperatorKernelContext_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateTemporaryData(::core::mem::transmute_copy(&size)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *data = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(data, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -179,7 +179,7 @@ impl IMLOperatorKernelCreationContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputEdgeDescription(::core::mem::transmute_copy(&inputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *edgedescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(edgedescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl IMLOperatorKernelCreationContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputEdgeDescription(::core::mem::transmute_copy(&outputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *edgedescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(edgedescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -206,7 +206,7 @@ impl IMLOperatorKernelCreationContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetTensorShapeDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *shapedescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(shapedescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl IMLOperatorKernelFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateKernel(::core::mem::transmute(&context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *kernel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(kernel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -322,7 +322,7 @@ impl IMLOperatorShapeInferenceContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputEdgeDescription(::core::mem::transmute_copy(&inputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *edgedescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(edgedescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -333,7 +333,7 @@ impl IMLOperatorShapeInferenceContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputTensorDimensionCount(::core::mem::transmute_copy(&inputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimensioncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimensioncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -459,7 +459,7 @@ impl IMLOperatorTensorShapeDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputTensorDimensionCount(::core::mem::transmute_copy(&inputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimensioncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimensioncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -480,7 +480,7 @@ impl IMLOperatorTensorShapeDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputTensorDimensionCount(::core::mem::transmute_copy(&outputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimensioncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimensioncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IMLOperatorTypeInferenceContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputEdgeDescription(::core::mem::transmute_copy(&inputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *edgedescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(edgedescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -603,7 +603,7 @@ impl IWinMLEvaluationContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetValueByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -642,7 +642,7 @@ impl IWinMLModel_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl IWinMLModel_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateModelInputs(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinputdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinputdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl IWinMLModel_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateModelOutputs(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutputdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutputdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -703,7 +703,7 @@ impl IWinMLRuntime_Vtbl {
             let this = (*this).get_impl();
             match this.LoadModel(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmodel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmodel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -714,7 +714,7 @@ impl IWinMLRuntime_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEvaluationContext(::core::mem::transmute(&device)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -747,7 +747,7 @@ impl IWinMLRuntimeFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRuntime(::core::mem::transmute_copy(&runtimetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppruntime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppruntime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
@@ -664,7 +664,7 @@ impl IWordBreakerConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetWordStemmer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstemmer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstemmer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
@@ -119,7 +119,7 @@ impl IMXNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.getAllowOverride() {
                 ::core::result::Result::Ok(ok__) => {
-                    *foverride = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(foverride, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -199,7 +199,7 @@ impl IMXNamespacePrefixes_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prefix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prefix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -210,7 +210,7 @@ impl IMXNamespacePrefixes_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -221,7 +221,7 @@ impl IMXNamespacePrefixes_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -333,7 +333,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.output() {
                 ::core::result::Result::Ok(ok__) => {
-                    *vardestination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(vardestination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -349,7 +349,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.encoding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -365,7 +365,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.byteOrderMark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fwritebyteordermark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fwritebyteordermark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -381,7 +381,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.indent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *findentmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(findentmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -397,7 +397,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.standalone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -413,7 +413,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.omitXMLDeclaration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -445,7 +445,7 @@ impl IMXWriter_Vtbl {
             let this = (*this).get_impl();
             match this.disableOutputEscaping() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -506,7 +506,7 @@ impl IMXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.getFeature(::core::mem::transmute(&strname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -522,7 +522,7 @@ impl IMXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.getProperty(::core::mem::transmute(&strname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *varvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -538,7 +538,7 @@ impl IMXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.entityResolver() {
                 ::core::result::Result::Ok(ok__) => {
-                    *oresolver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(oresolver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -554,7 +554,7 @@ impl IMXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.contentHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ohandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ohandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -570,7 +570,7 @@ impl IMXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.dtdHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ohandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ohandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -586,7 +586,7 @@ impl IMXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.errorHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ohandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ohandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -640,7 +640,7 @@ impl ISAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -671,7 +671,7 @@ impl ISAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getIndexFromName(::core::mem::transmute(&pwchuri), ::core::mem::transmute_copy(&cchuri), ::core::mem::transmute(&pwchlocalname), ::core::mem::transmute_copy(&cchlocalname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -682,7 +682,7 @@ impl ISAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getIndexFromQName(::core::mem::transmute(&pwchqname), ::core::mem::transmute_copy(&cchqname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -911,7 +911,7 @@ impl ISAXEntityResolver_Vtbl {
             let this = (*this).get_impl();
             match this.resolveEntity(::core::mem::transmute(&pwchpublicid), ::core::mem::transmute(&pwchsystemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarinput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarinput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1033,7 +1033,7 @@ impl ISAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.getColumnNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pncolumn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pncolumn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1044,7 +1044,7 @@ impl ISAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.getLineNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1055,7 +1055,7 @@ impl ISAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.getPublicId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwchpublicid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwchpublicid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1066,7 +1066,7 @@ impl ISAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.getSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwchsystemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwchsystemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1099,7 +1099,7 @@ impl ISAXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.getParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1151,7 +1151,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getFeature(::core::mem::transmute(&pwchname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvfvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvfvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1167,7 +1167,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getProperty(::core::mem::transmute(&pwchname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1183,7 +1183,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getEntityResolver() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresolver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresolver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1199,7 +1199,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getContentHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1215,7 +1215,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getDTDHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1231,7 +1231,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getErrorHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1247,7 +1247,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getBaseURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwchbaseurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwchbaseurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1263,7 +1263,7 @@ impl ISAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getSecureBaseURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwchsecurebaseurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwchsecurebaseurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1332,7 +1332,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.targetNamespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1343,7 +1343,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *version = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(version, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1354,7 +1354,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.types() {
                 ::core::result::Result::Ok(ok__) => {
-                    *types = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(types, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1365,7 +1365,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.elements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *elements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(elements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1376,7 +1376,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1387,7 +1387,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.attributeGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributegroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributegroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1398,7 +1398,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.modelGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modelgroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modelgroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1409,7 +1409,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.notations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *notations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(notations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1420,7 +1420,7 @@ impl ISchema_Vtbl {
             let this = (*this).get_impl();
             match this.schemaLocations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *schemalocations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(schemalocations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1458,7 +1458,7 @@ impl ISchemaAny_Vtbl {
             let this = (*this).get_impl();
             match this.namespaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1469,7 +1469,7 @@ impl ISchemaAny_Vtbl {
             let this = (*this).get_impl();
             match this.processContents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *processcontents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(processcontents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1504,7 +1504,7 @@ impl ISchemaAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.r#type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1515,7 +1515,7 @@ impl ISchemaAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1526,7 +1526,7 @@ impl ISchemaAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.defaultValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *defaultvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(defaultvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1537,7 +1537,7 @@ impl ISchemaAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.fixedValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fixedvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fixedvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1548,7 +1548,7 @@ impl ISchemaAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.r#use() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#use = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#use, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1559,7 +1559,7 @@ impl ISchemaAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.isReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1594,7 +1594,7 @@ impl ISchemaAttributeGroup_Vtbl {
             let this = (*this).get_impl();
             match this.anyAttribute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *anyattribute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(anyattribute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1605,7 +1605,7 @@ impl ISchemaAttributeGroup_Vtbl {
             let this = (*this).get_impl();
             match this.attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1640,7 +1640,7 @@ impl ISchemaComplexType_Vtbl {
             let this = (*this).get_impl();
             match this.isAbstract() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#abstract = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#abstract, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1651,7 +1651,7 @@ impl ISchemaComplexType_Vtbl {
             let this = (*this).get_impl();
             match this.anyAttribute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *anyattribute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(anyattribute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1662,7 +1662,7 @@ impl ISchemaComplexType_Vtbl {
             let this = (*this).get_impl();
             match this.attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1673,7 +1673,7 @@ impl ISchemaComplexType_Vtbl {
             let this = (*this).get_impl();
             match this.contentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1684,7 +1684,7 @@ impl ISchemaComplexType_Vtbl {
             let this = (*this).get_impl();
             match this.contentModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentmodel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentmodel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1695,7 +1695,7 @@ impl ISchemaComplexType_Vtbl {
             let this = (*this).get_impl();
             match this.prohibitedSubstitutions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prohibited = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prohibited, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1739,7 +1739,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.r#type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1750,7 +1750,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1761,7 +1761,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.defaultValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *defaultvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(defaultvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1772,7 +1772,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.fixedValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fixedvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fixedvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1783,7 +1783,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.isNillable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nillable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nillable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1794,7 +1794,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.identityConstraints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *constraints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(constraints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1805,7 +1805,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.substitutionGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1816,7 +1816,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.substitutionGroupExclusions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *exclusions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exclusions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1827,7 +1827,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.disallowedSubstitutions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1838,7 +1838,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.isAbstract() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#abstract = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#abstract, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1849,7 +1849,7 @@ impl ISchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.isReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1890,7 +1890,7 @@ impl ISchemaIdentityConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.selector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1901,7 +1901,7 @@ impl ISchemaIdentityConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.fields() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fields = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fields, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1912,7 +1912,7 @@ impl ISchemaIdentityConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.referencedKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1949,7 +1949,7 @@ impl ISchemaItem_Vtbl {
             let this = (*this).get_impl();
             match this.name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1960,7 +1960,7 @@ impl ISchemaItem_Vtbl {
             let this = (*this).get_impl();
             match this.namespaceURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaceuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaceuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1971,7 +1971,7 @@ impl ISchemaItem_Vtbl {
             let this = (*this).get_impl();
             match this.schema() {
                 ::core::result::Result::Ok(ok__) => {
-                    *schema = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(schema, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1982,7 +1982,7 @@ impl ISchemaItem_Vtbl {
             let this = (*this).get_impl();
             match this.id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1993,7 +1993,7 @@ impl ISchemaItem_Vtbl {
             let this = (*this).get_impl();
             match this.itemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2004,7 +2004,7 @@ impl ISchemaItem_Vtbl {
             let this = (*this).get_impl();
             match this.unhandledAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2015,7 +2015,7 @@ impl ISchemaItem_Vtbl {
             let this = (*this).get_impl();
             match this.writeAnnotation(::core::mem::transmute(&annotationsink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *iswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2054,7 +2054,7 @@ impl ISchemaItemCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2065,7 +2065,7 @@ impl ISchemaItemCollection_Vtbl {
             let this = (*this).get_impl();
             match this.itemByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2076,7 +2076,7 @@ impl ISchemaItemCollection_Vtbl {
             let this = (*this).get_impl();
             match this.itemByQName(::core::mem::transmute(&name), ::core::mem::transmute(&namespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2087,7 +2087,7 @@ impl ISchemaItemCollection_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2098,7 +2098,7 @@ impl ISchemaItemCollection_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2131,7 +2131,7 @@ impl ISchemaModelGroup_Vtbl {
             let this = (*this).get_impl();
             match this.particles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *particles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(particles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2158,7 +2158,7 @@ impl ISchemaNotation_Vtbl {
             let this = (*this).get_impl();
             match this.systemIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2169,7 +2169,7 @@ impl ISchemaNotation_Vtbl {
             let this = (*this).get_impl();
             match this.publicIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2200,7 +2200,7 @@ impl ISchemaParticle_Vtbl {
             let this = (*this).get_impl();
             match this.minOccurs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minoccurs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minoccurs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2211,7 +2211,7 @@ impl ISchemaParticle_Vtbl {
             let this = (*this).get_impl();
             match this.maxOccurs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxoccurs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxoccurs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2243,7 +2243,7 @@ impl ISchemaStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2254,7 +2254,7 @@ impl ISchemaStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2265,7 +2265,7 @@ impl ISchemaStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2312,7 +2312,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.baseTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *basetypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(basetypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2323,7 +2323,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.r#final() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#final = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#final, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2334,7 +2334,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.variety() {
                 ::core::result::Result::Ok(ok__) => {
-                    *variety = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variety, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2345,7 +2345,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.derivedBy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *derivedby = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(derivedby, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2356,7 +2356,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.isValid(::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *valid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(valid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2367,7 +2367,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.minExclusive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minexclusive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minexclusive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2378,7 +2378,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.minInclusive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mininclusive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mininclusive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2389,7 +2389,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.maxExclusive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxexclusive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxexclusive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2400,7 +2400,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.maxInclusive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxinclusive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxinclusive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2411,7 +2411,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.totalDigits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *totaldigits = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(totaldigits, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2422,7 +2422,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.fractionDigits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fractiondigits = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fractiondigits, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2433,7 +2433,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2444,7 +2444,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.minLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2455,7 +2455,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.maxLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2466,7 +2466,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.enumeration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumeration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumeration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2477,7 +2477,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.whitespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *whitespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(whitespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2488,7 +2488,7 @@ impl ISchemaType_Vtbl {
             let this = (*this).get_impl();
             match this.patterns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *patterns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patterns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2541,7 +2541,7 @@ impl IServerXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.waitForResponse(::core::mem::transmute(&timeoutinseconds)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *issuccessful = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issuccessful, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2552,7 +2552,7 @@ impl IServerXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.getOption(::core::mem::transmute_copy(&option)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2634,7 +2634,7 @@ impl IVBMXNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.allowOverride() {
                 ::core::result::Result::Ok(ok__) => {
-                    *foverride = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(foverride, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2670,7 +2670,7 @@ impl IVBMXNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.getDeclaredPrefixes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prefixes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prefixes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2681,7 +2681,7 @@ impl IVBMXNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.getPrefixes(::core::mem::transmute(&namespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prefixes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prefixes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2692,7 +2692,7 @@ impl IVBMXNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.getURI(::core::mem::transmute(&prefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2703,7 +2703,7 @@ impl IVBMXNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.getURIFromNode(::core::mem::transmute(&strprefix), ::core::mem::transmute(&contextnode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2753,7 +2753,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2764,7 +2764,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getURI(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *struri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(struri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2775,7 +2775,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getLocalName(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strlocalname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strlocalname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2786,7 +2786,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getQName(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strqname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strqname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2797,7 +2797,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getIndexFromName(::core::mem::transmute(&struri), ::core::mem::transmute(&strlocalname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2808,7 +2808,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getIndexFromQName(::core::mem::transmute(&strqname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2819,7 +2819,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getType(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2830,7 +2830,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getTypeFromName(::core::mem::transmute(&struri), ::core::mem::transmute(&strlocalname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2841,7 +2841,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getTypeFromQName(::core::mem::transmute(&strqname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2852,7 +2852,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getValue(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2863,7 +2863,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getValueFromName(::core::mem::transmute(&struri), ::core::mem::transmute(&strlocalname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2874,7 +2874,7 @@ impl IVBSAXAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.getValueFromQName(::core::mem::transmute(&strqname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3209,7 +3209,7 @@ impl IVBSAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.columnNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ncolumn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ncolumn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3220,7 +3220,7 @@ impl IVBSAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.lineNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3231,7 +3231,7 @@ impl IVBSAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.publicId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strpublicid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strpublicid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3242,7 +3242,7 @@ impl IVBSAXLocator_Vtbl {
             let this = (*this).get_impl();
             match this.systemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strsystemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strsystemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3275,7 +3275,7 @@ impl IVBSAXXMLFilter_Vtbl {
             let this = (*this).get_impl();
             match this.parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *oreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(oreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3327,7 +3327,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getFeature(::core::mem::transmute(&strname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3343,7 +3343,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.getProperty(::core::mem::transmute(&strname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *varvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3359,7 +3359,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.entityResolver() {
                 ::core::result::Result::Ok(ok__) => {
-                    *oresolver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(oresolver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3375,7 +3375,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.contentHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ohandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ohandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3391,7 +3391,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.dtdHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ohandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ohandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3407,7 +3407,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.errorHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ohandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ohandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3423,7 +3423,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.baseURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strbaseurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strbaseurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3439,7 +3439,7 @@ impl IVBSAXXMLReader_Vtbl {
             let this = (*this).get_impl();
             match this.secureBaseURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strsecurebaseurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strsecurebaseurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3501,7 +3501,7 @@ impl IXMLAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *n = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(n, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl IXMLAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *v = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(v, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3709,7 +3709,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.doctype() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3720,7 +3720,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.implementation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#impl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#impl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3731,7 +3731,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.documentElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *domelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(domelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3747,7 +3747,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createElement(::core::mem::transmute(&tagname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3758,7 +3758,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createDocumentFragment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *docfrag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(docfrag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3769,7 +3769,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createTextNode(::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3780,7 +3780,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createComment(::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *comment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(comment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3791,7 +3791,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createCDATASection(::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3802,7 +3802,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createProcessingInstruction(::core::mem::transmute(&target), ::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3813,7 +3813,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createAttribute(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *attribute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attribute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3824,7 +3824,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createEntityReference(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *entityref = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(entityref, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3835,7 +3835,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.getElementsByTagName(::core::mem::transmute(&tagname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3846,7 +3846,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createNode(::core::mem::transmute(&r#type), ::core::mem::transmute(&name), ::core::mem::transmute(&namespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *node = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(node, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3857,7 +3857,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.nodeFromID(::core::mem::transmute(&idstring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *node = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(node, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3878,7 +3878,7 @@ impl IXMLDOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.parseError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4019,7 +4019,7 @@ impl IXMLDOMDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.namespaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespacecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespacecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4030,7 +4030,7 @@ impl IXMLDOMDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.schemas() {
                 ::core::result::Result::Ok(ok__) => {
-                    *othercollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(othercollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4046,7 +4046,7 @@ impl IXMLDOMDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.validate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4062,7 +4062,7 @@ impl IXMLDOMDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.getProperty(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4097,7 +4097,7 @@ impl IXMLDOMDocument3_Vtbl {
             let this = (*this).get_impl();
             match this.validateNode(::core::mem::transmute(&node)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4108,7 +4108,7 @@ impl IXMLDOMDocument3_Vtbl {
             let this = (*this).get_impl();
             match this.importNode(::core::mem::transmute(&node), ::core::mem::transmute_copy(&deep)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *clone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4158,7 +4158,7 @@ impl IXMLDOMDocumentType_Vtbl {
             let this = (*this).get_impl();
             match this.entities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *entitymap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(entitymap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4169,7 +4169,7 @@ impl IXMLDOMDocumentType_Vtbl {
             let this = (*this).get_impl();
             match this.notations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *notationmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(notationmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4228,7 +4228,7 @@ impl IXMLDOMElement_Vtbl {
             let this = (*this).get_impl();
             match this.getAttributeNode(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributenode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributenode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4239,7 +4239,7 @@ impl IXMLDOMElement_Vtbl {
             let this = (*this).get_impl();
             match this.setAttributeNode(::core::mem::transmute(&domattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributenode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributenode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4250,7 +4250,7 @@ impl IXMLDOMElement_Vtbl {
             let this = (*this).get_impl();
             match this.removeAttributeNode(::core::mem::transmute(&domattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributenode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributenode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4261,7 +4261,7 @@ impl IXMLDOMElement_Vtbl {
             let this = (*this).get_impl();
             match this.getElementsByTagName(::core::mem::transmute(&tagname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4382,7 +4382,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this.getNamedItem(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nameditem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nameditem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4393,7 +4393,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this.setNamedItem(::core::mem::transmute(&newitem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nameitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nameitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4404,7 +4404,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this.removeNamedItem(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nameditem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nameditem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4415,7 +4415,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4431,7 +4431,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this.getQualifiedItem(::core::mem::transmute(&basename), ::core::mem::transmute(&namespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *qualifieditem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(qualifieditem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4442,7 +4442,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this.removeQualifiedItem(::core::mem::transmute(&basename), ::core::mem::transmute(&namespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *qualifieditem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(qualifieditem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4453,7 +4453,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this.nextNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4469,7 +4469,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4562,7 +4562,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.parentNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4573,7 +4573,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.childNodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *childlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(childlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4584,7 +4584,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.firstChild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *firstchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(firstchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4595,7 +4595,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.lastChild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4606,7 +4606,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.previousSibling() {
                 ::core::result::Result::Ok(ok__) => {
-                    *previoussibling = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previoussibling, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4617,7 +4617,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.nextSibling() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextsibling = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextsibling, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4628,7 +4628,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributemap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributemap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4639,7 +4639,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.insertBefore(::core::mem::transmute(&newchild), ::core::mem::transmute(&refchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *outnewchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(outnewchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4650,7 +4650,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.replaceChild(::core::mem::transmute(&newchild), ::core::mem::transmute(&oldchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *outoldchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(outoldchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4661,7 +4661,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.removeChild(::core::mem::transmute(&childnode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *oldchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(oldchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4672,7 +4672,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.appendChild(::core::mem::transmute(&newchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *outnewchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(outnewchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4688,7 +4688,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.ownerDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xmldomdocument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xmldomdocument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4699,7 +4699,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.cloneNode(::core::mem::transmute_copy(&deep)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cloneroot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cloneroot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4730,7 +4730,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.definition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *definitionnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(definitionnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4771,7 +4771,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.selectNodes(::core::mem::transmute(&querystring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4782,7 +4782,7 @@ impl IXMLDOMNode_Vtbl {
             let this = (*this).get_impl();
             match this.selectSingleNode(::core::mem::transmute(&querystring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4875,7 +4875,7 @@ impl IXMLDOMNodeList_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4891,7 +4891,7 @@ impl IXMLDOMNodeList_Vtbl {
             let this = (*this).get_impl();
             match this.nextNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4907,7 +4907,7 @@ impl IXMLDOMNodeList_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5038,7 +5038,7 @@ impl IXMLDOMParseError2_Vtbl {
             let this = (*this).get_impl();
             match this.errorXPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xpathexpr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xpathexpr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5049,7 +5049,7 @@ impl IXMLDOMParseError2_Vtbl {
             let this = (*this).get_impl();
             match this.allErrors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allerrors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allerrors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5060,7 +5060,7 @@ impl IXMLDOMParseError2_Vtbl {
             let this = (*this).get_impl();
             match this.errorParameters(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5071,7 +5071,7 @@ impl IXMLDOMParseError2_Vtbl {
             let this = (*this).get_impl();
             match this.errorParametersCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5107,7 +5107,7 @@ impl IXMLDOMParseErrorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *error = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(error, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5118,7 +5118,7 @@ impl IXMLDOMParseErrorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5129,7 +5129,7 @@ impl IXMLDOMParseErrorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *error = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(error, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5145,7 +5145,7 @@ impl IXMLDOMParseErrorCollection_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5226,7 +5226,7 @@ impl IXMLDOMSchemaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get(::core::mem::transmute(&namespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *schemanode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(schemanode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5242,7 +5242,7 @@ impl IXMLDOMSchemaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5253,7 +5253,7 @@ impl IXMLDOMSchemaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_namespaceURI(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5269,7 +5269,7 @@ impl IXMLDOMSchemaCollection_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5318,7 +5318,7 @@ impl IXMLDOMSchemaCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.validateOnLoad() {
                 ::core::result::Result::Ok(ok__) => {
-                    *validateonload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(validateonload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5329,7 +5329,7 @@ impl IXMLDOMSchemaCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.getSchema(::core::mem::transmute(&namespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *schema = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(schema, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5340,7 +5340,7 @@ impl IXMLDOMSchemaCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.getDeclaration(::core::mem::transmute(&node)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5383,7 +5383,7 @@ impl IXMLDOMSelection_Vtbl {
             let this = (*this).get_impl();
             match this.expr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *expression = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expression, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5399,7 +5399,7 @@ impl IXMLDOMSelection_Vtbl {
             let this = (*this).get_impl();
             match this.context() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5415,7 +5415,7 @@ impl IXMLDOMSelection_Vtbl {
             let this = (*this).get_impl();
             match this.peekNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5426,7 +5426,7 @@ impl IXMLDOMSelection_Vtbl {
             let this = (*this).get_impl();
             match this.matches(::core::mem::transmute(&pnode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5437,7 +5437,7 @@ impl IXMLDOMSelection_Vtbl {
             let this = (*this).get_impl();
             match this.removeNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5453,7 +5453,7 @@ impl IXMLDOMSelection_Vtbl {
             let this = (*this).get_impl();
             match this.clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5464,7 +5464,7 @@ impl IXMLDOMSelection_Vtbl {
             let this = (*this).get_impl();
             match this.getProperty(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5508,7 +5508,7 @@ impl IXMLDOMText_Vtbl {
             let this = (*this).get_impl();
             match this.splitText(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *righthandtextnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(righthandtextnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5538,7 +5538,7 @@ impl IXMLDSOControl_Vtbl {
             let this = (*this).get_impl();
             match this.XMLDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5604,7 +5604,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.root() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5615,7 +5615,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.fileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5626,7 +5626,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.fileModifiedDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5637,7 +5637,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.fileUpdatedDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5648,7 +5648,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.URL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5664,7 +5664,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.mimeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5675,7 +5675,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.readyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5686,7 +5686,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.charset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5702,7 +5702,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5713,7 +5713,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.doctype() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5724,7 +5724,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.dtdURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5735,7 +5735,7 @@ impl IXMLDocument_Vtbl {
             let this = (*this).get_impl();
             match this.createElement(::core::mem::transmute(&vtype), ::core::mem::transmute(&var1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppelem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppelem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5792,7 +5792,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.root() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5803,7 +5803,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.fileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5814,7 +5814,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.fileModifiedDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5825,7 +5825,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.fileUpdatedDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5836,7 +5836,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.URL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5852,7 +5852,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.mimeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5863,7 +5863,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.readyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5874,7 +5874,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.charset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5890,7 +5890,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5901,7 +5901,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.doctype() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5912,7 +5912,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.dtdURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5923,7 +5923,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.createElement(::core::mem::transmute(&vtype), ::core::mem::transmute(&var1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppelem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppelem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5934,7 +5934,7 @@ impl IXMLDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.r#async() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5994,7 +5994,7 @@ impl IXMLElement_Vtbl {
             let this = (*this).get_impl();
             match this.tagName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6010,7 +6010,7 @@ impl IXMLElement_Vtbl {
             let this = (*this).get_impl();
             match this.parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6026,7 +6026,7 @@ impl IXMLElement_Vtbl {
             let this = (*this).get_impl();
             match this.getAttribute(::core::mem::transmute(&strpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6042,7 +6042,7 @@ impl IXMLElement_Vtbl {
             let this = (*this).get_impl();
             match this.children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6053,7 +6053,7 @@ impl IXMLElement_Vtbl {
             let this = (*this).get_impl();
             match this.r#type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6064,7 +6064,7 @@ impl IXMLElement_Vtbl {
             let this = (*this).get_impl();
             match this.text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6131,7 +6131,7 @@ impl IXMLElement2_Vtbl {
             let this = (*this).get_impl();
             match this.tagName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6147,7 +6147,7 @@ impl IXMLElement2_Vtbl {
             let this = (*this).get_impl();
             match this.parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6163,7 +6163,7 @@ impl IXMLElement2_Vtbl {
             let this = (*this).get_impl();
             match this.getAttribute(::core::mem::transmute(&strpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6179,7 +6179,7 @@ impl IXMLElement2_Vtbl {
             let this = (*this).get_impl();
             match this.children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6190,7 +6190,7 @@ impl IXMLElement2_Vtbl {
             let this = (*this).get_impl();
             match this.r#type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6201,7 +6201,7 @@ impl IXMLElement2_Vtbl {
             let this = (*this).get_impl();
             match this.text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6227,7 +6227,7 @@ impl IXMLElement2_Vtbl {
             let this = (*this).get_impl();
             match this.attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6276,7 +6276,7 @@ impl IXMLElementCollection_Vtbl {
             let this = (*this).get_impl();
             match this.length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *p = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(p, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6287,7 +6287,7 @@ impl IXMLElementCollection_Vtbl {
             let this = (*this).get_impl();
             match this._newEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6298,7 +6298,7 @@ impl IXMLElementCollection_Vtbl {
             let this = (*this).get_impl();
             match this.item(::core::mem::transmute(&var1), ::core::mem::transmute(&var2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6373,7 +6373,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.getResponseHeader(::core::mem::transmute(&bstrheader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6384,7 +6384,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.getAllResponseHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6405,7 +6405,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6416,7 +6416,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.statusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6427,7 +6427,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseXML() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6438,7 +6438,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6449,7 +6449,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseBody() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6460,7 +6460,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6471,7 +6471,7 @@ impl IXMLHTTPRequest_Vtbl {
             let this = (*this).get_impl();
             match this.readyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6542,7 +6542,7 @@ impl IXMLHTTPRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.SetCookie(::core::mem::transmute_copy(&pcookie)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookiestate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookiestate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6568,7 +6568,7 @@ impl IXMLHTTPRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllResponseHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6584,7 +6584,7 @@ impl IXMLHTTPRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetResponseHeader(::core::mem::transmute(&pwszheader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6746,7 +6746,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.getResponseHeader(::core::mem::transmute(&bstrheader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6757,7 +6757,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.getAllResponseHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6778,7 +6778,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6789,7 +6789,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.statusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6800,7 +6800,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseXML() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6811,7 +6811,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6822,7 +6822,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseBody() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6833,7 +6833,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.responseStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6844,7 +6844,7 @@ impl IXMLHttpRequest_Vtbl {
             let this = (*this).get_impl();
             match this.readyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6909,7 +6909,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.input() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6920,7 +6920,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.ownerTemplate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6936,7 +6936,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.startMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6947,7 +6947,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.startModeURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaceuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaceuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6963,7 +6963,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.output() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6974,7 +6974,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.transform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6990,7 +6990,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.readyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preadystate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preadystate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7011,7 +7011,7 @@ impl IXSLProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.stylesheet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stylesheet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stylesheet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7060,7 +7060,7 @@ impl IXSLTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.stylesheet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stylesheet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stylesheet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7071,7 +7071,7 @@ impl IXSLTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.createProcessor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprocessor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprocessor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
@@ -39,7 +39,7 @@ impl IXmlReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&nproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -60,7 +60,7 @@ impl IXmlReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetNodeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnodetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnodetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -136,7 +136,7 @@ impl IXmlReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetLineNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnlinenumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnlinenumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -147,7 +147,7 @@ impl IXmlReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinePosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnlineposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnlineposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -158,7 +158,7 @@ impl IXmlReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnattributecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnattributecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -169,7 +169,7 @@ impl IXmlReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pndepth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pndepth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -222,7 +222,7 @@ impl IXmlResolver_Vtbl {
             let this = (*this).get_impl();
             match this.ResolveUri(::core::mem::transmute(&pwszbaseuri), ::core::mem::transmute(&pwszpublicidentifier), ::core::mem::transmute(&pwszsystemidentifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresolvedinput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresolvedinput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -281,7 +281,7 @@ impl IXmlWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&nproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -505,7 +505,7 @@ impl IXmlWriterLite_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&nproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
@@ -81,7 +81,7 @@ impl IViewHelper_Vtbl {
             let this = (*this).get_impl();
             match this.SetConfiguration(::core::mem::transmute(&pistream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
@@ -15,7 +15,7 @@ impl IUPnPAddressFamilyControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetAddressFamily() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -68,7 +68,7 @@ impl IUPnPDescriptionDocument_Vtbl {
             let this = (*this).get_impl();
             match this.ReadyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plreadystate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plreadystate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -89,7 +89,7 @@ impl IUPnPDescriptionDocument_Vtbl {
             let this = (*this).get_impl();
             match this.LoadResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -105,7 +105,7 @@ impl IUPnPDescriptionDocument_Vtbl {
             let this = (*this).get_impl();
             match this.RootDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppudrootdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppudrootdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -116,7 +116,7 @@ impl IUPnPDescriptionDocument_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceByUDN(::core::mem::transmute(&bstrudn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuddevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuddevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -186,7 +186,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IsRootDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -197,7 +197,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.RootDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppudrootdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppudrootdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -208,7 +208,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ParentDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuddeviceparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuddeviceparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -219,7 +219,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.HasChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -230,7 +230,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppudchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppudchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -241,7 +241,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.UniqueDeviceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -252,7 +252,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -263,7 +263,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -274,7 +274,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.PresentationURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -285,7 +285,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ManufacturerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -296,7 +296,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ManufacturerURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -307,7 +307,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ModelName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -318,7 +318,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ModelNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -329,7 +329,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -340,7 +340,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ModelURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -351,7 +351,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.UPC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -362,7 +362,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.SerialNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -373,7 +373,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IconURL(::core::mem::transmute(&bstrencodingformat), ::core::mem::transmute_copy(&lsizex), ::core::mem::transmute_copy(&lsizey), ::core::mem::transmute_copy(&lbitdepth)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstriconurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstriconurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -384,7 +384,7 @@ impl IUPnPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Services() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppusservices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppusservices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -437,7 +437,7 @@ impl IUPnPDeviceControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceObject(::core::mem::transmute(&bstrudn), ::core::mem::transmute(&bstrserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdispservice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdispservice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -467,7 +467,7 @@ impl IUPnPDeviceControlHttpHeaders_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdditionalResponseHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrhttpresponseheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrhttpresponseheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -496,7 +496,7 @@ impl IUPnPDeviceDocumentAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdocument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdocument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -522,7 +522,7 @@ impl IUPnPDeviceDocumentAccessEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdocument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdocument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -552,7 +552,7 @@ impl IUPnPDeviceFinder_Vtbl {
             let this = (*this).get_impl();
             match this.FindByType(::core::mem::transmute(&bstrtypeuri), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -563,7 +563,7 @@ impl IUPnPDeviceFinder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAsyncFind(::core::mem::transmute(&bstrtypeuri), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&punkdevicefindercallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfinddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfinddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -584,7 +584,7 @@ impl IUPnPDeviceFinder_Vtbl {
             let this = (*this).get_impl();
             match this.FindByUDN(::core::mem::transmute(&bstrudn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -702,7 +702,7 @@ impl IUPnPDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -713,7 +713,7 @@ impl IUPnPDevices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -724,7 +724,7 @@ impl IUPnPDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&bstrudn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -837,7 +837,7 @@ impl IUPnPRegistrar_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterDevice(::core::mem::transmute(&bstrxmldesc), ::core::mem::transmute(&bstrprogiddevicecontrolclass), ::core::mem::transmute(&bstrinitstring), ::core::mem::transmute(&bstrcontainerid), ::core::mem::transmute(&bstrresourcepath), ::core::mem::transmute_copy(&nlifetime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdeviceidentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdeviceidentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -848,7 +848,7 @@ impl IUPnPRegistrar_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterRunningDevice(::core::mem::transmute(&bstrxmldesc), ::core::mem::transmute(&punkdevicecontrol), ::core::mem::transmute(&bstrinitstring), ::core::mem::transmute(&bstrresourcepath), ::core::mem::transmute_copy(&nlifetime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdeviceidentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdeviceidentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -864,7 +864,7 @@ impl IUPnPRegistrar_Vtbl {
             let this = (*this).get_impl();
             match this.GetUniqueDeviceName(::core::mem::transmute(&bstrdeviceidentifier), ::core::mem::transmute(&bstrtemplateudn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrudn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrudn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -910,7 +910,7 @@ impl IUPnPRemoteEndpointInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDwordValue(::core::mem::transmute(&bstrvaluename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -921,7 +921,7 @@ impl IUPnPRemoteEndpointInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute(&bstrvaluename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -932,7 +932,7 @@ impl IUPnPRemoteEndpointInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuidValue(::core::mem::transmute(&bstrvaluename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -998,7 +998,7 @@ impl IUPnPService_Vtbl {
             let this = (*this).get_impl();
             match this.QueryStateVariable(::core::mem::transmute(&bstrvariablename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1014,7 +1014,7 @@ impl IUPnPService_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceTypeIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1030,7 +1030,7 @@ impl IUPnPService_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1041,7 +1041,7 @@ impl IUPnPService_Vtbl {
             let this = (*this).get_impl();
             match this.LastTransportStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1083,7 +1083,7 @@ impl IUPnPServiceAsync_Vtbl {
             let this = (*this).get_impl();
             match this.BeginInvokeAction(::core::mem::transmute(&bstractionname), ::core::mem::transmute(&vinactionargs), ::core::mem::transmute(&pasyncresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullrequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullrequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1099,7 +1099,7 @@ impl IUPnPServiceAsync_Vtbl {
             let this = (*this).get_impl();
             match this.BeginQueryStateVariable(::core::mem::transmute(&bstrvariablename), ::core::mem::transmute(&pasyncresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullrequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullrequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1115,7 +1115,7 @@ impl IUPnPServiceAsync_Vtbl {
             let this = (*this).get_impl();
             match this.BeginSubscribeToEvents(::core::mem::transmute(&punkcallback), ::core::mem::transmute(&pasyncresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullrequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullrequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1131,7 +1131,7 @@ impl IUPnPServiceAsync_Vtbl {
             let this = (*this).get_impl();
             match this.BeginSCPDDownload(::core::mem::transmute(&pasyncresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullrequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullrequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1142,7 +1142,7 @@ impl IUPnPServiceAsync_Vtbl {
             let this = (*this).get_impl();
             match this.EndSCPDDownload(::core::mem::transmute_copy(&ullrequestid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrscpddoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrscpddoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1215,7 +1215,7 @@ impl IUPnPServiceDocumentAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdocurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdocurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1226,7 +1226,7 @@ impl IUPnPServiceDocumentAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1275,7 +1275,7 @@ impl IUPnPServices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1286,7 +1286,7 @@ impl IUPnPServices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1297,7 +1297,7 @@ impl IUPnPServices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&bstrserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
@@ -15,7 +15,7 @@ impl IFaxAccount_Vtbl {
             let this = (*this).get_impl();
             match this.AccountName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstraccountname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstraccountname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26,7 +26,7 @@ impl IFaxAccount_Vtbl {
             let this = (*this).get_impl();
             match this.Folders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfolders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfolders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IFaxAccount_Vtbl {
             let this = (*this).get_impl();
             match this.RegisteredEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pregisteredevents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pregisteredevents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -77,7 +77,7 @@ impl IFaxAccountFolders_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -88,7 +88,7 @@ impl IFaxAccountFolders_Vtbl {
             let this = (*this).get_impl();
             match this.IncomingQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -99,7 +99,7 @@ impl IFaxAccountFolders_Vtbl {
             let this = (*this).get_impl();
             match this.IncomingArchive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingarchive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingarchive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -110,7 +110,7 @@ impl IFaxAccountFolders_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingArchive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingarchive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingarchive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -146,7 +146,7 @@ impl IFaxAccountIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeLow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizelow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizelow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -157,7 +157,7 @@ impl IFaxAccountIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeHigh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizehigh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizehigh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -173,7 +173,7 @@ impl IFaxAccountIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessages(::core::mem::transmute_copy(&lprefetchsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingmessageiterator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingmessageiterator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -184,7 +184,7 @@ impl IFaxAccountIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessage(::core::mem::transmute(&bstrmessageid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -218,7 +218,7 @@ impl IFaxAccountIncomingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJobs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingjobs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingjobs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -229,7 +229,7 @@ impl IFaxAccountIncomingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJob(::core::mem::transmute(&bstrjobid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl IFaxAccountOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeLow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizelow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizelow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -287,7 +287,7 @@ impl IFaxAccountOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeHigh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizehigh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizehigh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -303,7 +303,7 @@ impl IFaxAccountOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessages(::core::mem::transmute_copy(&lprefetchsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingmessageiterator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingmessageiterator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IFaxAccountOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessage(::core::mem::transmute(&bstrmessageid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -348,7 +348,7 @@ impl IFaxAccountOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJobs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingjobs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingjobs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -359,7 +359,7 @@ impl IFaxAccountOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJob(::core::mem::transmute(&bstrjobid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -392,7 +392,7 @@ impl IFaxAccountSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccounts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxaccounts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxaccounts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -403,7 +403,7 @@ impl IFaxAccountSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccount(::core::mem::transmute(&bstraccountname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxaccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxaccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -414,7 +414,7 @@ impl IFaxAccountSet_Vtbl {
             let this = (*this).get_impl();
             match this.AddAccount(::core::mem::transmute(&bstraccountname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxaccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxaccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -453,7 +453,7 @@ impl IFaxAccounts_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -464,7 +464,7 @@ impl IFaxAccounts_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxaccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxaccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -475,7 +475,7 @@ impl IFaxAccounts_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -510,7 +510,7 @@ impl IFaxActivity_Vtbl {
             let this = (*this).get_impl();
             match this.IncomingMessages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plincomingmessages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plincomingmessages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -521,7 +521,7 @@ impl IFaxActivity_Vtbl {
             let this = (*this).get_impl();
             match this.RoutingMessages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plroutingmessages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plroutingmessages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -532,7 +532,7 @@ impl IFaxActivity_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingMessages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ploutgoingmessages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ploutgoingmessages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -543,7 +543,7 @@ impl IFaxActivity_Vtbl {
             let this = (*this).get_impl();
             match this.QueuedMessages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plqueuedmessages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plqueuedmessages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -588,7 +588,7 @@ impl IFaxActivityLogging_Vtbl {
             let this = (*this).get_impl();
             match this.LogIncoming() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblogincoming = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblogincoming, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -604,7 +604,7 @@ impl IFaxActivityLogging_Vtbl {
             let this = (*this).get_impl();
             match this.LogOutgoing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblogoutgoing = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblogoutgoing, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -620,7 +620,7 @@ impl IFaxActivityLogging_Vtbl {
             let this = (*this).get_impl();
             match this.DatabasePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdatabasepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdatabasepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -712,7 +712,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.UseArchive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbusearchive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbusearchive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -728,7 +728,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ArchiveLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrarchivelocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrarchivelocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -744,7 +744,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SizeQuotaWarning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsizequotawarning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsizequotawarning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -760,7 +760,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.HighQuotaWaterMark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhighquotawatermark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhighquotawatermark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -776,7 +776,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.LowQuotaWaterMark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllowquotawatermark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllowquotawatermark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -792,7 +792,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ArchiveAgeLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plarchiveagelimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plarchiveagelimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -808,7 +808,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ArchiveSizeLow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizelow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizelow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -819,7 +819,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ArchiveSizeHigh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizehigh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizehigh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -830,7 +830,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingQueueBlocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pboutgoingblocked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pboutgoingblocked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -846,7 +846,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingQueuePaused() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pboutgoingpaused = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pboutgoingpaused, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -862,7 +862,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.AllowPersonalCoverPages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pballowpersonalcoverpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pballowpersonalcoverpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -878,7 +878,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.UseDeviceTSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbusedevicetsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbusedevicetsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -894,7 +894,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.Retries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -910,7 +910,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.RetryDelay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretrydelay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretrydelay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -926,7 +926,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DiscountRateStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatediscountratestart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatediscountratestart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -942,7 +942,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.DiscountRateEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatediscountrateend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatediscountrateend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -958,7 +958,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingQueueAgeLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ploutgoingqueueagelimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ploutgoingqueueagelimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -974,7 +974,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.Branding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbbranding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbbranding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -990,7 +990,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.IncomingQueueBlocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbincomingblocked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbincomingblocked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1006,7 +1006,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.AutoCreateAccountOnConnect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbautocreateaccountonconnect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbautocreateaccountonconnect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1022,7 +1022,7 @@ impl IFaxConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.IncomingFaxesArePublic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbincomingfaxesarepublic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbincomingfaxesarepublic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1132,7 +1132,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1143,7 +1143,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1154,7 +1154,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderUniqueName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprovideruniquename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprovideruniquename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1165,7 +1165,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.PoweredOff() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbpoweredoff = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbpoweredoff, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1176,7 +1176,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ReceivingNow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbreceivingnow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbreceivingnow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1187,7 +1187,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.SendingNow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsendingnow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsendingnow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1198,7 +1198,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.UsedRoutingMethods() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvusedroutingmethods = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvusedroutingmethods, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1209,7 +1209,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1225,7 +1225,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.SendEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsendenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsendenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1241,7 +1241,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preceivemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preceivemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1257,7 +1257,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.RingsBeforeAnswer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plringsbeforeanswer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plringsbeforeanswer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1273,7 +1273,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1289,7 +1289,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1315,7 +1315,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionProperty(::core::mem::transmute(&bstrguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1336,7 +1336,7 @@ impl IFaxDevice_Vtbl {
             let this = (*this).get_impl();
             match this.RingingNow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbringingnow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbringingnow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1400,7 +1400,7 @@ impl IFaxDeviceIds_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1411,7 +1411,7 @@ impl IFaxDeviceIds_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1422,7 +1422,7 @@ impl IFaxDeviceIds_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1482,7 +1482,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1493,7 +1493,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ImageName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrimagename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrimagename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1504,7 +1504,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.UniqueName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruniquename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruniquename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1515,7 +1515,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.TapiProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtapiprovidername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtapiprovidername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1526,7 +1526,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1537,7 +1537,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1548,7 +1548,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MajorBuild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorbuild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorbuild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1559,7 +1559,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MinorBuild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorbuild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorbuild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1570,7 +1570,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Debug() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdebug = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdebug, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1581,7 +1581,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1592,7 +1592,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.InitErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pliniterrorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pliniterrorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1603,7 +1603,7 @@ impl IFaxDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceIds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvdeviceids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvdeviceids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1645,7 +1645,7 @@ impl IFaxDeviceProviders_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1656,7 +1656,7 @@ impl IFaxDeviceProviders_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxdeviceprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxdeviceprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1667,7 +1667,7 @@ impl IFaxDeviceProviders_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1701,7 +1701,7 @@ impl IFaxDevices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1712,7 +1712,7 @@ impl IFaxDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1723,7 +1723,7 @@ impl IFaxDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1734,7 +1734,7 @@ impl IFaxDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemById(::core::mem::transmute_copy(&lid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1799,7 +1799,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Body() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1815,7 +1815,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Sender() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxsender = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxsender, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1826,7 +1826,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Recipients() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxrecipients = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxrecipients, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1837,7 +1837,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CoverPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcoverpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcoverpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1853,7 +1853,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Subject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1869,7 +1869,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Note() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnote = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnote, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1885,7 +1885,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.ScheduleTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatescheduletime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatescheduletime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1901,7 +1901,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiptAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrreceiptaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrreceiptaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1917,7 +1917,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdocumentname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdocumentname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1933,7 +1933,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CallHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1949,7 +1949,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CoverPageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcoverpagetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcoverpagetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1965,7 +1965,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.ScheduleType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pscheduletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pscheduletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1981,7 +1981,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiptType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preceipttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preceipttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1997,7 +1997,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GroupBroadcastReceipts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbusegrouping = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbusegrouping, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2013,7 +2013,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2029,7 +2029,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.TapiConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptapiconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptapiconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2045,7 +2045,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Submit(::core::mem::transmute(&bstrfaxservername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvfaxoutgoingjobids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvfaxoutgoingjobids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2056,7 +2056,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectedSubmit(::core::mem::transmute(&pfaxserver)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvfaxoutgoingjobids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvfaxoutgoingjobids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2067,7 +2067,7 @@ impl IFaxDocument_Vtbl {
             let this = (*this).get_impl();
             match this.AttachFaxToReceipt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbattachfax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbattachfax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2138,7 +2138,7 @@ impl IFaxDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.SubmissionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubmissionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubmissionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2149,7 +2149,7 @@ impl IFaxDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.Bodies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbodies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbodies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2206,7 +2206,7 @@ impl IFaxEventLogging_Vtbl {
             let this = (*this).get_impl();
             match this.InitEventsLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piniteventlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piniteventlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2222,7 +2222,7 @@ impl IFaxEventLogging_Vtbl {
             let this = (*this).get_impl();
             match this.InboundEventsLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinboundeventlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinboundeventlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2238,7 +2238,7 @@ impl IFaxEventLogging_Vtbl {
             let this = (*this).get_impl();
             match this.OutboundEventsLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutboundeventlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutboundeventlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2254,7 +2254,7 @@ impl IFaxEventLogging_Vtbl {
             let this = (*this).get_impl();
             match this.GeneralEventsLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgeneraleventlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgeneraleventlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2310,7 +2310,7 @@ impl IFaxFolders_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2321,7 +2321,7 @@ impl IFaxFolders_Vtbl {
             let this = (*this).get_impl();
             match this.IncomingQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2332,7 +2332,7 @@ impl IFaxFolders_Vtbl {
             let this = (*this).get_impl();
             match this.IncomingArchive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingarchive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingarchive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2343,7 +2343,7 @@ impl IFaxFolders_Vtbl {
             let this = (*this).get_impl();
             match this.OutgoingArchive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingarchive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingarchive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2376,7 +2376,7 @@ impl IFaxInboundRouting_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxinboundroutingextensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxinboundroutingextensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2387,7 +2387,7 @@ impl IFaxInboundRouting_Vtbl {
             let this = (*this).get_impl();
             match this.GetMethods() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxinboundroutingmethods = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxinboundroutingmethods, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2427,7 +2427,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2438,7 +2438,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.ImageName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrimagename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrimagename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2449,7 +2449,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.UniqueName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruniquename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruniquename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2460,7 +2460,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.MajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2471,7 +2471,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.MinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2482,7 +2482,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.MajorBuild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorbuild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorbuild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2493,7 +2493,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.MinorBuild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorbuild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorbuild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2504,7 +2504,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.Debug() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdebug = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdebug, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2515,7 +2515,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2526,7 +2526,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.InitErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pliniterrorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pliniterrorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2537,7 +2537,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
             let this = (*this).get_impl();
             match this.Methods() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvmethods = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvmethods, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2578,7 +2578,7 @@ impl IFaxInboundRoutingExtensions_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2589,7 +2589,7 @@ impl IFaxInboundRoutingExtensions_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxinboundroutingextension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxinboundroutingextension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2600,7 +2600,7 @@ impl IFaxInboundRoutingExtensions_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2639,7 +2639,7 @@ impl IFaxInboundRoutingMethod_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2650,7 +2650,7 @@ impl IFaxInboundRoutingMethod_Vtbl {
             let this = (*this).get_impl();
             match this.GUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2661,7 +2661,7 @@ impl IFaxInboundRoutingMethod_Vtbl {
             let this = (*this).get_impl();
             match this.FunctionName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfunctionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfunctionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2672,7 +2672,7 @@ impl IFaxInboundRoutingMethod_Vtbl {
             let this = (*this).get_impl();
             match this.ExtensionFriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrextensionfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrextensionfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2683,7 +2683,7 @@ impl IFaxInboundRoutingMethod_Vtbl {
             let this = (*this).get_impl();
             match this.ExtensionImageName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrextensionimagename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrextensionimagename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2694,7 +2694,7 @@ impl IFaxInboundRoutingMethod_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2748,7 +2748,7 @@ impl IFaxInboundRoutingMethods_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2759,7 +2759,7 @@ impl IFaxInboundRoutingMethods_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxinboundroutingmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxinboundroutingmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2770,7 +2770,7 @@ impl IFaxInboundRoutingMethods_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2818,7 +2818,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.UseArchive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbusearchive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbusearchive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2834,7 +2834,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.ArchiveFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrarchivefolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrarchivefolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2850,7 +2850,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeQuotaWarning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsizequotawarning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsizequotawarning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2866,7 +2866,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.HighQuotaWaterMark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhighquotawatermark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhighquotawatermark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2882,7 +2882,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.LowQuotaWaterMark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllowquotawatermark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllowquotawatermark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2898,7 +2898,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.AgeLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plagelimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plagelimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2914,7 +2914,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeLow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizelow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizelow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2925,7 +2925,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeHigh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizehigh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizehigh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2946,7 +2946,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessages(::core::mem::transmute_copy(&lprefetchsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingmessageiterator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingmessageiterator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2957,7 +2957,7 @@ impl IFaxIncomingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessage(::core::mem::transmute(&bstrmessageid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3021,7 +3021,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3032,7 +3032,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3043,7 +3043,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcurrentpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcurrentpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3054,7 +3054,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3065,7 +3065,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3076,7 +3076,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedStatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextendedstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextendedstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3087,7 +3087,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrextendedstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrextendedstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3098,7 +3098,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableOperations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pavailableoperations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pavailableoperations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3109,7 +3109,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Retries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3120,7 +3120,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3131,7 +3131,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3142,7 +3142,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.CSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3153,7 +3153,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3164,7 +3164,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.CallerId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcallerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcallerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3175,7 +3175,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.RoutingInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrroutinginformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrroutinginformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3186,7 +3186,7 @@ impl IFaxIncomingJob_Vtbl {
             let this = (*this).get_impl();
             match this.JobType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pjobtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pjobtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3250,7 +3250,7 @@ impl IFaxIncomingJobs_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3261,7 +3261,7 @@ impl IFaxIncomingJobs_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3272,7 +3272,7 @@ impl IFaxIncomingJobs_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3315,7 +3315,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3326,7 +3326,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Pages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3337,7 +3337,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3348,7 +3348,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3359,7 +3359,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Retries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3370,7 +3370,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3381,7 +3381,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3392,7 +3392,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.CSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3403,7 +3403,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3414,7 +3414,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.CallerId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcallerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcallerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3425,7 +3425,7 @@ impl IFaxIncomingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.RoutingInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrroutinginformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrroutinginformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3491,7 +3491,7 @@ impl IFaxIncomingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Subject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3507,7 +3507,7 @@ impl IFaxIncomingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SenderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsendername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsendername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl IFaxIncomingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SenderFaxNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsenderfaxnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsenderfaxnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3539,7 +3539,7 @@ impl IFaxIncomingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.HasCoverPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbhascoverpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbhascoverpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3555,7 +3555,7 @@ impl IFaxIncomingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Recipients() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrrecipients = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrrecipients, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3571,7 +3571,7 @@ impl IFaxIncomingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.WasReAssigned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbwasreassigned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbwasreassigned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3582,7 +3582,7 @@ impl IFaxIncomingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Read() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3651,7 +3651,7 @@ impl IFaxIncomingMessageIterator_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3662,7 +3662,7 @@ impl IFaxIncomingMessageIterator_Vtbl {
             let this = (*this).get_impl();
             match this.PrefetchSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprefetchsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprefetchsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3678,7 +3678,7 @@ impl IFaxIncomingMessageIterator_Vtbl {
             let this = (*this).get_impl();
             match this.AtEOF() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbeof = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbeof, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3727,7 +3727,7 @@ impl IFaxIncomingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Blocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbblocked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbblocked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3753,7 +3753,7 @@ impl IFaxIncomingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJobs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingjobs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingjobs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3764,7 +3764,7 @@ impl IFaxIncomingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJob(::core::mem::transmute(&bstrjobid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxincomingjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxincomingjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3814,7 +3814,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3825,7 +3825,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Pages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3836,7 +3836,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3847,7 +3847,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcurrentpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcurrentpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3858,7 +3858,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3869,7 +3869,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3880,7 +3880,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3891,7 +3891,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedStatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextendedstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextendedstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3902,7 +3902,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrextendedstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrextendedstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3913,7 +3913,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableOperations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pavailableoperations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pavailableoperations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3924,7 +3924,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Retries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3935,7 +3935,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.JobType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pjobtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pjobtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3946,7 +3946,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.ScheduledTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatescheduledtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatescheduledtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3957,7 +3957,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3968,7 +3968,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3979,7 +3979,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CallerId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcallerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcallerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3990,7 +3990,7 @@ impl IFaxJobStatus_Vtbl {
             let this = (*this).get_impl();
             match this.RoutingInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrroutinginformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrroutinginformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4036,7 +4036,7 @@ impl IFaxLoggingOptions_Vtbl {
             let this = (*this).get_impl();
             match this.EventLogging() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxeventlogging = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxeventlogging, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4047,7 +4047,7 @@ impl IFaxLoggingOptions_Vtbl {
             let this = (*this).get_impl();
             match this.ActivityLogging() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxactivitylogging = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxactivitylogging, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4078,7 +4078,7 @@ impl IFaxOutboundRouting_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutboundroutinggroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutboundroutinggroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4089,7 +4089,7 @@ impl IFaxOutboundRouting_Vtbl {
             let this = (*this).get_impl();
             match this.GetRules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutboundroutingrules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutboundroutingrules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4121,7 +4121,7 @@ impl IFaxOutboundRoutingGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4132,7 +4132,7 @@ impl IFaxOutboundRoutingGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4143,7 +4143,7 @@ impl IFaxOutboundRoutingGroup_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceIds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxdeviceids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxdeviceids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4178,7 +4178,7 @@ impl IFaxOutboundRoutingGroups_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4189,7 +4189,7 @@ impl IFaxOutboundRoutingGroups_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutboundroutinggroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutboundroutinggroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4200,7 +4200,7 @@ impl IFaxOutboundRoutingGroups_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4211,7 +4211,7 @@ impl IFaxOutboundRoutingGroups_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutboundroutinggroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutboundroutinggroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4259,7 +4259,7 @@ impl IFaxOutboundRoutingRule_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcountrycode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcountrycode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4270,7 +4270,7 @@ impl IFaxOutboundRoutingRule_Vtbl {
             let this = (*this).get_impl();
             match this.AreaCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plareacode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plareacode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4281,7 +4281,7 @@ impl IFaxOutboundRoutingRule_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4292,7 +4292,7 @@ impl IFaxOutboundRoutingRule_Vtbl {
             let this = (*this).get_impl();
             match this.UseDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbusedevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbusedevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4308,7 +4308,7 @@ impl IFaxOutboundRoutingRule_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4324,7 +4324,7 @@ impl IFaxOutboundRoutingRule_Vtbl {
             let this = (*this).get_impl();
             match this.GroupName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrgroupname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrgroupname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4384,7 +4384,7 @@ impl IFaxOutboundRoutingRules_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4395,7 +4395,7 @@ impl IFaxOutboundRoutingRules_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutboundroutingrule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutboundroutingrule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4406,7 +4406,7 @@ impl IFaxOutboundRoutingRules_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4417,7 +4417,7 @@ impl IFaxOutboundRoutingRules_Vtbl {
             let this = (*this).get_impl();
             match this.ItemByCountryAndArea(::core::mem::transmute_copy(&lcountrycode), ::core::mem::transmute_copy(&lareacode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutboundroutingrule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutboundroutingrule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4438,7 +4438,7 @@ impl IFaxOutboundRoutingRules_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute_copy(&lcountrycode), ::core::mem::transmute_copy(&lareacode), ::core::mem::transmute_copy(&busedevice), ::core::mem::transmute(&bstrgroupname), ::core::mem::transmute_copy(&ldeviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutboundroutingrule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutboundroutingrule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4490,7 +4490,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.UseArchive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbusearchive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbusearchive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4506,7 +4506,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.ArchiveFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrarchivefolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrarchivefolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4522,7 +4522,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeQuotaWarning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsizequotawarning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsizequotawarning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4538,7 +4538,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.HighQuotaWaterMark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhighquotawatermark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhighquotawatermark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4554,7 +4554,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.LowQuotaWaterMark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllowquotawatermark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllowquotawatermark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4570,7 +4570,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.AgeLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plagelimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plagelimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4586,7 +4586,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeLow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizelow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizelow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4597,7 +4597,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.SizeHigh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsizehigh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsizehigh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4618,7 +4618,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessages(::core::mem::transmute_copy(&lprefetchsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingmessageiterator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingmessageiterator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4629,7 +4629,7 @@ impl IFaxOutgoingArchive_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessage(::core::mem::transmute(&bstrmessageid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4705,7 +4705,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Subject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4716,7 +4716,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdocumentname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdocumentname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4727,7 +4727,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Pages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4738,7 +4738,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4749,7 +4749,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.SubmissionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubmissionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubmissionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4760,7 +4760,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4771,7 +4771,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.OriginalScheduledTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdateoriginalscheduledtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdateoriginalscheduledtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4782,7 +4782,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.SubmissionTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatesubmissiontime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatesubmissiontime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4793,7 +4793,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiptType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preceipttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preceipttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4804,7 +4804,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4815,7 +4815,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Sender() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxsender = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxsender, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4826,7 +4826,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Recipient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxrecipient = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxrecipient, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4837,7 +4837,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcurrentpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcurrentpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4848,7 +4848,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4859,7 +4859,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4870,7 +4870,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedStatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextendedstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextendedstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4881,7 +4881,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrextendedstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrextendedstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4892,7 +4892,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableOperations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pavailableoperations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pavailableoperations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4903,7 +4903,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.Retries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4914,7 +4914,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.ScheduledTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatescheduledtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatescheduledtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4925,7 +4925,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4936,7 +4936,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4947,7 +4947,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.CSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4958,7 +4958,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4969,7 +4969,7 @@ impl IFaxOutgoingJob_Vtbl {
             let this = (*this).get_impl();
             match this.GroupBroadcastReceipts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbgroupbroadcastreceipts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbgroupbroadcastreceipts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5060,7 +5060,7 @@ impl IFaxOutgoingJob2_Vtbl {
             let this = (*this).get_impl();
             match this.HasCoverPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbhascoverpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbhascoverpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5071,7 +5071,7 @@ impl IFaxOutgoingJob2_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiptAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrreceiptaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrreceiptaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5082,7 +5082,7 @@ impl IFaxOutgoingJob2_Vtbl {
             let this = (*this).get_impl();
             match this.ScheduleType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pscheduletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pscheduletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5115,7 +5115,7 @@ impl IFaxOutgoingJobs_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5126,7 +5126,7 @@ impl IFaxOutgoingJobs_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&vindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5137,7 +5137,7 @@ impl IFaxOutgoingJobs_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5186,7 +5186,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SubmissionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubmissionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubmissionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5197,7 +5197,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5208,7 +5208,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Subject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5219,7 +5219,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdocumentname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdocumentname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5230,7 +5230,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Retries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5241,7 +5241,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Pages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5252,7 +5252,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5263,7 +5263,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.OriginalScheduledTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdateoriginalscheduledtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdateoriginalscheduledtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5274,7 +5274,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SubmissionTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatesubmissiontime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatesubmissiontime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5285,7 +5285,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5296,7 +5296,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Sender() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxsender = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxsender, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5307,7 +5307,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Recipient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxrecipient = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxrecipient, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5318,7 +5318,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5329,7 +5329,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5340,7 +5340,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetransmissionend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetransmissionend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5351,7 +5351,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.CSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5362,7 +5362,7 @@ impl IFaxOutgoingMessage_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5425,7 +5425,7 @@ impl IFaxOutgoingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.HasCoverPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbhascoverpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbhascoverpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5436,7 +5436,7 @@ impl IFaxOutgoingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiptType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preceipttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preceipttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5447,7 +5447,7 @@ impl IFaxOutgoingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiptAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrreceiptaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrreceiptaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5458,7 +5458,7 @@ impl IFaxOutgoingMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Read() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5513,7 +5513,7 @@ impl IFaxOutgoingMessageIterator_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5524,7 +5524,7 @@ impl IFaxOutgoingMessageIterator_Vtbl {
             let this = (*this).get_impl();
             match this.AtEOF() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbeof = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbeof, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5535,7 +5535,7 @@ impl IFaxOutgoingMessageIterator_Vtbl {
             let this = (*this).get_impl();
             match this.PrefetchSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprefetchsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprefetchsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5607,7 +5607,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Blocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbblocked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbblocked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5623,7 +5623,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Paused() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbpaused = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbpaused, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5639,7 +5639,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.AllowPersonalCoverPages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pballowpersonalcoverpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pballowpersonalcoverpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5655,7 +5655,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.UseDeviceTSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbusedevicetsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbusedevicetsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5671,7 +5671,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Retries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5687,7 +5687,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.RetryDelay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretrydelay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretrydelay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5703,7 +5703,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.DiscountRateStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatediscountratestart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatediscountratestart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5719,7 +5719,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.DiscountRateEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatediscountrateend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatediscountrateend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5735,7 +5735,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.AgeLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plagelimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plagelimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5751,7 +5751,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Branding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbbranding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbbranding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5777,7 +5777,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJobs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingjobs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingjobs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5788,7 +5788,7 @@ impl IFaxOutgoingQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetJob(::core::mem::transmute(&bstrjobid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxoutgoingjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxoutgoingjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5857,7 +5857,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5873,7 +5873,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.SMTPServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsmtpserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsmtpserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5889,7 +5889,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.SMTPPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsmtpport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsmtpport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5905,7 +5905,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.SMTPSender() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsmtpsender = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsmtpsender, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5921,7 +5921,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.SMTPUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsmtpuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsmtpuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5937,7 +5937,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.AllowedReceipts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pallowedreceipts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pallowedreceipts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5953,7 +5953,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.SMTPPassword() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsmtppassword = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsmtppassword, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5979,7 +5979,7 @@ impl IFaxReceiptOptions_Vtbl {
             let this = (*this).get_impl();
             match this.UseForInboundRouting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbuseforinboundrouting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbuseforinboundrouting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6033,7 +6033,7 @@ impl IFaxRecipient_Vtbl {
             let this = (*this).get_impl();
             match this.FaxNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfaxnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfaxnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6049,7 +6049,7 @@ impl IFaxRecipient_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6090,7 +6090,7 @@ impl IFaxRecipients_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6101,7 +6101,7 @@ impl IFaxRecipients_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxrecipient = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxrecipient, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6112,7 +6112,7 @@ impl IFaxRecipients_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6123,7 +6123,7 @@ impl IFaxRecipients_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&bstrfaxnumber), ::core::mem::transmute(&bstrrecipientname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxrecipient = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxrecipient, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6167,7 +6167,7 @@ impl IFaxSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.Descriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6183,7 +6183,7 @@ impl IFaxSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.GrantedRights() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgrantedrights = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgrantedrights, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6204,7 +6204,7 @@ impl IFaxSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.InformationType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plinformationtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plinformationtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6250,7 +6250,7 @@ impl IFaxSecurity2_Vtbl {
             let this = (*this).get_impl();
             match this.Descriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6266,7 +6266,7 @@ impl IFaxSecurity2_Vtbl {
             let this = (*this).get_impl();
             match this.GrantedRights() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgrantedrights = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgrantedrights, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6287,7 +6287,7 @@ impl IFaxSecurity2_Vtbl {
             let this = (*this).get_impl();
             match this.InformationType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plinformationtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plinformationtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6360,7 +6360,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.BillingCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbillingcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbillingcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6376,7 +6376,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.City() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6392,7 +6392,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.Company() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcompany = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcompany, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6408,7 +6408,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.Country() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcountry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcountry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6424,7 +6424,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.Department() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdepartment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdepartment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6440,7 +6440,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.Email() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstremail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstremail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6456,7 +6456,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.FaxNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfaxnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfaxnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6472,7 +6472,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.HomePhone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrhomephone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrhomephone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6488,7 +6488,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6504,7 +6504,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6520,7 +6520,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.OfficePhone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrofficephone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrofficephone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6536,7 +6536,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.OfficeLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrofficelocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrofficelocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6552,7 +6552,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6568,7 +6568,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.StreetAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstreetaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstreetaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6584,7 +6584,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6600,7 +6600,7 @@ impl IFaxSender_Vtbl {
             let this = (*this).get_impl();
             match this.ZipCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrzipcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrzipcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6707,7 +6707,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.ServerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrservername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrservername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6718,7 +6718,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxdeviceproviders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxdeviceproviders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6729,7 +6729,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxdevices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxdevices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6740,7 +6740,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.InboundRouting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxinboundrouting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxinboundrouting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6751,7 +6751,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.Folders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaxfolders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaxfolders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6762,7 +6762,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.LoggingOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxloggingoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxloggingoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6773,7 +6773,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.MajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6784,7 +6784,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.MinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6795,7 +6795,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.MajorBuild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorbuild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorbuild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6806,7 +6806,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.MinorBuild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorbuild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorbuild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6817,7 +6817,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.Debug() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdebug = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdebug, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6828,7 +6828,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.Activity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxactivity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxactivity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6839,7 +6839,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.OutboundRouting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxoutboundrouting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxoutboundrouting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6850,7 +6850,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiptOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxreceiptoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxreceiptoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6861,7 +6861,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.Security() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6877,7 +6877,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionProperty(::core::mem::transmute(&bstrguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6918,7 +6918,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.RegisteredEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventtypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventtypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6929,7 +6929,7 @@ impl IFaxServer_Vtbl {
             let this = (*this).get_impl();
             match this.APIVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *papiversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(papiversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6986,7 +6986,7 @@ impl IFaxServer2_Vtbl {
             let this = (*this).get_impl();
             match this.Configuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxconfiguration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxconfiguration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6997,7 +6997,7 @@ impl IFaxServer2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAccount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcurrentaccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcurrentaccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7008,7 +7008,7 @@ impl IFaxServer2_Vtbl {
             let this = (*this).get_impl();
             match this.FaxAccountSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxaccountset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxaccountset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7019,7 +7019,7 @@ impl IFaxServer2_Vtbl {
             let this = (*this).get_impl();
             match this.Security2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfaxsecurity2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfaxsecurity2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7123,7 +7123,7 @@ impl IStiDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlastdeviceerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlastdeviceerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7169,7 +7169,7 @@ impl IStiDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastNotificationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpnotify = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpnotify, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7185,7 +7185,7 @@ impl IStiDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastErrorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plasterrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plasterrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7343,7 +7343,7 @@ impl IStiUSD_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7374,7 +7374,7 @@ impl IStiUSD_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlastdeviceerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlastdeviceerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7420,7 +7420,7 @@ impl IStiUSD_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotificationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpnotify = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpnotify, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7431,7 +7431,7 @@ impl IStiUSD_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastErrorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plasterrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plasterrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7539,7 +7539,7 @@ impl IStillImageW_Vtbl {
             let this = (*this).get_impl();
             match this.GetHwNotificationState(::core::mem::transmute(&pwszdevicename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbcurrentstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbcurrentstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
@@ -17,7 +17,7 @@ impl IFunctionDiscovery_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceCollection(::core::mem::transmute(&pszcategory), ::core::mem::transmute(&pszsubcategory), ::core::mem::transmute_copy(&fincludeallsubcategories)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstancecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstancecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28,7 +28,7 @@ impl IFunctionDiscovery_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstance(::core::mem::transmute(&pszfunctioninstanceidentity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -49,7 +49,7 @@ impl IFunctionDiscovery_Vtbl {
             let this = (*this).get_impl();
             match this.AddInstance(::core::mem::transmute_copy(&enumsystemvisibility), ::core::mem::transmute(&pszcategory), ::core::mem::transmute(&pszsubcategory), ::core::mem::transmute(&pszcategoryidentity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -132,7 +132,7 @@ impl IFunctionDiscoveryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Initialize(::core::mem::transmute(&pifunctiondiscoveryproviderfactory), ::core::mem::transmute(&pifunctiondiscoverynotification), ::core::mem::transmute_copy(&lciduserdefault)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstgaccesscapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstgaccesscapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -143,7 +143,7 @@ impl IFunctionDiscoveryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Query(::core::mem::transmute(&pifunctiondiscoveryproviderquery)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstancecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstancecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -164,7 +164,7 @@ impl IFunctionDiscoveryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.InstancePropertyStoreOpen(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&iproviderinstancecontext), ::core::mem::transmute_copy(&dwstgaccess)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -180,7 +180,7 @@ impl IFunctionDiscoveryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.InstanceQueryService(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&iproviderinstancecontext), ::core::mem::transmute_copy(&guidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -223,7 +223,7 @@ impl IFunctionDiscoveryProviderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyStore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl IFunctionDiscoveryProviderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute(&pszsubcategory), ::core::mem::transmute(&pszproviderinstanceidentity), ::core::mem::transmute_copy(&iproviderinstancecontext), ::core::mem::transmute(&pipropertystore), ::core::mem::transmute(&pifunctiondiscoveryprovider)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl IFunctionDiscoveryProviderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFunctionInstanceCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstancecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstancecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -289,7 +289,7 @@ impl IFunctionDiscoveryProviderQuery_Vtbl {
             let this = (*this).get_impl();
             match this.GetQueryConstraints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiproviderqueryconstraints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiproviderqueryconstraints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -300,7 +300,7 @@ impl IFunctionDiscoveryProviderQuery_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyConstraints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiproviderpropertyconstraints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiproviderpropertyconstraints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -355,7 +355,7 @@ impl IFunctionInstance_Vtbl {
             let this = (*this).get_impl();
             match this.GetID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomemidentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomemidentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -366,7 +366,7 @@ impl IFunctionInstance_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderInstanceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomemproviderinstanceidentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomemproviderinstanceidentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -377,7 +377,7 @@ impl IFunctionInstance_Vtbl {
             let this = (*this).get_impl();
             match this.OpenPropertyStore(::core::mem::transmute_copy(&dwstgaccess)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -420,7 +420,7 @@ impl IFunctionInstanceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -436,7 +436,7 @@ impl IFunctionInstanceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -452,7 +452,7 @@ impl IFunctionInstanceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Remove(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -509,7 +509,7 @@ impl IFunctionInstanceCollectionQuery_Vtbl {
             let this = (*this).get_impl();
             match this.Execute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstancecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstancecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IFunctionInstanceQuery_Vtbl {
             let this = (*this).get_impl();
             match this.Execute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -640,7 +640,7 @@ impl IPropertyStoreCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -656,7 +656,7 @@ impl IPropertyStoreCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -672,7 +672,7 @@ impl IPropertyStoreCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Remove(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pipropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pipropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -720,7 +720,7 @@ impl IProviderProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&iproviderinstancecontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -731,7 +731,7 @@ impl IProviderProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&iproviderinstancecontext), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -742,7 +742,7 @@ impl IProviderProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&iproviderinstancecontext), ::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -784,7 +784,7 @@ impl IProviderPropertyConstraintCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -844,7 +844,7 @@ impl IProviderPublishing_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute_copy(&enumvisibilityflags), ::core::mem::transmute(&pszsubcategory), ::core::mem::transmute(&pszproviderinstanceidentity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifunctioninstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -881,7 +881,7 @@ impl IProviderQueryConstraintCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -892,7 +892,7 @@ impl IProviderQueryConstraintCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Get(::core::mem::transmute(&pszconstraintname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszconstraintvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszconstraintvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
@@ -18,7 +18,7 @@ impl ICivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetAddressLine1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstraddress1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstraddress1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29,7 +29,7 @@ impl ICivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetAddressLine2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstraddress2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstraddress2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40,7 +40,7 @@ impl ICivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetCity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -51,7 +51,7 @@ impl ICivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetStateProvince() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstateprovince = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstateprovince, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -62,7 +62,7 @@ impl ICivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetPostalCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpostalcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpostalcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -73,7 +73,7 @@ impl ICivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountryRegion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcountryregion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcountryregion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -84,7 +84,7 @@ impl ICivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdetaillevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdetaillevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -119,7 +119,7 @@ impl ICivicAddressReportFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CivicAddressReport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -148,7 +148,7 @@ impl IDefaultLocation_Vtbl {
             let this = (*this).get_impl();
             match this.GetReport(::core::mem::transmute_copy(&reporttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplocationreport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplocationreport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -185,7 +185,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.AddressLine1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paddress1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paddress1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -196,7 +196,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.AddressLine2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paddress2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paddress2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -207,7 +207,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.City() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -218,7 +218,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.StateProvince() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstateprovince = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstateprovince, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -229,7 +229,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.PostalCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppostalcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppostalcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -240,7 +240,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.CountryRegion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcountryregion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcountryregion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -251,7 +251,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.DetailLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdetaillevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdetaillevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -262,7 +262,7 @@ impl IDispCivicAddressReport_Vtbl {
             let this = (*this).get_impl();
             match this.Timestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -303,7 +303,7 @@ impl IDispLatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.Latitude() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IDispLatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.Longitude() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -325,7 +325,7 @@ impl IDispLatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorRadius() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -336,7 +336,7 @@ impl IDispLatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.Altitude() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -347,7 +347,7 @@ impl IDispLatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.AltitudeError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl IDispLatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.Timestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -396,7 +396,7 @@ impl ILatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatitude() {
                 ::core::result::Result::Ok(ok__) => {
-                    *platitude = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(platitude, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -407,7 +407,7 @@ impl ILatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetLongitude() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plongitude = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plongitude, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -418,7 +418,7 @@ impl ILatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorRadius() {
                 ::core::result::Result::Ok(ok__) => {
-                    *perrorradius = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(perrorradius, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl ILatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetAltitude() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paltitude = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paltitude, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl ILatLongReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetAltitudeError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paltitudeerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paltitudeerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -473,7 +473,7 @@ impl ILatLongReportFactory_Vtbl {
             let this = (*this).get_impl();
             match this.LatLongReport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -517,7 +517,7 @@ impl ILocation_Vtbl {
             let this = (*this).get_impl();
             match this.GetReport(::core::mem::transmute_copy(&reporttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplocationreport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplocationreport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -528,7 +528,7 @@ impl ILocation_Vtbl {
             let this = (*this).get_impl();
             match this.GetReportStatus(::core::mem::transmute_copy(&reporttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -539,7 +539,7 @@ impl ILocation_Vtbl {
             let this = (*this).get_impl();
             match this.GetReportInterval(::core::mem::transmute_copy(&reporttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmilliseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmilliseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -555,7 +555,7 @@ impl ILocation_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesiredAccuracy(::core::mem::transmute_copy(&reporttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesiredaccuracy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesiredaccuracy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl ILocationReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psensorid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psensorid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl ILocationReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcreationtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcreationtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl ILocationReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&pkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -728,7 +728,7 @@ impl ILocationReportFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -739,7 +739,7 @@ impl ILocationReportFactory_Vtbl {
             let this = (*this).get_impl();
             match this.ReportInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmilliseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmilliseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -755,7 +755,7 @@ impl ILocationReportFactory_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredAccuracy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesiredaccuracy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesiredaccuracy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
@@ -31,7 +31,7 @@ impl IEnumWIA_DEV_CAPS_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IEnumWIA_DEV_CAPS_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcelt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcelt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -91,7 +91,7 @@ impl IEnumWIA_DEV_INFO_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -102,7 +102,7 @@ impl IEnumWIA_DEV_INFO_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *celt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(celt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -151,7 +151,7 @@ impl IEnumWIA_FORMAT_INFO_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -162,7 +162,7 @@ impl IEnumWIA_FORMAT_INFO_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcelt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcelt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -211,7 +211,7 @@ impl IEnumWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -222,7 +222,7 @@ impl IEnumWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *celt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(celt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -271,7 +271,7 @@ impl IEnumWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -282,7 +282,7 @@ impl IEnumWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *celt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(celt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IWiaAppErrorHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -387,7 +387,7 @@ impl IWiaDataTransfer_Vtbl {
             let this = (*this).get_impl();
             match this.idtEnumWIA_FORMAT_INFO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -398,7 +398,7 @@ impl IWiaDataTransfer_Vtbl {
             let this = (*this).get_impl();
             match this.idtGetExtendedTransferInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextendedtransferinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextendedtransferinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -439,7 +439,7 @@ impl IWiaDevMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDeviceInfo(::core::mem::transmute_copy(&lflag)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -450,7 +450,7 @@ impl IWiaDevMgr_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice(::core::mem::transmute(&bstrdeviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwiaitemroot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwiaitemroot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -481,7 +481,7 @@ impl IWiaDevMgr_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterEventCallbackInterface(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstrdeviceid), ::core::mem::transmute_copy(&peventguid), ::core::mem::transmute(&piwiaeventcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -535,7 +535,7 @@ impl IWiaDevMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDeviceInfo(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -546,7 +546,7 @@ impl IWiaDevMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstrdeviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwiaitem2root = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwiaitem2root, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -567,7 +567,7 @@ impl IWiaDevMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterEventCallbackInterface(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstrdeviceid), ::core::mem::transmute_copy(&peventguid), ::core::mem::transmute(&piwiaeventcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -630,7 +630,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0000 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0000, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -641,7 +641,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceSpecContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0001 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0001, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -652,7 +652,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullItemName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0002 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0002, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -663,7 +663,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0003 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0003, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -689,7 +689,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemByName(::core::mem::transmute_copy(&__midl__iwiadrvitem0007), ::core::mem::transmute(&__midl__iwiadrvitem0008)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0009 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0009, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -700,7 +700,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.FindChildItemByName(::core::mem::transmute(&__midl__iwiadrvitem0010)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0011 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0011, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -711,7 +711,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0012 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0012, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -722,7 +722,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstChildItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0013 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0013, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -733,7 +733,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextSiblingItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0014 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0014, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -744,7 +744,7 @@ impl IWiaDrvItem_Vtbl {
             let this = (*this).get_impl();
             match this.DumpItemData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiadrvitem0015 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiadrvitem0015, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -791,7 +791,7 @@ impl IWiaErrorHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatusDescription(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pwiaitem2), ::core::mem::transmute_copy(&hrstatus)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -899,7 +899,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitemtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitemtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -915,7 +915,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.EnumChildItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumwiaitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumwiaitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -931,7 +931,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.CreateChildItem(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstritemname), ::core::mem::transmute(&bstrfullitemname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiaitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiaitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -942,7 +942,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRegisterEventInfo(::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&peventguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -953,7 +953,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemByName(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstrfullitemname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiaitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiaitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -974,7 +974,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiaitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiaitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -985,7 +985,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDeviceCapabilities(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumwia_dev_caps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumwia_dev_caps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -996,7 +996,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.DumpItemData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1007,7 +1007,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.DumpDrvItemData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1018,7 +1018,7 @@ impl IWiaItem_Vtbl {
             let this = (*this).get_impl();
             match this.DumpTreeItemData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1081,7 +1081,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateChildItem(::core::mem::transmute_copy(&litemflags), ::core::mem::transmute_copy(&lcreationflags), ::core::mem::transmute(&bstritemname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiaitem2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiaitem2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1097,7 +1097,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumChildItems(::core::mem::transmute_copy(&pcategoryguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumwiaitem2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumwiaitem2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1108,7 +1108,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemByName(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstrfullitemname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiaitem2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiaitem2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1119,7 +1119,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitemcategoryguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitemcategoryguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1130,7 +1130,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitemtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitemtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1151,7 +1151,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDeviceCapabilities(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumwia_dev_caps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumwia_dev_caps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1172,7 +1172,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiaitem2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiaitem2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1183,7 +1183,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiaitem2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiaitem2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1194,7 +1194,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviewComponent(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwiapreview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwiapreview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1205,7 +1205,7 @@ impl IWiaItem2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRegisterEventInfo(::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&peventguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1256,7 +1256,7 @@ impl IWiaItemExtras_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtendedErrorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrerrortext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrerrortext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1412,7 +1412,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvInitItemProperties(::core::mem::transmute_copy(&__midl__iwiaminidrv0013), ::core::mem::transmute_copy(&__midl__iwiaminidrv0014)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0015 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0015, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1423,7 +1423,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvValidateItemProperties(::core::mem::transmute_copy(&__midl__iwiaminidrv0016), ::core::mem::transmute_copy(&__midl__iwiaminidrv0017), ::core::mem::transmute_copy(&__midl__iwiaminidrv0018), ::core::mem::transmute_copy(&__midl__iwiaminidrv0019)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0020 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0020, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1434,7 +1434,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvWriteItemProperties(::core::mem::transmute_copy(&__midl__iwiaminidrv0021), ::core::mem::transmute_copy(&__midl__iwiaminidrv0022), ::core::mem::transmute_copy(&__midl__iwiaminidrv0023)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0024 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0024, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1445,7 +1445,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvReadItemProperties(::core::mem::transmute_copy(&__midl__iwiaminidrv0025), ::core::mem::transmute_copy(&__midl__iwiaminidrv0026), ::core::mem::transmute_copy(&__midl__iwiaminidrv0027), ::core::mem::transmute_copy(&__midl__iwiaminidrv0028)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0029 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0029, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1456,7 +1456,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvLockWiaDevice(::core::mem::transmute_copy(&__midl__iwiaminidrv0030), ::core::mem::transmute_copy(&__midl__iwiaminidrv0031)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0032 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0032, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1467,7 +1467,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvUnLockWiaDevice(::core::mem::transmute_copy(&__midl__iwiaminidrv0033), ::core::mem::transmute_copy(&__midl__iwiaminidrv0034)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0035 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0035, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1498,7 +1498,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvDeleteItem(::core::mem::transmute_copy(&__midl__iwiaminidrv0053), ::core::mem::transmute_copy(&__midl__iwiaminidrv0054)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0055 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0055, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1509,7 +1509,7 @@ impl IWiaMiniDrv_Vtbl {
             let this = (*this).get_impl();
             match this.drvFreeDrvItemContext(::core::mem::transmute_copy(&__midl__iwiaminidrv0056), ::core::mem::transmute_copy(&__midl__iwiaminidrv0057)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__iwiaminidrv0058 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__iwiaminidrv0058, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1590,7 +1590,7 @@ impl IWiaMiniDrvTransferCallback_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextStream(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstritemname), ::core::mem::transmute(&bstrfullitemname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1738,7 +1738,7 @@ impl IWiaPropertyStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Enum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1759,7 +1759,7 @@ impl IWiaPropertyStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Stat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatpsstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatpsstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1775,7 +1775,7 @@ impl IWiaPropertyStorage_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulnumprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulnumprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1867,7 +1867,7 @@ impl IWiaTransfer_Vtbl {
             let this = (*this).get_impl();
             match this.EnumWIA_FORMAT_INFO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1905,7 +1905,7 @@ impl IWiaTransferCallback_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextStream(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstritemname), ::core::mem::transmute(&bstrfullitemname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2014,7 +2014,7 @@ impl IWiaVideo_Vtbl {
             let this = (*this).get_impl();
             match this.PreviewVisible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbpreviewvisible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbpreviewvisible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2030,7 +2030,7 @@ impl IWiaVideo_Vtbl {
             let this = (*this).get_impl();
             match this.ImagesDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrimagedirectory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrimagedirectory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2076,7 +2076,7 @@ impl IWiaVideo_Vtbl {
             let this = (*this).get_impl();
             match this.TakePicture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnewimagefilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnewimagefilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2092,7 +2092,7 @@ impl IWiaVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
@@ -44,7 +44,7 @@ impl IEnumPortableDeviceConnectors_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -92,7 +92,7 @@ impl IEnumPortableDeviceObjectIDs_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -128,7 +128,7 @@ impl IMediaRadioManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadioInstances() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -210,7 +210,7 @@ impl IPortableDevice_Vtbl {
             let this = (*this).get_impl();
             match this.SendCommand(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -221,7 +221,7 @@ impl IPortableDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Content() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -232,7 +232,7 @@ impl IPortableDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Capabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -253,7 +253,7 @@ impl IPortableDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pcallback), ::core::mem::transmute(&pparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -269,7 +269,7 @@ impl IPortableDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetPnPDeviceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpnpdeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpnpdeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedCommands() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcommands = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcommands, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -327,7 +327,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetCommandOptions(::core::mem::transmute_copy(&command)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -338,7 +338,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionalCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcategories = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcategories, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -349,7 +349,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionalObjects(::core::mem::transmute_copy(&category)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjectids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjectids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -360,7 +360,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedContentTypes(::core::mem::transmute_copy(&category)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontenttypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontenttypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -371,7 +371,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedFormats(::core::mem::transmute_copy(&contenttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -382,7 +382,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedFormatProperties(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -393,7 +393,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFixedPropertyAttributes(::core::mem::transmute_copy(&format), ::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -409,7 +409,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppevents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppevents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -420,7 +420,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventOptions(::core::mem::transmute_copy(&event)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -489,7 +489,7 @@ impl IPortableDeviceConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetPnPID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszpnpid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszpnpid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -532,7 +532,7 @@ impl IPortableDeviceContent_Vtbl {
             let this = (*this).get_impl();
             match this.EnumObjects(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pszparentobjectid), ::core::mem::transmute(&pfilter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -543,7 +543,7 @@ impl IPortableDeviceContent_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -554,7 +554,7 @@ impl IPortableDeviceContent_Vtbl {
             let this = (*this).get_impl();
             match this.Transfer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -580,7 +580,7 @@ impl IPortableDeviceContent_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectIDsFromPersistentUniqueIDs(::core::mem::transmute(&ppersistentuniqueids)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjectids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjectids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -657,7 +657,7 @@ impl IPortableDeviceDataStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszobjectid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszobjectid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -692,7 +692,7 @@ impl IPortableDeviceDispatchFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceDispatch(::core::mem::transmute(&pszpnpdeviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevicedispatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevicedispatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -869,7 +869,7 @@ impl IPortableDevicePropVariantCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -924,7 +924,7 @@ impl IPortableDeviceProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedProperties(::core::mem::transmute(&pszobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -935,7 +935,7 @@ impl IPortableDeviceProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyAttributes(::core::mem::transmute(&pszobjectid), ::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -946,7 +946,7 @@ impl IPortableDeviceProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetValues(::core::mem::transmute(&pszobjectid), ::core::mem::transmute(&pkeys)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -957,7 +957,7 @@ impl IPortableDeviceProperties_Vtbl {
             let this = (*this).get_impl();
             match this.SetValues(::core::mem::transmute(&pszobjectid), ::core::mem::transmute(&pvalues)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1002,7 +1002,7 @@ impl IPortableDevicePropertiesBulk_Vtbl {
             let this = (*this).get_impl();
             match this.QueueGetValuesByObjectList(::core::mem::transmute(&pobjectids), ::core::mem::transmute(&pkeys), ::core::mem::transmute(&pcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1013,7 +1013,7 @@ impl IPortableDevicePropertiesBulk_Vtbl {
             let this = (*this).get_impl();
             match this.QueueGetValuesByObjectFormat(::core::mem::transmute_copy(&pguidobjectformat), ::core::mem::transmute(&pszparentobjectid), ::core::mem::transmute_copy(&dwdepth), ::core::mem::transmute(&pkeys), ::core::mem::transmute(&pcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1024,7 +1024,7 @@ impl IPortableDevicePropertiesBulk_Vtbl {
             let this = (*this).get_impl();
             match this.QueueSetValuesByObjectList(::core::mem::transmute(&pobjectvalues), ::core::mem::transmute(&pcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1106,7 +1106,7 @@ impl IPortableDeviceResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedResources(::core::mem::transmute(&pszobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1117,7 +1117,7 @@ impl IPortableDeviceResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceAttributes(::core::mem::transmute(&pszobjectid), ::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresourceattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresourceattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1183,7 +1183,7 @@ impl IPortableDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.Capabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1194,7 +1194,7 @@ impl IPortableDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.Content() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1205,7 +1205,7 @@ impl IPortableDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.Methods() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmethods = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmethods, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1226,7 +1226,7 @@ impl IPortableDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceObjectID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszserviceobjectid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszserviceobjectid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1237,7 +1237,7 @@ impl IPortableDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.GetPnPServiceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpnpserviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpnpserviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1248,7 +1248,7 @@ impl IPortableDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pcallback), ::core::mem::transmute(&pparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1264,7 +1264,7 @@ impl IPortableDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.SendCommand(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1345,7 +1345,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedMethods() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmethods = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmethods, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1356,7 +1356,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedMethodsByFormat(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmethods = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmethods, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1367,7 +1367,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetMethodAttributes(::core::mem::transmute_copy(&method)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1378,7 +1378,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetMethodParameterAttributes(::core::mem::transmute_copy(&method), ::core::mem::transmute_copy(&parameter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1389,7 +1389,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1400,7 +1400,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatAttributes(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1411,7 +1411,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedFormatProperties(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1422,7 +1422,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatPropertyAttributes(::core::mem::transmute_copy(&format), ::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1433,7 +1433,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppevents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppevents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1444,7 +1444,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventAttributes(::core::mem::transmute_copy(&event)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1455,7 +1455,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventParameterAttributes(::core::mem::transmute_copy(&event), ::core::mem::transmute_copy(&parameter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1466,7 +1466,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetInheritedServices(::core::mem::transmute_copy(&dwinheritancetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1477,7 +1477,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatRenderingProfiles(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprenderingprofiles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprenderingprofiles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1488,7 +1488,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedCommands() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcommands = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcommands, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1499,7 +1499,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetCommandOptions(::core::mem::transmute_copy(&command)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1551,7 +1551,7 @@ impl IPortableDeviceServiceManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceForService(::core::mem::transmute(&pszpnpserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpnpdeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpnpdeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1647,7 +1647,7 @@ impl IPortableDeviceUnitsStream_Vtbl {
             let this = (*this).get_impl();
             match this.SeekInUnits(::core::mem::transmute_copy(&dlibmove), ::core::mem::transmute_copy(&units), ::core::mem::transmute_copy(&dworigin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plibnewposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plibnewposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1736,7 +1736,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1752,7 +1752,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1768,7 +1768,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnsignedIntegerValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1784,7 +1784,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignedIntegerValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1800,7 +1800,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnsignedLargeIntegerValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1816,7 +1816,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignedLargeIntegerValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1832,7 +1832,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetFloatValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1848,7 +1848,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1864,7 +1864,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1880,7 +1880,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoolValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1896,7 +1896,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetIUnknownValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1912,7 +1912,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuidValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1938,7 +1938,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetIPortableDeviceValuesValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1954,7 +1954,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetIPortableDevicePropVariantCollectionValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1970,7 +1970,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetIPortableDeviceKeyCollectionValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1986,7 +1986,7 @@ impl IPortableDeviceValues_Vtbl {
             let this = (*this).get_impl();
             match this.GetIPortableDeviceValuesCollectionValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2080,7 +2080,7 @@ impl IPortableDeviceValuesCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2129,7 +2129,7 @@ impl IPortableDeviceWebControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceFromId(::core::mem::transmute(&deviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2170,7 +2170,7 @@ impl IRadioInstance_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadioManagerSignature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2181,7 +2181,7 @@ impl IRadioInstance_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceSignature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2192,7 +2192,7 @@ impl IRadioInstance_Vtbl {
             let this = (*this).get_impl();
             match this.GetFriendlyName(::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2203,7 +2203,7 @@ impl IRadioInstance_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadioState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pradiostate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pradiostate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2251,7 +2251,7 @@ impl IRadioInstanceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2262,7 +2262,7 @@ impl IRadioInstanceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppradioinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppradioinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2292,7 +2292,7 @@ impl IWpdSerializer_Vtbl {
             let this = (*this).get_impl();
             match this.GetIPortableDeviceValuesFromBuffer(::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&dwinputbufferlength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2313,7 +2313,7 @@ impl IWpdSerializer_Vtbl {
             let this = (*this).get_impl();
             match this.GetSerializedSize(::core::mem::transmute(&psource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
@@ -13,7 +13,7 @@ impl ILocationPermissions_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlobalLocationPermission() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -62,7 +62,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -73,7 +73,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psensorcategory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psensorcategory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -84,7 +84,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psensortype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psensortype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -95,7 +95,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -106,7 +106,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -117,7 +117,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties(::core::mem::transmute(&pkeys)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -128,7 +128,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedDataFields() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdatafields = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdatafields, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -139,7 +139,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.SetProperties(::core::mem::transmute(&pproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -150,7 +150,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.SupportsDataField(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pissupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pissupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -161,7 +161,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -172,7 +172,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdatareport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdatareport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -183,7 +183,7 @@ impl ISensor_Vtbl {
             let this = (*this).get_impl();
             match this.SupportsEvent(::core::mem::transmute_copy(&eventguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pissupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pissupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -243,7 +243,7 @@ impl ISensorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsensor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsensor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -254,7 +254,7 @@ impl ISensorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -310,7 +310,7 @@ impl ISensorDataReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimestamp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimestamp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -321,7 +321,7 @@ impl ISensorDataReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorValue(::core::mem::transmute_copy(&pkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -332,7 +332,7 @@ impl ISensorDataReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorValues(::core::mem::transmute(&pkeys)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -411,7 +411,7 @@ impl ISensorManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorsByCategory(::core::mem::transmute_copy(&sensorcategory)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsensorsfound = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsensorsfound, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -422,7 +422,7 @@ impl ISensorManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorsByType(::core::mem::transmute_copy(&sensortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsensorsfound = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsensorsfound, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -433,7 +433,7 @@ impl ISensorManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorByID(::core::mem::transmute_copy(&sensorid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsensor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsensor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
@@ -30,7 +30,7 @@ impl IEnumACDGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -80,7 +80,7 @@ impl IEnumAddress_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -130,7 +130,7 @@ impl IEnumAgent_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -180,7 +180,7 @@ impl IEnumAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -230,7 +230,7 @@ impl IEnumAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -280,7 +280,7 @@ impl IEnumBstr_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IEnumCall_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -380,7 +380,7 @@ impl IEnumCallHub_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -430,7 +430,7 @@ impl IEnumCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -480,7 +480,7 @@ impl IEnumDialableAddrs_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -530,7 +530,7 @@ impl IEnumDirectory_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -580,7 +580,7 @@ impl IEnumDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -630,7 +630,7 @@ impl IEnumLocation_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl IEnumMcastScope_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -730,7 +730,7 @@ impl IEnumPhone_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -780,7 +780,7 @@ impl IEnumPluggableSuperclassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -830,7 +830,7 @@ impl IEnumPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -880,7 +880,7 @@ impl IEnumQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -930,7 +930,7 @@ impl IEnumStream_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -980,7 +980,7 @@ impl IEnumSubStream_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1030,7 +1030,7 @@ impl IEnumTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1077,7 +1077,7 @@ impl IEnumTerminalClass_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1115,7 +1115,7 @@ impl IMcastAddressAllocation_Vtbl {
             let this = (*this).get_impl();
             match this.Scopes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1126,7 +1126,7 @@ impl IMcastAddressAllocation_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateScopes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenummcastscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenummcastscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1137,7 +1137,7 @@ impl IMcastAddressAllocation_Vtbl {
             let this = (*this).get_impl();
             match this.RequestAddress(::core::mem::transmute(&pscope), ::core::mem::transmute_copy(&leasestarttime), ::core::mem::transmute_copy(&leasestoptime), ::core::mem::transmute_copy(&numaddresses)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppleaseresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppleaseresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1148,7 +1148,7 @@ impl IMcastAddressAllocation_Vtbl {
             let this = (*this).get_impl();
             match this.RenewAddress(::core::mem::transmute_copy(&lreserved), ::core::mem::transmute(&prenewrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprenewresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprenewresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1164,7 +1164,7 @@ impl IMcastAddressAllocation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLeaseInfo(::core::mem::transmute_copy(&leasestarttime), ::core::mem::transmute_copy(&leasestoptime), ::core::mem::transmute_copy(&dwnumaddresses), ::core::mem::transmute_copy(&ppaddresses), ::core::mem::transmute(&prequestid), ::core::mem::transmute(&pserveraddress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreleaserequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreleaserequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1175,7 +1175,7 @@ impl IMcastAddressAllocation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLeaseInfoFromVariant(::core::mem::transmute_copy(&leasestarttime), ::core::mem::transmute_copy(&leasestoptime), ::core::mem::transmute(&vaddresses), ::core::mem::transmute(&prequestid), ::core::mem::transmute(&pserveraddress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreleaserequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreleaserequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1219,7 +1219,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RequestID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1230,7 +1230,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LeaseStartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1246,7 +1246,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LeaseStopTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1262,7 +1262,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AddressCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1273,7 +1273,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ServerAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1284,7 +1284,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TTL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pttl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pttl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1295,7 +1295,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Addresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1306,7 +1306,7 @@ impl IMcastLeaseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumaddresses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumaddresses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1348,7 +1348,7 @@ impl IMcastScope_Vtbl {
             let this = (*this).get_impl();
             match this.ScopeID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1359,7 +1359,7 @@ impl IMcastScope_Vtbl {
             let this = (*this).get_impl();
             match this.ServerID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1370,7 +1370,7 @@ impl IMcastScope_Vtbl {
             let this = (*this).get_impl();
             match this.InterfaceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1381,7 +1381,7 @@ impl IMcastScope_Vtbl {
             let this = (*this).get_impl();
             match this.ScopeDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1392,7 +1392,7 @@ impl IMcastScope_Vtbl {
             let this = (*this).get_impl();
             match this.TTL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pttl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pttl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1427,7 +1427,7 @@ impl ITACDGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1438,7 +1438,7 @@ impl ITACDGroup_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateQueues() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1449,7 +1449,7 @@ impl ITACDGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Queues() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1481,7 +1481,7 @@ impl ITACDGroupEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Group() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1492,7 +1492,7 @@ impl ITACDGroupEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1523,7 +1523,7 @@ impl ITAMMediaFormat_Vtbl {
             let this = (*this).get_impl();
             match this.MediaFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1560,7 +1560,7 @@ impl ITASRTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Terminal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1571,7 +1571,7 @@ impl ITASRTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1582,7 +1582,7 @@ impl ITASRTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrerrorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrerrorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1627,7 +1627,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paddressstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paddressstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1638,7 +1638,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.AddressName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1649,7 +1649,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1660,7 +1660,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.TAPIObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptapiobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptapiobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1671,7 +1671,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCall(::core::mem::transmute(&pdestaddress), ::core::mem::transmute_copy(&laddresstype), ::core::mem::transmute_copy(&lmediatypes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1682,7 +1682,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.Calls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1693,7 +1693,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1704,7 +1704,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.DialableAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdialableaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdialableaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1715,7 +1715,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.CreateForwardInfoObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppforwardinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppforwardinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1731,7 +1731,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentForwardInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppforwardinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppforwardinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1747,7 +1747,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.MessageWaiting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmessagewaiting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmessagewaiting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1763,7 +1763,7 @@ impl ITAddress_Vtbl {
             let this = (*this).get_impl();
             match this.DoNotDisturb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdonotdisturb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdonotdisturb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1815,7 +1815,7 @@ impl ITAddress2_Vtbl {
             let this = (*this).get_impl();
             match this.Phones() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphones = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphones, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1826,7 +1826,7 @@ impl ITAddress2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePhones() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumphone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumphone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1837,7 +1837,7 @@ impl ITAddress2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPhoneFromTerminal(::core::mem::transmute(&pterminal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1848,7 +1848,7 @@ impl ITAddress2_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredPhones() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphones = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphones, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1859,7 +1859,7 @@ impl ITAddress2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePreferredPhones() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumphone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumphone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1870,7 +1870,7 @@ impl ITAddress2_Vtbl {
             let this = (*this).get_impl();
             match this.get_EventFilter(::core::mem::transmute_copy(&tapievent), ::core::mem::transmute_copy(&lsubevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1896,7 +1896,7 @@ impl ITAddress2_Vtbl {
             let this = (*this).get_impl();
             match this.NegotiateExtVersion(::core::mem::transmute_copy(&llowversion), ::core::mem::transmute_copy(&lhighversion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plextversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plextversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1941,7 +1941,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.get_AddressCapability(::core::mem::transmute_copy(&addresscap)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcapability = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcapability, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1952,7 +1952,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.get_AddressCapabilityString(::core::mem::transmute_copy(&addresscapstring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcapabilitystring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcapabilitystring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1963,7 +1963,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.CallTreatments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1974,7 +1974,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateCallTreatments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcalltreatment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcalltreatment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1985,7 +1985,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.CompletionMessages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1996,7 +1996,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateCompletionMessages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcompletionmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcompletionmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2007,7 +2007,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceClasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2018,7 +2018,7 @@ impl ITAddressCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateDeviceClasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdeviceclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdeviceclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2058,7 +2058,7 @@ impl ITAddressDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2069,7 +2069,7 @@ impl ITAddressDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2080,7 +2080,7 @@ impl ITAddressDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.lParam1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparam1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparam1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2091,7 +2091,7 @@ impl ITAddressDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.lParam2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparam2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparam2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2102,7 +2102,7 @@ impl ITAddressDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.lParam3() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparam3 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparam3, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2137,7 +2137,7 @@ impl ITAddressEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2148,7 +2148,7 @@ impl ITAddressEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2159,7 +2159,7 @@ impl ITAddressEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Terminal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2195,7 +2195,7 @@ impl ITAddressTranslation_Vtbl {
             let this = (*this).get_impl();
             match this.TranslateAddress(::core::mem::transmute(&paddresstotranslate), ::core::mem::transmute_copy(&lcard), ::core::mem::transmute_copy(&ltranslateoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptranslated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptranslated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2211,7 +2211,7 @@ impl ITAddressTranslation_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateLocations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumlocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumlocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2222,7 +2222,7 @@ impl ITAddressTranslation_Vtbl {
             let this = (*this).get_impl();
             match this.Locations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2233,7 +2233,7 @@ impl ITAddressTranslation_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateCallingCards() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcallingcard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcallingcard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2244,7 +2244,7 @@ impl ITAddressTranslation_Vtbl {
             let this = (*this).get_impl();
             match this.CallingCards() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2282,7 +2282,7 @@ impl ITAddressTranslationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DialableString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdialablestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdialablestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2293,7 +2293,7 @@ impl ITAddressTranslationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayableString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisplayablestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisplayablestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2304,7 +2304,7 @@ impl ITAddressTranslationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *countrycode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(countrycode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2315,7 +2315,7 @@ impl ITAddressTranslationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationCountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *countrycode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(countrycode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2326,7 +2326,7 @@ impl ITAddressTranslationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TranslationResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2375,7 +2375,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateAgentSessions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumagentsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumagentsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2386,7 +2386,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession(::core::mem::transmute(&pacdgroup), ::core::mem::transmute(&paddress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppagentsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppagentsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2397,7 +2397,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSessionWithPIN(::core::mem::transmute(&pacdgroup), ::core::mem::transmute(&paddress), ::core::mem::transmute(&ppin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppagentsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppagentsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2408,7 +2408,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2419,7 +2419,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2435,7 +2435,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagentstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagentstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2451,7 +2451,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.MeasurementPeriod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plperiod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plperiod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2462,7 +2462,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.OverallCallRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcycallrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcycallrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2473,7 +2473,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfACDCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2484,7 +2484,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfIncomingCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2495,7 +2495,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfOutgoingCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2506,7 +2506,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.TotalACDTalkTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltalktime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltalktime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2517,7 +2517,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.TotalACDCallTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2528,7 +2528,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.TotalWrapUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwrapuptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwrapuptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2539,7 +2539,7 @@ impl ITAgent_Vtbl {
             let this = (*this).get_impl();
             match this.AgentSessions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2585,7 +2585,7 @@ impl ITAgentEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Agent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppagent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppagent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2596,7 +2596,7 @@ impl ITAgentEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2632,7 +2632,7 @@ impl ITAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2643,7 +2643,7 @@ impl ITAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAgent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppagent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppagent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2654,7 +2654,7 @@ impl ITAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAgentWithID(::core::mem::transmute(&pid), ::core::mem::transmute(&ppin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppagent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppagent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2665,7 +2665,7 @@ impl ITAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateACDGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumacdgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumacdgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2676,7 +2676,7 @@ impl ITAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateUsableAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2687,7 +2687,7 @@ impl ITAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.ACDGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2698,7 +2698,7 @@ impl ITAgentHandler_Vtbl {
             let this = (*this).get_impl();
             match this.UsableAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2734,7 +2734,7 @@ impl ITAgentHandlerEvent_Vtbl {
             let this = (*this).get_impl();
             match this.AgentHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppagenthandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppagenthandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2745,7 +2745,7 @@ impl ITAgentHandlerEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2791,7 +2791,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.Agent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppagent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppagent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2802,7 +2802,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2813,7 +2813,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.ACDGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppacdgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppacdgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2829,7 +2829,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psessionstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psessionstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2840,7 +2840,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.SessionStartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatesessionstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatesessionstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2851,7 +2851,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.SessionDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2862,7 +2862,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2873,7 +2873,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.TotalTalkTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltalktime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltalktime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2884,7 +2884,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.AverageTalkTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltalktime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltalktime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2895,7 +2895,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.TotalCallTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2906,7 +2906,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.AverageCallTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2917,7 +2917,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.TotalWrapUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwrapuptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwrapuptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2928,7 +2928,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.AverageWrapUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwrapuptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwrapuptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2939,7 +2939,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.ACDCallRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcycallrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcycallrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2950,7 +2950,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.LongestTimeToAnswer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *planswertime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planswertime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2961,7 +2961,7 @@ impl ITAgentSession_Vtbl {
             let this = (*this).get_impl();
             match this.AverageTimeToAnswer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *planswertime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planswertime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3007,7 +3007,7 @@ impl ITAgentSessionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3018,7 +3018,7 @@ impl ITAgentSessionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3058,7 +3058,7 @@ impl ITAllocatorProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocatorProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pallocproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pallocproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3074,7 +3074,7 @@ impl ITAllocatorProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocateBuffers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pballocbuffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pballocbuffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3090,7 +3090,7 @@ impl ITAllocatorProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetBufferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbuffersize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbuffersize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3165,7 +3165,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.Tone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3186,7 +3186,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.Ringer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfringing = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfringing, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3202,7 +3202,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.PhoneHandlingEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3218,7 +3218,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoEndOfNumberTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltimeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltimeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3234,7 +3234,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoDialtone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3250,7 +3250,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoStopTonesOnOnHook() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3266,7 +3266,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoStopRingOnOffHook() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3282,7 +3282,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoKeypadTones() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3298,7 +3298,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoKeypadTonesMinimumDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3314,7 +3314,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoVolumeControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3330,7 +3330,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoVolumeControlStep() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstepsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstepsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3346,7 +3346,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoVolumeControlRepeatDelay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldelay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldelay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3362,7 +3362,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoVolumeControlRepeatPeriod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plperiod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plperiod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3383,7 +3383,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateSelectedCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3394,7 +3394,7 @@ impl ITAutomatedPhoneControl_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3462,7 +3462,7 @@ impl ITBasicAudioTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.Volume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3478,7 +3478,7 @@ impl ITBasicAudioTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.Balance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbalance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbalance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3582,7 +3582,7 @@ impl ITBasicCallControl_Vtbl {
             let this = (*this).get_impl();
             match this.ParkIndirect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnondiraddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnondiraddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3660,7 +3660,7 @@ impl ITBasicCallControl2_Vtbl {
             let this = (*this).get_impl();
             match this.RequestTerminal(::core::mem::transmute(&bstrterminalclassguid), ::core::mem::transmute_copy(&lmediatype), ::core::mem::transmute_copy(&direction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3710,7 +3710,7 @@ impl ITCallHub_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3721,7 +3721,7 @@ impl ITCallHub_Vtbl {
             let this = (*this).get_impl();
             match this.Calls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3732,7 +3732,7 @@ impl ITCallHub_Vtbl {
             let this = (*this).get_impl();
             match this.NumCalls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3743,7 +3743,7 @@ impl ITCallHub_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3778,7 +3778,7 @@ impl ITCallHubEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3789,7 +3789,7 @@ impl ITCallHubEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallHub() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallhub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallhub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3800,7 +3800,7 @@ impl ITCallHubEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3843,7 +3843,7 @@ impl ITCallInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3854,7 +3854,7 @@ impl ITCallInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CallState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcallstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcallstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3865,7 +3865,7 @@ impl ITCallInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Privilege() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprivilege = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprivilege, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3876,7 +3876,7 @@ impl ITCallInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CallHub() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallhub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallhub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3887,7 +3887,7 @@ impl ITCallInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_CallInfoLong(::core::mem::transmute_copy(&callinfolong)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallinfolongval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallinfolongval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3903,7 +3903,7 @@ impl ITCallInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_CallInfoString(::core::mem::transmute_copy(&callinfostring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfostring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfostring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3919,7 +3919,7 @@ impl ITCallInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_CallInfoBuffer(::core::mem::transmute_copy(&callinfobuffer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfobuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfobuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3981,7 +3981,7 @@ impl ITCallInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.get_EventFilter(::core::mem::transmute_copy(&tapievent), ::core::mem::transmute_copy(&lsubevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4018,7 +4018,7 @@ impl ITCallInfoChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4029,7 +4029,7 @@ impl ITCallInfoChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Cause() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4040,7 +4040,7 @@ impl ITCallInfoChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4076,7 +4076,7 @@ impl ITCallMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4087,7 +4087,7 @@ impl ITCallMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcallmediaevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcallmediaevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4098,7 +4098,7 @@ impl ITCallMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4109,7 +4109,7 @@ impl ITCallMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Terminal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4120,7 +4120,7 @@ impl ITCallMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Stream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4131,7 +4131,7 @@ impl ITCallMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Cause() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcause = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcause, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4167,7 +4167,7 @@ impl ITCallNotificationEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4178,7 +4178,7 @@ impl ITCallNotificationEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcallnotificationevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcallnotificationevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4189,7 +4189,7 @@ impl ITCallNotificationEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4223,7 +4223,7 @@ impl ITCallStateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4234,7 +4234,7 @@ impl ITCallStateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcallstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcallstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4245,7 +4245,7 @@ impl ITCallStateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Cause() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4256,7 +4256,7 @@ impl ITCallStateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4294,7 +4294,7 @@ impl ITCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.PermanentCardID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcardid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcardid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4305,7 +4305,7 @@ impl ITCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfDigits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldigits = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldigits, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4316,7 +4316,7 @@ impl ITCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.Options() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ploptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ploptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4327,7 +4327,7 @@ impl ITCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.CardName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcardname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcardname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4338,7 +4338,7 @@ impl ITCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.SameAreaDialingRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4349,7 +4349,7 @@ impl ITCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.LongDistanceDialingRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4360,7 +4360,7 @@ impl ITCallingCard_Vtbl {
             let this = (*this).get_impl();
             match this.InternationalDialingRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4397,7 +4397,7 @@ impl ITCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4408,7 +4408,7 @@ impl ITCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4419,7 +4419,7 @@ impl ITCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4483,7 +4483,7 @@ impl ITCustomTone_Vtbl {
             let this = (*this).get_impl();
             match this.Frequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfrequency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfrequency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4499,7 +4499,7 @@ impl ITCustomTone_Vtbl {
             let this = (*this).get_impl();
             match this.CadenceOn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcadenceon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcadenceon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4515,7 +4515,7 @@ impl ITCustomTone_Vtbl {
             let this = (*this).get_impl();
             match this.CadenceOff() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcadenceoff = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcadenceoff, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4531,7 +4531,7 @@ impl ITCustomTone_Vtbl {
             let this = (*this).get_impl();
             match this.Volume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4577,7 +4577,7 @@ impl ITDetectTone_Vtbl {
             let this = (*this).get_impl();
             match this.AppSpecific() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plappspecific = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plappspecific, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4593,7 +4593,7 @@ impl ITDetectTone_Vtbl {
             let this = (*this).get_impl();
             match this.Duration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4609,7 +4609,7 @@ impl ITDetectTone_Vtbl {
             let this = (*this).get_impl();
             match this.get_Frequency(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfrequency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfrequency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4652,7 +4652,7 @@ impl ITDigitDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4663,7 +4663,7 @@ impl ITDigitDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Digit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucdigit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucdigit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4674,7 +4674,7 @@ impl ITDigitDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.DigitMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdigitmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdigitmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4685,7 +4685,7 @@ impl ITDigitDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.TickCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltickcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltickcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4696,7 +4696,7 @@ impl ITDigitDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4732,7 +4732,7 @@ impl ITDigitGenerationEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4743,7 +4743,7 @@ impl ITDigitGenerationEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GenerationTermination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plgenerationtermination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plgenerationtermination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4754,7 +4754,7 @@ impl ITDigitGenerationEvent_Vtbl {
             let this = (*this).get_impl();
             match this.TickCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltickcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltickcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4765,7 +4765,7 @@ impl ITDigitGenerationEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4801,7 +4801,7 @@ impl ITDigitsGatheredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4812,7 +4812,7 @@ impl ITDigitsGatheredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Digits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdigits = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdigits, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4823,7 +4823,7 @@ impl ITDigitsGatheredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GatherTermination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgathertermination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgathertermination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4834,7 +4834,7 @@ impl ITDigitsGatheredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.TickCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltickcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltickcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4845,7 +4845,7 @@ impl ITDigitsGatheredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4891,7 +4891,7 @@ impl ITDirectory_Vtbl {
             let this = (*this).get_impl();
             match this.DirectoryType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdirectorytype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdirectorytype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4902,7 +4902,7 @@ impl ITDirectory_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4913,7 +4913,7 @@ impl ITDirectory_Vtbl {
             let this = (*this).get_impl();
             match this.IsDynamic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdynamic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdynamic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4924,7 +4924,7 @@ impl ITDirectory_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultObjectTTL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pttl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pttl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4975,7 +4975,7 @@ impl ITDirectory_Vtbl {
             let this = (*this).get_impl();
             match this.get_DirectoryObjects(::core::mem::transmute_copy(&directoryobjecttype), ::core::mem::transmute(&pname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4986,7 +4986,7 @@ impl ITDirectory_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateDirectoryObjects(::core::mem::transmute_copy(&directoryobjecttype), ::core::mem::transmute(&pname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5034,7 +5034,7 @@ impl ITDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pobjecttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pobjecttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5045,7 +5045,7 @@ impl ITDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5061,7 +5061,7 @@ impl ITDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.get_DialableAddrs(::core::mem::transmute_copy(&dwaddresstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5072,7 +5072,7 @@ impl ITDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateDialableAddrs(::core::mem::transmute_copy(&dwaddresstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdialableaddrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdialableaddrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5083,7 +5083,7 @@ impl ITDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.SecurityDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecdes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecdes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5137,7 +5137,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.Protocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprotocol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprotocol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5148,7 +5148,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.Originator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pporiginator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pporiginator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5164,7 +5164,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.AdvertisingScope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *padvertisingscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(padvertisingscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5180,7 +5180,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.Url() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5196,7 +5196,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5212,7 +5212,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.IsEncrypted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfencrypted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfencrypted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5228,7 +5228,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5244,7 +5244,7 @@ impl ITDirectoryObjectConference_Vtbl {
             let this = (*this).get_impl();
             match this.StopTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5293,7 +5293,7 @@ impl ITDirectoryObjectUser_Vtbl {
             let this = (*this).get_impl();
             match this.IPPhonePrimary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5328,7 +5328,7 @@ impl ITDispatchMapper_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDispatchInterface(::core::mem::transmute(&piid), ::core::mem::transmute(&pinterfacetomap)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreturnedinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreturnedinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5362,7 +5362,7 @@ impl ITFileTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Terminal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5373,7 +5373,7 @@ impl ITFileTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Track() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptrackterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptrackterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5384,7 +5384,7 @@ impl ITFileTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5395,7 +5395,7 @@ impl ITFileTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5406,7 +5406,7 @@ impl ITFileTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Cause() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcause = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcause, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5417,7 +5417,7 @@ impl ITFileTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrerrorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrerrorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5456,7 +5456,7 @@ impl ITFileTrack_Vtbl {
             let this = (*this).get_impl();
             match this.Format() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5472,7 +5472,7 @@ impl ITFileTrack_Vtbl {
             let this = (*this).get_impl();
             match this.ControllingTerminal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontrollingterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontrollingterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5483,7 +5483,7 @@ impl ITFileTrack_Vtbl {
             let this = (*this).get_impl();
             match this.AudioFormatForScripting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaudioformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaudioformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5499,7 +5499,7 @@ impl ITFileTrack_Vtbl {
             let this = (*this).get_impl();
             match this.EmptyAudioFormatForScripting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaudioformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaudioformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5544,7 +5544,7 @@ impl ITForwardInformation_Vtbl {
             let this = (*this).get_impl();
             match this.NumRingsNoAnswer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnumrings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnumrings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5560,7 +5560,7 @@ impl ITForwardInformation_Vtbl {
             let this = (*this).get_impl();
             match this.get_ForwardTypeDestination(::core::mem::transmute_copy(&forwardtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5571,7 +5571,7 @@ impl ITForwardInformation_Vtbl {
             let this = (*this).get_impl();
             match this.get_ForwardTypeCaller(::core::mem::transmute_copy(&forwardtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcalleraddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcalleraddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5629,7 +5629,7 @@ impl ITForwardInformation2_Vtbl {
             let this = (*this).get_impl();
             match this.get_ForwardTypeDestinationAddressType(::core::mem::transmute_copy(&forwardtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdestaddresstype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdestaddresstype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5640,7 +5640,7 @@ impl ITForwardInformation2_Vtbl {
             let this = (*this).get_impl();
             match this.get_ForwardTypeCallerAddressType(::core::mem::transmute_copy(&forwardtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcalleraddresstype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcalleraddresstype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5673,7 +5673,7 @@ impl ITILSConfig_Vtbl {
             let this = (*this).get_impl();
             match this.Port() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5870,7 +5870,7 @@ impl ITLegacyCallMediaControl2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDetectToneObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdetecttone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdetecttone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5881,7 +5881,7 @@ impl ITLegacyCallMediaControl2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomToneObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcustomtone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcustomtone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5892,7 +5892,7 @@ impl ITLegacyCallMediaControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIDAsVariant(::core::mem::transmute(&bstrdeviceclass)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5930,7 +5930,7 @@ impl ITLegacyWaveSupport_Vtbl {
             let this = (*this).get_impl();
             match this.IsFullDuplex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5966,7 +5966,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PermanentLocationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllocationid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllocationid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5977,7 +5977,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcountrycode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcountrycode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5988,7 +5988,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CountryID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcountryid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcountryid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5999,7 +5999,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Options() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ploptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ploptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6010,7 +6010,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredCardID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcardid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcardid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6021,7 +6021,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LocationName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplocationname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplocationname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6032,7 +6032,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CityCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6043,7 +6043,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LocalAccessCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6054,7 +6054,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LongDistanceAccessCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6065,7 +6065,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TollPrefixList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptolllist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptolllist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6076,7 +6076,7 @@ impl ITLocationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CancelCallWaitingCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6127,7 +6127,7 @@ impl ITMSPAddress_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMSPCall(::core::mem::transmute_copy(&hcall), ::core::mem::transmute_copy(&dwreserved), ::core::mem::transmute_copy(&dwmediatype), ::core::mem::transmute(&pouterunknown)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreamcontrol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreamcontrol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6194,7 +6194,7 @@ impl ITMediaControl_Vtbl {
             let this = (*this).get_impl();
             match this.MediaState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pterminalmediastate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pterminalmediastate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6232,7 +6232,7 @@ impl ITMediaPlayback_Vtbl {
             let this = (*this).get_impl();
             match this.PlayList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplaylistvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplaylistvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6268,7 +6268,7 @@ impl ITMediaRecord_Vtbl {
             let this = (*this).get_impl();
             match this.FileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6299,7 +6299,7 @@ impl ITMediaSupport_Vtbl {
             let this = (*this).get_impl();
             match this.MediaTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6310,7 +6310,7 @@ impl ITMediaSupport_Vtbl {
             let this = (*this).get_impl();
             match this.QueryMediaType(::core::mem::transmute_copy(&lmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6345,7 +6345,7 @@ impl ITMultiTrackTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.TrackTerminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6356,7 +6356,7 @@ impl ITMultiTrackTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateTrackTerminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6367,7 +6367,7 @@ impl ITMultiTrackTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTrackTerminal(::core::mem::transmute_copy(&mediatype), ::core::mem::transmute_copy(&terminaldirection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6378,7 +6378,7 @@ impl ITMultiTrackTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.MediaTypesInUse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatypesinuse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatypesinuse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6389,7 +6389,7 @@ impl ITMultiTrackTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.DirectionsInUse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldirectionsinused = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldirectionsinused, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6470,7 +6470,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.Addresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paddresses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paddresses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6481,7 +6481,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6492,7 +6492,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_PhoneCapsLong(::core::mem::transmute_copy(&pclcap)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcapability = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcapability, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6503,7 +6503,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_PhoneCapsString(::core::mem::transmute_copy(&pcscap)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcapability = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcapability, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6514,7 +6514,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_Terminals(::core::mem::transmute(&paddress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pterminals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pterminals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6525,7 +6525,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateTerminals(::core::mem::transmute(&paddress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6536,7 +6536,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_ButtonMode(::core::mem::transmute_copy(&lbuttonid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbuttonmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbuttonmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6552,7 +6552,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_ButtonFunction(::core::mem::transmute_copy(&lbuttonid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbuttonfunction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbuttonfunction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6568,7 +6568,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_ButtonText(::core::mem::transmute_copy(&lbuttonid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuttontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuttontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6584,7 +6584,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_ButtonState(::core::mem::transmute_copy(&lbuttonid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbuttonstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbuttonstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6595,7 +6595,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_HookSwitchState(::core::mem::transmute_copy(&hookswitchdevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phookswitchstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phookswitchstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6616,7 +6616,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.RingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plringmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plringmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6632,7 +6632,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.RingVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plringvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plringvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6643,7 +6643,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.Privilege() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprivilege = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprivilege, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6659,7 +6659,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_PhoneCapsBuffer(::core::mem::transmute_copy(&pcbcaps)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6670,7 +6670,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.get_LampMode(::core::mem::transmute_copy(&llampid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plampmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plampmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6686,7 +6686,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.Display() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdisplay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdisplay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6702,7 +6702,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paddresses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paddresses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6713,7 +6713,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePreferredAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6734,7 +6734,7 @@ impl ITPhone_Vtbl {
             let this = (*this).get_impl();
             match this.NegotiateExtVersion(::core::mem::transmute_copy(&llowversion), ::core::mem::transmute_copy(&lhighversion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plextversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plextversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6798,7 +6798,7 @@ impl ITPhoneDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Phone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6809,7 +6809,7 @@ impl ITPhoneDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.lParam1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparam1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparam1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6820,7 +6820,7 @@ impl ITPhoneDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.lParam2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparam2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparam2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6831,7 +6831,7 @@ impl ITPhoneDeviceSpecificEvent_Vtbl {
             let this = (*this).get_impl();
             match this.lParam3() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparam3 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparam3, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6871,7 +6871,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Phone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6882,7 +6882,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6893,7 +6893,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.ButtonState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6904,7 +6904,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.HookSwitchState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6915,7 +6915,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.HookSwitchDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6926,7 +6926,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.RingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plringmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plringmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6937,7 +6937,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.ButtonLampId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbuttonlampid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbuttonlampid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6948,7 +6948,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.NumberGathered() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6959,7 +6959,7 @@ impl ITPhoneEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7002,7 +7002,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7013,7 +7013,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Company() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcompany = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcompany, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7024,7 +7024,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7035,7 +7035,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pterminalclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pterminalclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7046,7 +7046,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7057,7 +7057,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Direction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdirection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdirection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7068,7 +7068,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MediaTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7151,7 +7151,7 @@ impl ITPluggableTerminalSuperclassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7162,7 +7162,7 @@ impl ITPluggableTerminalSuperclassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7196,7 +7196,7 @@ impl ITPrivateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7207,7 +7207,7 @@ impl ITPrivateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7218,7 +7218,7 @@ impl ITPrivateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallHub() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallhub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallhub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7229,7 +7229,7 @@ impl ITPrivateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pleventcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pleventcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7240,7 +7240,7 @@ impl ITPrivateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7275,7 +7275,7 @@ impl ITQOSEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7286,7 +7286,7 @@ impl ITQOSEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqosevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqosevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7297,7 +7297,7 @@ impl ITQOSEvent_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7344,7 +7344,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.MeasurementPeriod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plperiod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plperiod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7355,7 +7355,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.TotalCallsQueued() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7366,7 +7366,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCallsQueued() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7377,7 +7377,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.TotalCallsAbandoned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7388,7 +7388,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.TotalCallsFlowedIn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7399,7 +7399,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.TotalCallsFlowedOut() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7410,7 +7410,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.LongestEverWaitTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwaittime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwaittime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7421,7 +7421,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLongestWaitTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwaittime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwaittime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7432,7 +7432,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.AverageWaitTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwaittime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwaittime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7443,7 +7443,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.FinalDisposition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcalls = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcalls, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7454,7 +7454,7 @@ impl ITQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7495,7 +7495,7 @@ impl ITQueueEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Queue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7506,7 +7506,7 @@ impl ITQueueEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7539,7 +7539,7 @@ impl ITRendezvous_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultDirectories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7550,7 +7550,7 @@ impl ITRendezvous_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateDefaultDirectories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdirectory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdirectory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7561,7 +7561,7 @@ impl ITRendezvous_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDirectory(::core::mem::transmute_copy(&directorytype), ::core::mem::transmute(&pname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7572,7 +7572,7 @@ impl ITRendezvous_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDirectoryObject(::core::mem::transmute_copy(&directoryobjecttype), ::core::mem::transmute(&pname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdirectoryobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdirectoryobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7629,7 +7629,7 @@ impl ITRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.RegistrationInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plregistrationinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plregistrationinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7640,7 +7640,7 @@ impl ITRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.RequestMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plrequestmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plrequestmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7651,7 +7651,7 @@ impl ITRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.DestAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7662,7 +7662,7 @@ impl ITRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.AppName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppappname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppappname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7673,7 +7673,7 @@ impl ITRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CalledParty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcalledparty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcalledparty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7684,7 +7684,7 @@ impl ITRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Comment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7729,7 +7729,7 @@ impl ITScriptableAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Channels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7745,7 +7745,7 @@ impl ITScriptableAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.SamplesPerSec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7761,7 +7761,7 @@ impl ITScriptableAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.AvgBytesPerSec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7777,7 +7777,7 @@ impl ITScriptableAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.BlockAlign() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7793,7 +7793,7 @@ impl ITScriptableAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.BitsPerSample() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7809,7 +7809,7 @@ impl ITScriptableAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.FormatTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7854,7 +7854,7 @@ impl ITStaticAudioTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.WaveId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwaveid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwaveid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7889,7 +7889,7 @@ impl ITStream_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7900,7 +7900,7 @@ impl ITStream_Vtbl {
             let this = (*this).get_impl();
             match this.Direction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7911,7 +7911,7 @@ impl ITStream_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7947,7 +7947,7 @@ impl ITStream_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateTerminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7958,7 +7958,7 @@ impl ITStream_Vtbl {
             let this = (*this).get_impl();
             match this.Terminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pterminals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pterminals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7999,7 +7999,7 @@ impl ITStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStream(::core::mem::transmute_copy(&lmediatype), ::core::mem::transmute_copy(&td)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8015,7 +8015,7 @@ impl ITStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8026,7 +8026,7 @@ impl ITStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.Streams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8090,7 +8090,7 @@ impl ITSubStream_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateTerminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8101,7 +8101,7 @@ impl ITSubStream_Vtbl {
             let this = (*this).get_impl();
             match this.Terminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pterminals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pterminals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8112,7 +8112,7 @@ impl ITSubStream_Vtbl {
             let this = (*this).get_impl();
             match this.Stream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8151,7 +8151,7 @@ impl ITSubStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSubStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8167,7 +8167,7 @@ impl ITSubStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateSubStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumsubstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumsubstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8178,7 +8178,7 @@ impl ITSubStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.SubStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8235,7 +8235,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.Addresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8246,7 +8246,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8257,7 +8257,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterCallNotifications(::core::mem::transmute(&paddress), ::core::mem::transmute_copy(&fmonitor), ::core::mem::transmute_copy(&fowner), ::core::mem::transmute_copy(&lmediatypes), ::core::mem::transmute_copy(&lcallbackinstance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plregister = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plregister, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8273,7 +8273,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.CallHubs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8284,7 +8284,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateCallHubs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcallhub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcallhub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8300,7 +8300,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePrivateTAPIObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8311,7 +8311,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateTAPIObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8342,7 +8342,7 @@ impl ITTAPI_Vtbl {
             let this = (*this).get_impl();
             match this.EventFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfiltermask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfiltermask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8388,7 +8388,7 @@ impl ITTAPI2_Vtbl {
             let this = (*this).get_impl();
             match this.Phones() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphones = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphones, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8399,7 +8399,7 @@ impl ITTAPI2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePhones() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumphone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumphone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8410,7 +8410,7 @@ impl ITTAPI2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEmptyCollectionObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8442,7 +8442,7 @@ impl ITTAPICallCenter_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateAgentHandlers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumhandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumhandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8453,7 +8453,7 @@ impl ITTAPICallCenter_Vtbl {
             let this = (*this).get_impl();
             match this.AgentHandlers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8519,7 +8519,7 @@ impl ITTAPIObjectEvent_Vtbl {
             let this = (*this).get_impl();
             match this.TAPIObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptapiobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptapiobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8530,7 +8530,7 @@ impl ITTAPIObjectEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Event() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8541,7 +8541,7 @@ impl ITTAPIObjectEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8552,7 +8552,7 @@ impl ITTAPIObjectEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8584,7 +8584,7 @@ impl ITTAPIObjectEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.Phone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8612,7 +8612,7 @@ impl ITTTSTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Terminal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8623,7 +8623,7 @@ impl ITTTSTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8634,7 +8634,7 @@ impl ITTTSTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrerrorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrerrorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8670,7 +8670,7 @@ impl ITTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8681,7 +8681,7 @@ impl ITTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pterminalstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pterminalstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8692,7 +8692,7 @@ impl ITTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8703,7 +8703,7 @@ impl ITTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminalclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminalclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8714,7 +8714,7 @@ impl ITTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8725,7 +8725,7 @@ impl ITTerminal_Vtbl {
             let this = (*this).get_impl();
             match this.Direction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdirection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdirection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8764,7 +8764,7 @@ impl ITTerminalSupport_Vtbl {
             let this = (*this).get_impl();
             match this.StaticTerminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8775,7 +8775,7 @@ impl ITTerminalSupport_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateStaticTerminals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminalenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminalenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8786,7 +8786,7 @@ impl ITTerminalSupport_Vtbl {
             let this = (*this).get_impl();
             match this.DynamicTerminalClasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8797,7 +8797,7 @@ impl ITTerminalSupport_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateDynamicTerminalClasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminalclassenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminalclassenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8808,7 +8808,7 @@ impl ITTerminalSupport_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTerminal(::core::mem::transmute(&pterminalclass), ::core::mem::transmute_copy(&lmediatype), ::core::mem::transmute_copy(&direction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8819,7 +8819,7 @@ impl ITTerminalSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultStaticTerminal(::core::mem::transmute_copy(&lmediatype), ::core::mem::transmute_copy(&direction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8856,7 +8856,7 @@ impl ITTerminalSupport2_Vtbl {
             let this = (*this).get_impl();
             match this.PluggableSuperclasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8867,7 +8867,7 @@ impl ITTerminalSupport2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePluggableSuperclasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsuperclassenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsuperclassenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8878,7 +8878,7 @@ impl ITTerminalSupport2_Vtbl {
             let this = (*this).get_impl();
             match this.get_PluggableTerminalClasses(::core::mem::transmute(&bstrterminalsuperclass), ::core::mem::transmute_copy(&lmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8889,7 +8889,7 @@ impl ITTerminalSupport2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePluggableTerminalClasses(::core::mem::transmute(&iidterminalsuperclass), ::core::mem::transmute_copy(&lmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclassenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclassenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8924,7 +8924,7 @@ impl ITToneDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8935,7 +8935,7 @@ impl ITToneDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.AppSpecific() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plappspecific = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plappspecific, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8946,7 +8946,7 @@ impl ITToneDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.TickCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltickcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltickcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8957,7 +8957,7 @@ impl ITToneDetectionEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CallbackInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcallbackinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcallbackinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8991,7 +8991,7 @@ impl ITToneTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Terminal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppterminal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppterminal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9002,7 +9002,7 @@ impl ITToneTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Call() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9013,7 +9013,7 @@ impl ITToneTerminalEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrerrorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrerrorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9065,7 +9065,7 @@ impl ITnef_Vtbl {
             let this = (*this).get_impl();
             match this.OpenTaggedBody(::core::mem::transmute(&lpmessage), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
@@ -80,7 +80,7 @@ impl IWSDAsyncResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetAsyncState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasyncstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasyncstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -96,7 +96,7 @@ impl IWSDAsyncResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -107,7 +107,7 @@ impl IWSDAsyncResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndpointProxy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppendpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppendpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -249,7 +249,7 @@ impl IWSDDeviceHostNotify_Vtbl {
             let this = (*this).get_impl();
             match this.GetService(::core::mem::transmute(&pszserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -286,7 +286,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.BeginGetMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -302,7 +302,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetHostMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphostmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphostmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -313,7 +313,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetThisModelMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmanufacturermetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmanufacturermetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -324,7 +324,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetThisDeviceMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppthisdevicemetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppthisdevicemetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -335,7 +335,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -346,7 +346,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceProxyById(::core::mem::transmute(&pszserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserviceproxy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserviceproxy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -357,7 +357,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceProxyByType(::core::mem::transmute_copy(&ptype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserviceproxy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserviceproxy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -368,7 +368,7 @@ impl IWSDDeviceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndpointProxy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproxy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproxy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -422,7 +422,7 @@ impl IWSDEndpointProxy_Vtbl {
             let this = (*this).get_impl();
             match this.SendTwoWayRequestAsync(::core::mem::transmute_copy(&pbody), ::core::mem::transmute_copy(&poperation), ::core::mem::transmute(&pasyncstate), ::core::mem::transmute(&pcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -443,7 +443,7 @@ impl IWSDEndpointProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszerrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszerrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -454,7 +454,7 @@ impl IWSDEndpointProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetFaultInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfault = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfault, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -536,7 +536,7 @@ impl IWSDHttpAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -574,7 +574,7 @@ impl IWSDHttpAuthParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientAccessToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phtoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phtoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -585,7 +585,7 @@ impl IWSDHttpAuthParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetAuthType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pauthtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pauthtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -625,7 +625,7 @@ impl IWSDHttpMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetInboundHttpHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -641,7 +641,7 @@ impl IWSDHttpMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutboundHttpHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -657,7 +657,7 @@ impl IWSDHttpMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -673,7 +673,7 @@ impl IWSDHttpMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -739,7 +739,7 @@ impl IWSDMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -755,7 +755,7 @@ impl IWSDMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetRemoteAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -771,7 +771,7 @@ impl IWSDMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetLowerParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptxparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptxparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -801,7 +801,7 @@ impl IWSDMetadataExchange_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *metadataout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metadataout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -826,7 +826,7 @@ impl IWSDOutboundAttachment_Vtbl {
             let this = (*this).get_impl();
             match this.Write(::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&dwbytestowrite)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumberofbyteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumberofbyteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -868,7 +868,7 @@ impl IWSDSSLClientCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcertcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcertcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -879,7 +879,7 @@ impl IWSDSSLClientCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.GetMappedAccessToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phtoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phtoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -910,7 +910,7 @@ impl IWSDScopeMatchingRule_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszscopematchingrule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszscopematchingrule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -921,7 +921,7 @@ impl IWSDScopeMatchingRule_Vtbl {
             let this = (*this).get_impl();
             match this.MatchScopes(::core::mem::transmute(&pszscope1), ::core::mem::transmute(&pszscope2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -981,7 +981,7 @@ impl IWSDServiceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.BeginGetMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -992,7 +992,7 @@ impl IWSDServiceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.EndGetMetadata(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1003,7 +1003,7 @@ impl IWSDServiceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservicemetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservicemetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1014,7 +1014,7 @@ impl IWSDServiceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.SubscribeToOperation(::core::mem::transmute_copy(&poperation), ::core::mem::transmute(&punknown), ::core::mem::transmute_copy(&pany)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppany = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppany, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1035,7 +1035,7 @@ impl IWSDServiceProxy_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndpointProxy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproxy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproxy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1086,7 +1086,7 @@ impl IWSDServiceProxyEventing_Vtbl {
             let this = (*this).get_impl();
             match this.BeginSubscribeToMultipleOperations(::core::mem::transmute_copy(&poperations), ::core::mem::transmute_copy(&dwoperationcount), ::core::mem::transmute(&punknown), ::core::mem::transmute_copy(&pexpires), ::core::mem::transmute_copy(&pany), ::core::mem::transmute(&pasyncstate), ::core::mem::transmute(&pasynccallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1107,7 +1107,7 @@ impl IWSDServiceProxyEventing_Vtbl {
             let this = (*this).get_impl();
             match this.BeginUnsubscribeToMultipleOperations(::core::mem::transmute_copy(&poperations), ::core::mem::transmute_copy(&dwoperationcount), ::core::mem::transmute_copy(&pany), ::core::mem::transmute(&pasyncstate), ::core::mem::transmute(&pasynccallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1128,7 +1128,7 @@ impl IWSDServiceProxyEventing_Vtbl {
             let this = (*this).get_impl();
             match this.BeginRenewMultipleOperations(::core::mem::transmute_copy(&poperations), ::core::mem::transmute_copy(&dwoperationcount), ::core::mem::transmute_copy(&pexpires), ::core::mem::transmute_copy(&pany), ::core::mem::transmute(&pasyncstate), ::core::mem::transmute(&pasynccallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1149,7 +1149,7 @@ impl IWSDServiceProxyEventing_Vtbl {
             let this = (*this).get_impl();
             match this.BeginGetStatusForMultipleOperations(::core::mem::transmute_copy(&poperations), ::core::mem::transmute_copy(&dwoperationcount), ::core::mem::transmute_copy(&pany), ::core::mem::transmute(&pasyncstate), ::core::mem::transmute(&pasynccallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1198,7 +1198,7 @@ impl IWSDSignatureProperty_Vtbl {
             let this = (*this).get_impl();
             match this.IsMessageSigned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsigned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsigned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1209,7 +1209,7 @@ impl IWSDSignatureProperty_Vtbl {
             let this = (*this).get_impl();
             match this.IsMessageSignatureTrusted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsignaturetrusted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsignaturetrusted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1261,7 +1261,7 @@ impl IWSDTransportAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1277,7 +1277,7 @@ impl IWSDTransportAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1288,7 +1288,7 @@ impl IWSDTransportAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportAddressEx(::core::mem::transmute_copy(&fsafe)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1340,7 +1340,7 @@ impl IWSDUdpAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetSockaddr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psockaddr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psockaddr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1366,7 +1366,7 @@ impl IWSDUdpAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmessagetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmessagetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1382,7 +1382,7 @@ impl IWSDUdpAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetTTL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwttl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwttl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1398,7 +1398,7 @@ impl IWSDUdpAddress_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlias() {
                 ::core::result::Result::Ok(ok__) => {
-                    *palias = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(palias, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1439,7 +1439,7 @@ impl IWSDUdpMessageParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetRetransmitParams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1469,7 +1469,7 @@ impl IWSDXMLContext_Vtbl {
             let this = (*this).get_impl();
             match this.AddNamespace(::core::mem::transmute(&pszuri), ::core::mem::transmute(&pszsuggestedprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1480,7 +1480,7 @@ impl IWSDXMLContext_Vtbl {
             let this = (*this).get_impl();
             match this.AddNameToNamespace(::core::mem::transmute(&pszuri), ::core::mem::transmute(&pszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1529,7 +1529,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndpointReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppendpointreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppendpointreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1540,7 +1540,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptypeslist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptypeslist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1551,7 +1551,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscopeslist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscopeslist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1562,7 +1562,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetXAddrs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppxaddrslist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppxaddrslist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1573,7 +1573,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullmetadataversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullmetadataversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1589,7 +1589,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetProbeResolveTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1600,7 +1600,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetRemoteTransportAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszremotetransportaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszremotetransportaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1611,7 +1611,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalTransportAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszlocaltransportaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszlocaltransportaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1622,7 +1622,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalInterfaceGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1633,7 +1633,7 @@ impl IWSDiscoveredService_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullinstanceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullinstanceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1705,7 +1705,7 @@ impl IWSDiscoveryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetXMLContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1899,7 +1899,7 @@ impl IWSDiscoveryPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.GetXMLContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
@@ -30,7 +30,7 @@ impl IGameExplorer_Vtbl {
             let this = (*this).get_impl();
             match this.VerifyAccess(::core::mem::transmute(&bstrgdfbinarypath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfhasaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfhasaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -74,7 +74,7 @@ impl IGameExplorer2_Vtbl {
             let this = (*this).get_impl();
             match this.CheckAccess(::core::mem::transmute(&binarygdfpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phasaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phasaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -116,7 +116,7 @@ impl IGameStatistics_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxCategoryLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -127,7 +127,7 @@ impl IGameStatistics_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxNameLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -138,7 +138,7 @@ impl IGameStatistics_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxValueLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -149,7 +149,7 @@ impl IGameStatistics_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -160,7 +160,7 @@ impl IGameStatistics_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxStatsPerCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -176,7 +176,7 @@ impl IGameStatistics_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategoryTitle(::core::mem::transmute_copy(&categoryindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -207,7 +207,7 @@ impl IGameStatistics_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastPlayedCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcategoryindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcategoryindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -294,7 +294,7 @@ impl IXblIdpAuthManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnvironment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *environment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(environment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl IXblIdpAuthManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSandbox() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sandbox = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sandbox, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IXblIdpAuthManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetTokenAndSignatureWithTokenResult(::core::mem::transmute(&msaaccountid), ::core::mem::transmute(&appsid), ::core::mem::transmute(&msatarget), ::core::mem::transmute(&msapolicy), ::core::mem::transmute(&httpmethod), ::core::mem::transmute(&uri), ::core::mem::transmute(&headers), ::core::mem::transmute_copy(&body), ::core::mem::transmute_copy(&bodysize), ::core::mem::transmute_copy(&forcerefresh)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -366,7 +366,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -377,7 +377,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -388,7 +388,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *token = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(token, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -399,7 +399,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -410,7 +410,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetSandbox() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sandbox = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sandbox, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -421,7 +421,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnvironment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *environment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(environment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -432,7 +432,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetMsaAccountId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *msaaccountid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(msaaccountid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -443,7 +443,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetXuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xuid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xuid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -454,7 +454,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetGamertag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *gamertag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gamertag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -465,7 +465,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetAgeGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *agegroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(agegroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -476,7 +476,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrivileges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *privileges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(privileges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -487,7 +487,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetMsaTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *msatarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(msatarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -498,7 +498,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetMsaPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *msapolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(msapolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -509,7 +509,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetMsaAppId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *msaappid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(msaappid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -520,7 +520,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetRedirect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *redirect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(redirect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -531,7 +531,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *message = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(message, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -542,7 +542,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelpId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *helpid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(helpid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -553,7 +553,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnforcementBans() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enforcementbans = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enforcementbans, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -564,7 +564,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *restrictions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(restrictions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -575,7 +575,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitleRestrictions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *titlerestrictions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(titlerestrictions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -622,7 +622,7 @@ impl IXblIdpAuthTokenResult2_Vtbl {
             let this = (*this).get_impl();
             match this.GetModernGamertag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -633,7 +633,7 @@ impl IXblIdpAuthTokenResult2_Vtbl {
             let this = (*this).get_impl();
             match this.GetModernGamertagSuffix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -644,7 +644,7 @@ impl IXblIdpAuthTokenResult2_Vtbl {
             let this = (*this).get_impl();
             match this.GetUniqueModernGamertag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
@@ -9,7 +9,7 @@ impl IComprehensiveSpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ComprehensiveCheck(::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35,7 +35,7 @@ impl IEnumCodePage_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -82,7 +82,7 @@ impl IEnumRfc1766_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -129,7 +129,7 @@ impl IEnumScript_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -173,7 +173,7 @@ impl IEnumSpellingError_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -199,7 +199,7 @@ impl IMLangCodePages_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharCodePages(::core::mem::transmute_copy(&chsrc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcodepages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcodepages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -215,7 +215,7 @@ impl IMLangCodePages_Vtbl {
             let this = (*this).get_impl();
             match this.CodePageToCodePages(::core::mem::transmute_copy(&ucodepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcodepages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcodepages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -226,7 +226,7 @@ impl IMLangCodePages_Vtbl {
             let this = (*this).get_impl();
             match this.CodePagesToCodePage(::core::mem::transmute_copy(&dwcodepages), ::core::mem::transmute_copy(&udefaultcodepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -266,7 +266,7 @@ impl IMLangConvertCharset_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceCodePage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puisrccodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puisrccodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -277,7 +277,7 @@ impl IMLangConvertCharset_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationCodePage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puidstcodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puidstcodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -288,7 +288,7 @@ impl IMLangConvertCharset_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -341,7 +341,7 @@ impl IMLangFontLink_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontCodePages(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&hfont)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcodepages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcodepages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -352,7 +352,7 @@ impl IMLangFontLink_Vtbl {
             let this = (*this).get_impl();
             match this.MapFont(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&dwcodepages), ::core::mem::transmute_copy(&hsrcfont)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdestfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdestfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -400,7 +400,7 @@ impl IMLangFontLink2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontCodePages(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&hfont)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcodepages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcodepages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -421,7 +421,7 @@ impl IMLangFontLink2_Vtbl {
             let this = (*this).get_impl();
             match this.MapFont(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&dwcodepages), ::core::mem::transmute_copy(&chsrc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -432,7 +432,7 @@ impl IMLangFontLink2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontUnicodeRanges(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&puiranges)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puranges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puranges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -448,7 +448,7 @@ impl IMLangFontLink2_Vtbl {
             let this = (*this).get_impl();
             match this.CodePageToScriptID(::core::mem::transmute_copy(&uicodepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -525,7 +525,7 @@ impl IMLangString_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl IMLangStringBufA_Vtbl {
             let this = (*this).get_impl();
             match this.Insert(::core::mem::transmute_copy(&cchoffset), ::core::mem::transmute_copy(&cchmaxinsert)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchactual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchactual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -712,7 +712,7 @@ impl IMLangStringBufW_Vtbl {
             let this = (*this).get_impl();
             match this.Insert(::core::mem::transmute_copy(&cchoffset), ::core::mem::transmute_copy(&cchmaxinsert)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchactual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchactual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -836,7 +836,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfCodePageInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -847,7 +847,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodePageInfo(::core::mem::transmute_copy(&uicodepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcodepageinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcodepageinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -858,7 +858,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.GetFamilyCodePage(::core::mem::transmute_copy(&uicodepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puifamilycodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puifamilycodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -869,7 +869,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCodePages(::core::mem::transmute_copy(&grfflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -880,7 +880,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharsetInfo(::core::mem::transmute(&charset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcharsetinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcharsetinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -916,7 +916,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.GetRfc1766FromLcid(::core::mem::transmute_copy(&locale)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrrfc1766 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrrfc1766, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -932,7 +932,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRfc1766() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumrfc1766 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumrfc1766, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.GetRfc1766Info(::core::mem::transmute_copy(&locale)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prfc1766info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prfc1766info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl IMultiLanguage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateConvertCharset(::core::mem::transmute_copy(&uisrccodepage), ::core::mem::transmute_copy(&uidstcodepage), ::core::mem::transmute_copy(&dwproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmlangconvertcharset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmlangconvertcharset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1023,7 +1023,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfCodePageInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1034,7 +1034,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodePageInfo(::core::mem::transmute_copy(&uicodepage), ::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcodepageinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcodepageinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1045,7 +1045,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFamilyCodePage(::core::mem::transmute_copy(&uicodepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puifamilycodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puifamilycodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1056,7 +1056,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCodePages(::core::mem::transmute_copy(&grfflags), ::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1067,7 +1067,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharsetInfo(::core::mem::transmute(&charset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcharsetinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcharsetinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1103,7 +1103,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRfc1766FromLcid(::core::mem::transmute_copy(&locale)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrrfc1766 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrrfc1766, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1119,7 +1119,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRfc1766(::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumrfc1766 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumrfc1766, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1130,7 +1130,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRfc1766Info(::core::mem::transmute_copy(&locale), ::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prfc1766info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prfc1766info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1141,7 +1141,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateConvertCharset(::core::mem::transmute_copy(&uisrccodepage), ::core::mem::transmute_copy(&uidstcodepage), ::core::mem::transmute_copy(&dwproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmlangconvertcharset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmlangconvertcharset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1197,7 +1197,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfScripts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnscripts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnscripts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1208,7 +1208,7 @@ impl IMultiLanguage2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumScripts(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumscript = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumscript, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1301,7 +1301,7 @@ impl IOptionDescription_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1312,7 +1312,7 @@ impl IOptionDescription_Vtbl {
             let this = (*this).get_impl();
             match this.Heading() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1323,7 +1323,7 @@ impl IOptionDescription_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1334,7 +1334,7 @@ impl IOptionDescription_Vtbl {
             let this = (*this).get_impl();
             match this.Labels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1375,7 +1375,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1386,7 +1386,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Check(::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1397,7 +1397,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Suggest(::core::mem::transmute(&word)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1408,7 +1408,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionValue(::core::mem::transmute(&optionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1424,7 +1424,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.OptionIds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1435,7 +1435,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1446,7 +1446,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.LocalizedName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1457,7 +1457,7 @@ impl ISpellCheckProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionDescription(::core::mem::transmute(&optionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1502,7 +1502,7 @@ impl ISpellCheckProviderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedLanguages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1513,7 +1513,7 @@ impl ISpellCheckProviderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.IsSupported(::core::mem::transmute(&languagetag)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1524,7 +1524,7 @@ impl ISpellCheckProviderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSpellCheckProvider(::core::mem::transmute(&languagetag)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1568,7 +1568,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1579,7 +1579,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.Check(::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1590,7 +1590,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.Suggest(::core::mem::transmute(&word)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1616,7 +1616,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionValue(::core::mem::transmute(&optionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1627,7 +1627,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.OptionIds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1638,7 +1638,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1649,7 +1649,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.LocalizedName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1660,7 +1660,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.add_SpellCheckerChanged(::core::mem::transmute(&handler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1676,7 +1676,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionDescription(::core::mem::transmute(&optionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1687,7 +1687,7 @@ impl ISpellChecker_Vtbl {
             let this = (*this).get_impl();
             match this.ComprehensiveCheck(::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1768,7 +1768,7 @@ impl ISpellCheckerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedLanguages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1779,7 +1779,7 @@ impl ISpellCheckerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.IsSupported(::core::mem::transmute(&languagetag)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1790,7 +1790,7 @@ impl ISpellCheckerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSpellChecker(::core::mem::transmute(&languagetag)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1821,7 +1821,7 @@ impl ISpellingError_Vtbl {
             let this = (*this).get_impl();
             match this.StartIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1832,7 +1832,7 @@ impl ISpellingError_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1843,7 +1843,7 @@ impl ISpellingError_Vtbl {
             let this = (*this).get_impl();
             match this.CorrectiveAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1854,7 +1854,7 @@ impl ISpellingError_Vtbl {
             let this = (*this).get_impl();
             match this.Replacement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
@@ -155,7 +155,7 @@ impl IPresentationBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *availableeventhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(availableeventhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -166,7 +166,7 @@ impl IPresentationBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.IsAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isavailable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isavailable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -222,7 +222,7 @@ impl IPresentationFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePresentationManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppresentationmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppresentationmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl IPresentationManager_Vtbl {
             let this = (*this).get_impl();
             match this.AddBufferFromResource(::core::mem::transmute(&resource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presentationbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presentationbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl IPresentationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePresentationSurface(::core::mem::transmute_copy(&compositionsurfacehandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presentationsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presentationsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -312,7 +312,7 @@ impl IPresentationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresentRetiringFence(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -328,7 +328,7 @@ impl IPresentationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetLostEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *losteventhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(losteventhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -339,7 +339,7 @@ impl IPresentationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresentStatisticsAvailableEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *presentstatisticsavailableeventhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presentstatisticsavailableeventhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -355,7 +355,7 @@ impl IPresentationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextPresentStatistics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextpresentstatistics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextpresentstatistics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
@@ -38,7 +38,7 @@ impl IDXCoreAdapter_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertySize(::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffersize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffersize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -120,7 +120,7 @@ impl IDXCoreAdapterFactory_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterEventNotification(::core::mem::transmute(&dxcoreobject), ::core::mem::transmute_copy(&notificationtype), ::core::mem::transmute(&callbackfunction), ::core::mem::transmute_copy(&callbackcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
@@ -108,7 +108,7 @@ impl ID2D1Bitmap1_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dxgisurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dxgisurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -119,7 +119,7 @@ impl ID2D1Bitmap1_Vtbl {
             let this = (*this).get_impl();
             match this.Map(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mappedrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mappedrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -259,7 +259,7 @@ impl ID2D1BitmapRenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitmap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -479,7 +479,7 @@ impl ID2D1ColorContext1_Vtbl {
             let this = (*this).get_impl();
             match this.GetSimpleColorProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *simpleprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(simpleprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -962,7 +962,7 @@ impl ID2D1Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeviceContext(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -973,7 +973,7 @@ impl ID2D1Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePrintControl(::core::mem::transmute(&wicfactory), ::core::mem::transmute(&documenttarget), ::core::mem::transmute_copy(&printcontrolproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *printcontrol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(printcontrol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1033,7 +1033,7 @@ impl ID2D1Device1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeviceContext2(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecontext1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecontext1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1066,7 +1066,7 @@ impl ID2D1Device2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeviceContext3(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecontext2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecontext2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1082,7 +1082,7 @@ impl ID2D1Device2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDxgiDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dxgidevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dxgidevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1113,7 +1113,7 @@ impl ID2D1Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeviceContext4(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecontext3 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecontext3, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1141,7 +1141,7 @@ impl ID2D1Device4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeviceContext5(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecontext4 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecontext4, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1182,7 +1182,7 @@ impl ID2D1Device5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeviceContext6(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecontext5 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecontext5, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1208,7 +1208,7 @@ impl ID2D1Device6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeviceContext7(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecontext6 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecontext6, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1268,7 +1268,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmap2(::core::mem::transmute(&size), ::core::mem::transmute_copy(&sourcedata), ::core::mem::transmute_copy(&pitch), ::core::mem::transmute_copy(&bitmapproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1279,7 +1279,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromWicBitmap2(::core::mem::transmute(&wicbitmapsource), ::core::mem::transmute_copy(&bitmapproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1290,7 +1290,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContext(::core::mem::transmute_copy(&space), ::core::mem::transmute_copy(&profile), ::core::mem::transmute_copy(&profilesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1301,7 +1301,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromFilename(::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1312,7 +1312,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromWicColorContext(::core::mem::transmute(&wiccolorcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1323,7 +1323,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromDxgiSurface(::core::mem::transmute(&surface), ::core::mem::transmute_copy(&bitmapproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1334,7 +1334,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEffect(::core::mem::transmute_copy(&effectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *effect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(effect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1345,7 +1345,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGradientStopCollection2(::core::mem::transmute_copy(&straightalphagradientstops), ::core::mem::transmute_copy(&straightalphagradientstopscount), ::core::mem::transmute_copy(&preinterpolationspace), ::core::mem::transmute_copy(&postinterpolationspace), ::core::mem::transmute_copy(&bufferprecision), ::core::mem::transmute_copy(&extendmode), ::core::mem::transmute_copy(&colorinterpolationmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *gradientstopcollection1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gradientstopcollection1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1356,7 +1356,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageBrush(::core::mem::transmute(&image), ::core::mem::transmute_copy(&imagebrushproperties), ::core::mem::transmute_copy(&brushproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagebrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagebrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1367,7 +1367,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapBrush2(::core::mem::transmute(&bitmap), ::core::mem::transmute_copy(&bitmapbrushproperties), ::core::mem::transmute_copy(&brushproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmapbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmapbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1378,7 +1378,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCommandList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *commandlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(commandlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1399,7 +1399,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageLocalBounds(::core::mem::transmute(&image)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *localbounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localbounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1410,7 +1410,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageWorldBounds(::core::mem::transmute(&image)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *worldbounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(worldbounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1421,7 +1421,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphRunWorldBounds(::core::mem::transmute(&baselineorigin), ::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute_copy(&measuringmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1507,7 +1507,7 @@ impl ID2D1DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectInvalidRectangleCount(::core::mem::transmute(&effect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectanglecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectanglecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1587,7 +1587,7 @@ impl ID2D1DeviceContext1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFilledGeometryRealization(::core::mem::transmute(&geometry), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometryrealization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometryrealization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1598,7 +1598,7 @@ impl ID2D1DeviceContext1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStrokedGeometryRealization(::core::mem::transmute(&geometry), ::core::mem::transmute_copy(&flatteningtolerance), ::core::mem::transmute_copy(&strokewidth), ::core::mem::transmute(&strokestyle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometryrealization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometryrealization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1644,7 +1644,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInk(::core::mem::transmute_copy(&startpoint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1655,7 +1655,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInkStyle(::core::mem::transmute_copy(&inkstyleproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inkstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inkstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1666,7 +1666,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGradientMesh(::core::mem::transmute_copy(&patches), ::core::mem::transmute_copy(&patchescount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *gradientmesh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gradientmesh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1677,7 +1677,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageSourceFromWic(::core::mem::transmute(&wicbitmapsource), ::core::mem::transmute_copy(&loadingoptions), ::core::mem::transmute_copy(&alphamode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagesource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagesource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1688,7 +1688,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLookupTable3D(::core::mem::transmute_copy(&precision), ::core::mem::transmute_copy(&extents), ::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&datacount), ::core::mem::transmute_copy(&strides)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lookuptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lookuptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1699,7 +1699,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageSourceFromDxgi(::core::mem::transmute_copy(&surfaces), ::core::mem::transmute_copy(&surfacecount), ::core::mem::transmute_copy(&colorspace), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagesource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagesource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1710,7 +1710,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGradientMeshWorldBounds(::core::mem::transmute(&gradientmesh)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1736,7 +1736,7 @@ impl ID2D1DeviceContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransformedImageSource(::core::mem::transmute(&imagesource), ::core::mem::transmute_copy(&properties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformedimagesource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformedimagesource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1776,7 +1776,7 @@ impl ID2D1DeviceContext3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSpriteBatch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *spritebatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(spritebatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1817,7 +1817,7 @@ impl ID2D1DeviceContext4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSvgGlyphStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *svgglyphstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(svgglyphstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1887,7 +1887,7 @@ impl ID2D1DeviceContext5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSvgDocument(::core::mem::transmute(&inputxmlstream), ::core::mem::transmute(&viewportsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *svgdocument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(svgdocument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1903,7 +1903,7 @@ impl ID2D1DeviceContext5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromDxgiColorSpace(::core::mem::transmute_copy(&colorspace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1914,7 +1914,7 @@ impl ID2D1DeviceContext5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromSimpleColorProfile(::core::mem::transmute_copy(&simpleprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2187,7 +2187,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEffect(::core::mem::transmute_copy(&effectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *effect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(effect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2198,7 +2198,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumSupportedFeatureLevel(::core::mem::transmute_copy(&featurelevels), ::core::mem::transmute_copy(&featurelevelscount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *maximumsupportedfeaturelevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maximumsupportedfeaturelevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2209,7 +2209,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransformNodeFromEffect(::core::mem::transmute(&effect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2220,7 +2220,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlendTransform(::core::mem::transmute_copy(&numinputs), ::core::mem::transmute_copy(&blenddescription)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2231,7 +2231,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBorderTransform(::core::mem::transmute_copy(&extendmodex), ::core::mem::transmute_copy(&extendmodey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2242,7 +2242,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateOffsetTransform(::core::mem::transmute(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2253,7 +2253,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBoundsAdjustmentTransform(::core::mem::transmute_copy(&outputrectangle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2284,7 +2284,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateResourceTexture(::core::mem::transmute_copy(&resourceid), ::core::mem::transmute_copy(&resourcetextureproperties), ::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&strides), ::core::mem::transmute_copy(&datasize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcetexture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcetexture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2295,7 +2295,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.FindResourceTexture(::core::mem::transmute_copy(&resourceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcetexture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcetexture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2306,7 +2306,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVertexBuffer(::core::mem::transmute_copy(&vertexbufferproperties), ::core::mem::transmute_copy(&resourceid), ::core::mem::transmute_copy(&customvertexbufferproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2317,7 +2317,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.FindVertexBuffer(::core::mem::transmute_copy(&resourceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2328,7 +2328,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContext(::core::mem::transmute_copy(&space), ::core::mem::transmute_copy(&profile), ::core::mem::transmute_copy(&profilesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2339,7 +2339,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromFilename(::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2350,7 +2350,7 @@ impl ID2D1EffectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromWicColorContext(::core::mem::transmute(&wiccolorcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2409,7 +2409,7 @@ impl ID2D1EffectContext1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLookupTable3D(::core::mem::transmute_copy(&precision), ::core::mem::transmute_copy(&extents), ::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&datacount), ::core::mem::transmute_copy(&strides)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lookuptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lookuptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2436,7 +2436,7 @@ impl ID2D1EffectContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromDxgiColorSpace(::core::mem::transmute_copy(&colorspace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2447,7 +2447,7 @@ impl ID2D1EffectContext2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContextFromSimpleColorProfile(::core::mem::transmute_copy(&simpleprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2554,7 +2554,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRectangleGeometry(::core::mem::transmute_copy(&rectangle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectanglegeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectanglegeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2565,7 +2565,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRoundedRectangleGeometry(::core::mem::transmute_copy(&roundedrectangle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *roundedrectanglegeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(roundedrectanglegeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2576,7 +2576,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEllipseGeometry(::core::mem::transmute_copy(&ellipse)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ellipsegeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ellipsegeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2587,7 +2587,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeometryGroup(::core::mem::transmute_copy(&fillmode), ::core::mem::transmute_copy(&geometries), ::core::mem::transmute_copy(&geometriescount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometrygroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometrygroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2598,7 +2598,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransformedGeometry(::core::mem::transmute(&sourcegeometry), ::core::mem::transmute_copy(&transform)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformedgeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformedgeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2609,7 +2609,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePathGeometry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pathgeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pathgeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2620,7 +2620,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStrokeStyle(::core::mem::transmute_copy(&strokestyleproperties), ::core::mem::transmute_copy(&dashes), ::core::mem::transmute_copy(&dashescount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokestyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokestyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2631,7 +2631,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDrawingStateBlock(::core::mem::transmute_copy(&drawingstatedescription), ::core::mem::transmute(&textrenderingparams)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *drawingstateblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(drawingstateblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2642,7 +2642,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateWicBitmapRenderTarget(::core::mem::transmute(&target), ::core::mem::transmute_copy(&rendertargetproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rendertarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rendertarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2653,7 +2653,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateHwndRenderTarget(::core::mem::transmute_copy(&rendertargetproperties), ::core::mem::transmute_copy(&hwndrendertargetproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *hwndrendertarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hwndrendertarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2664,7 +2664,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDxgiSurfaceRenderTarget(::core::mem::transmute(&dxgisurface), ::core::mem::transmute_copy(&rendertargetproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rendertarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rendertarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2675,7 +2675,7 @@ impl ID2D1Factory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDCRenderTarget(::core::mem::transmute_copy(&rendertargetproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dcrendertarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dcrendertarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2726,7 +2726,7 @@ impl ID2D1Factory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice(::core::mem::transmute(&dxgidevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *d2ddevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(d2ddevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2737,7 +2737,7 @@ impl ID2D1Factory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStrokeStyle2(::core::mem::transmute_copy(&strokestyleproperties), ::core::mem::transmute_copy(&dashes), ::core::mem::transmute_copy(&dashescount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokestyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokestyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2748,7 +2748,7 @@ impl ID2D1Factory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePathGeometry2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pathgeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pathgeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2759,7 +2759,7 @@ impl ID2D1Factory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDrawingStateBlock2(::core::mem::transmute_copy(&drawingstatedescription), ::core::mem::transmute(&textrenderingparams)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *drawingstateblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(drawingstateblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2770,7 +2770,7 @@ impl ID2D1Factory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGdiMetafile(::core::mem::transmute(&metafilestream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *metafile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metafile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2801,7 +2801,7 @@ impl ID2D1Factory1_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectProperties(::core::mem::transmute_copy(&effectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *properties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(properties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2839,7 +2839,7 @@ impl ID2D1Factory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice2(::core::mem::transmute(&dxgidevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *d2ddevice1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(d2ddevice1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2865,7 +2865,7 @@ impl ID2D1Factory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice3(::core::mem::transmute(&dxgidevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *d2ddevice2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(d2ddevice2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2891,7 +2891,7 @@ impl ID2D1Factory4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice4(::core::mem::transmute(&dxgidevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *d2ddevice3 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(d2ddevice3, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2917,7 +2917,7 @@ impl ID2D1Factory5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice5(::core::mem::transmute(&dxgidevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *d2ddevice4 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(d2ddevice4, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2943,7 +2943,7 @@ impl ID2D1Factory6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice6(::core::mem::transmute(&dxgidevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *d2ddevice5 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(d2ddevice5, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2969,7 +2969,7 @@ impl ID2D1Factory7_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDevice7(::core::mem::transmute(&dxgidevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *d2ddevice6 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(d2ddevice6, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2996,7 +2996,7 @@ impl ID2D1GdiInteropRenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetDC(::core::mem::transmute_copy(&mode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *hdc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hdc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3037,7 +3037,7 @@ impl ID2D1GdiMetafile_Vtbl {
             let this = (*this).get_impl();
             match this.GetBounds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3073,7 +3073,7 @@ impl ID2D1GdiMetafile1_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceBounds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3149,7 +3149,7 @@ impl ID2D1Geometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetBounds(::core::mem::transmute_copy(&worldtransform)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3160,7 +3160,7 @@ impl ID2D1Geometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetWidenedBounds(::core::mem::transmute_copy(&strokewidth), ::core::mem::transmute(&strokestyle), ::core::mem::transmute_copy(&worldtransform), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3171,7 +3171,7 @@ impl ID2D1Geometry_Vtbl {
             let this = (*this).get_impl();
             match this.StrokeContainsPoint(::core::mem::transmute(&point), ::core::mem::transmute_copy(&strokewidth), ::core::mem::transmute(&strokestyle), ::core::mem::transmute_copy(&worldtransform), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contains = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contains, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3182,7 +3182,7 @@ impl ID2D1Geometry_Vtbl {
             let this = (*this).get_impl();
             match this.FillContainsPoint(::core::mem::transmute(&point), ::core::mem::transmute_copy(&worldtransform), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contains = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contains, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3193,7 +3193,7 @@ impl ID2D1Geometry_Vtbl {
             let this = (*this).get_impl();
             match this.CompareWithGeometry(::core::mem::transmute(&inputgeometry), ::core::mem::transmute_copy(&inputgeometrytransform), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3224,7 +3224,7 @@ impl ID2D1Geometry_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeArea(::core::mem::transmute_copy(&worldtransform), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *area = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(area, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3235,7 +3235,7 @@ impl ID2D1Geometry_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeLength(::core::mem::transmute_copy(&worldtransform), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3648,7 +3648,7 @@ impl ID2D1ImageSource_Vtbl {
             let this = (*this).get_impl();
             match this.TryReclaimResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcesdiscarded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcesdiscarded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3769,7 +3769,7 @@ impl ID2D1Ink_Vtbl {
             let this = (*this).get_impl();
             match this.GetBounds(::core::mem::transmute(&inkstyle), ::core::mem::transmute_copy(&worldtransform)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3929,7 +3929,7 @@ impl ID2D1Mesh_Vtbl {
             let this = (*this).get_impl();
             match this.Open() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tessellationsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tessellationsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4025,7 +4025,7 @@ impl ID2D1PathGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.Open() {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometrysink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometrysink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4041,7 +4041,7 @@ impl ID2D1PathGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetSegmentCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4052,7 +4052,7 @@ impl ID2D1PathGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetFigureCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4084,7 +4084,7 @@ impl ID2D1PathGeometry1_Vtbl {
             let this = (*this).get_impl();
             match this.ComputePointAndSegmentAtLength(::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&startsegment), ::core::mem::transmute_copy(&worldtransform), ::core::mem::transmute_copy(&flatteningtolerance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pointdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pointdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4200,7 +4200,7 @@ impl ID2D1Properties_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubProperties(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *subproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4434,7 +4434,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmap(::core::mem::transmute(&size), ::core::mem::transmute_copy(&srcdata), ::core::mem::transmute_copy(&pitch), ::core::mem::transmute_copy(&bitmapproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4445,7 +4445,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromWicBitmap(::core::mem::transmute(&wicbitmapsource), ::core::mem::transmute_copy(&bitmapproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4461,7 +4461,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapBrush(::core::mem::transmute(&bitmap), ::core::mem::transmute_copy(&bitmapbrushproperties), ::core::mem::transmute_copy(&brushproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmapbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmapbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4472,7 +4472,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSolidColorBrush(::core::mem::transmute_copy(&color), ::core::mem::transmute_copy(&brushproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *solidcolorbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(solidcolorbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4483,7 +4483,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGradientStopCollection(::core::mem::transmute_copy(&gradientstops), ::core::mem::transmute_copy(&gradientstopscount), ::core::mem::transmute_copy(&colorinterpolationgamma), ::core::mem::transmute_copy(&extendmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *gradientstopcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gradientstopcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4494,7 +4494,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearGradientBrush(::core::mem::transmute_copy(&lineargradientbrushproperties), ::core::mem::transmute_copy(&brushproperties), ::core::mem::transmute(&gradientstopcollection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lineargradientbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lineargradientbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4505,7 +4505,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRadialGradientBrush(::core::mem::transmute_copy(&radialgradientbrushproperties), ::core::mem::transmute_copy(&brushproperties), ::core::mem::transmute(&gradientstopcollection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *radialgradientbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radialgradientbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4516,7 +4516,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCompatibleRenderTarget(::core::mem::transmute_copy(&desiredsize), ::core::mem::transmute_copy(&desiredpixelsize), ::core::mem::transmute_copy(&desiredformat), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmaprendertarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmaprendertarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4527,7 +4527,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLayer(::core::mem::transmute_copy(&size)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *layer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(layer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4538,7 +4538,7 @@ impl ID2D1RenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMesh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mesh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mesh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5091,7 +5091,7 @@ impl ID2D1SvgAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attribute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attribute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5151,7 +5151,7 @@ impl ID2D1SvgDocument_Vtbl {
             let this = (*this).get_impl();
             match this.FindElementById(::core::mem::transmute(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *svgelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(svgelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5167,7 +5167,7 @@ impl ID2D1SvgDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Deserialize(::core::mem::transmute(&inputxmlstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *subtree = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subtree, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5178,7 +5178,7 @@ impl ID2D1SvgDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePaint(::core::mem::transmute_copy(&painttype), ::core::mem::transmute_copy(&color), ::core::mem::transmute(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *paint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5189,7 +5189,7 @@ impl ID2D1SvgDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStrokeDashArray(::core::mem::transmute_copy(&dashes), ::core::mem::transmute_copy(&dashescount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokedasharray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokedasharray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5200,7 +5200,7 @@ impl ID2D1SvgDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePointCollection(::core::mem::transmute_copy(&points), ::core::mem::transmute_copy(&pointscount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pointcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pointcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5211,7 +5211,7 @@ impl ID2D1SvgDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePathData(::core::mem::transmute_copy(&segmentdata), ::core::mem::transmute_copy(&segmentdatacount), ::core::mem::transmute_copy(&commands), ::core::mem::transmute_copy(&commandscount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pathdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pathdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5319,7 +5319,7 @@ impl ID2D1SvgElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousChild(::core::mem::transmute(&referencechild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *previouschild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previouschild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5330,7 +5330,7 @@ impl ID2D1SvgElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextChild(::core::mem::transmute(&referencechild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5361,7 +5361,7 @@ impl ID2D1SvgElement_Vtbl {
             let this = (*this).get_impl();
             match this.CreateChild(::core::mem::transmute(&tagname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5442,7 +5442,7 @@ impl ID2D1SvgElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeValueLength(::core::mem::transmute(&name), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *valuelength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(valuelength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5661,7 +5661,7 @@ impl ID2D1SvgPathData_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePathGeometry(::core::mem::transmute_copy(&fillmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pathgeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pathgeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5839,7 +5839,7 @@ impl ID2D1Transform_Vtbl {
             let this = (*this).get_impl();
             match this.MapInvalidRect(::core::mem::transmute_copy(&inputindex), ::core::mem::transmute(&invalidinputrect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *invalidoutputrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(invalidoutputrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
@@ -9,7 +9,7 @@ impl IDxcAssembler_Vtbl {
             let this = (*this).get_impl();
             match this.AssembleToContainer(::core::mem::transmute(&pshader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -141,7 +141,7 @@ impl IDxcCompiler_Vtbl {
             let this = (*this).get_impl();
             match this.Compile(::core::mem::transmute(&psource), ::core::mem::transmute(&psourcename), ::core::mem::transmute(&pentrypoint), ::core::mem::transmute(&ptargetprofile), ::core::mem::transmute_copy(&parguments), ::core::mem::transmute_copy(&argcount), ::core::mem::transmute_copy(&pdefines), ::core::mem::transmute_copy(&definecount), ::core::mem::transmute(&pincludehandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -152,7 +152,7 @@ impl IDxcCompiler_Vtbl {
             let this = (*this).get_impl();
             match this.Preprocess(::core::mem::transmute(&psource), ::core::mem::transmute(&psourcename), ::core::mem::transmute_copy(&parguments), ::core::mem::transmute_copy(&argcount), ::core::mem::transmute_copy(&pdefines), ::core::mem::transmute_copy(&definecount), ::core::mem::transmute(&pincludehandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -163,7 +163,7 @@ impl IDxcCompiler_Vtbl {
             let this = (*this).get_impl();
             match this.Disassemble(::core::mem::transmute(&psource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisassembly = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisassembly, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -315,7 +315,7 @@ impl IDxcContainerBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.SerializeContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -354,7 +354,7 @@ impl IDxcContainerReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -365,7 +365,7 @@ impl IDxcContainerReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartKind(::core::mem::transmute_copy(&idx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -376,7 +376,7 @@ impl IDxcContainerReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartContent(::core::mem::transmute_copy(&idx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -387,7 +387,7 @@ impl IDxcContainerReflection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstPartKind(::core::mem::transmute_copy(&kind)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -450,7 +450,7 @@ impl IDxcIncludeHandler_Vtbl {
             let this = (*this).get_impl();
             match this.LoadSource(::core::mem::transmute(&pfilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppincludesource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppincludesource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -490,7 +490,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlobFromBlob(::core::mem::transmute(&pblob), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&length)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -501,7 +501,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlobFromFile(::core::mem::transmute(&pfilename), ::core::mem::transmute_copy(&codepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -512,7 +512,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlobWithEncodingFromPinned(::core::mem::transmute_copy(&ptext), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&codepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -523,7 +523,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlobWithEncodingOnHeapCopy(::core::mem::transmute_copy(&ptext), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&codepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -534,7 +534,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlobWithEncodingOnMalloc(::core::mem::transmute_copy(&ptext), ::core::mem::transmute(&pimalloc), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&codepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -545,7 +545,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateIncludeHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStreamFromBlobReadOnly(::core::mem::transmute(&pblob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -567,7 +567,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlobAsUtf8(::core::mem::transmute(&pblob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -578,7 +578,7 @@ impl IDxcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlobAsUtf16(::core::mem::transmute(&pblob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -619,7 +619,7 @@ impl IDxcLinker_Vtbl {
             let this = (*this).get_impl();
             match this.Link(::core::mem::transmute(&pentryname), ::core::mem::transmute(&ptargetprofile), ::core::mem::transmute_copy(&plibnames), ::core::mem::transmute_copy(&libcount), ::core::mem::transmute_copy(&parguments), ::core::mem::transmute_copy(&argcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl IDxcOperationResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -659,7 +659,7 @@ impl IDxcOperationResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -670,7 +670,7 @@ impl IDxcOperationResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperrors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperrors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -700,7 +700,7 @@ impl IDxcOptimizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailablePassCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -711,7 +711,7 @@ impl IDxcOptimizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailablePass(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -748,7 +748,7 @@ impl IDxcOptimizerPass_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -759,7 +759,7 @@ impl IDxcOptimizerPass_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -770,7 +770,7 @@ impl IDxcOptimizerPass_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionArgCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -781,7 +781,7 @@ impl IDxcOptimizerPass_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionArgName(::core::mem::transmute_copy(&argindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -792,7 +792,7 @@ impl IDxcOptimizerPass_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionArgDescription(::core::mem::transmute_copy(&argindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -853,7 +853,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -864,7 +864,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetSource(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -875,7 +875,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceName(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -886,7 +886,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlagCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -897,7 +897,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlag(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -908,7 +908,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetArgCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -919,7 +919,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetArg(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -930,7 +930,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetArgPairCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -946,7 +946,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefineCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -957,7 +957,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefine(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -968,7 +968,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -979,7 +979,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntryPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -990,7 +990,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetMainFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1001,7 +1001,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1012,7 +1012,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1028,7 +1028,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullPDB() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfullpdb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfullpdb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1039,7 +1039,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppversioninfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppversioninfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1055,7 +1055,7 @@ impl IDxcPdbUtils_Vtbl {
             let this = (*this).get_impl();
             match this.CompileForFullPDB() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1180,7 +1180,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlobFromBlob(::core::mem::transmute(&pblob), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&length)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1191,7 +1191,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlobFromPinned(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&codepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1202,7 +1202,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.MoveToBlob(::core::mem::transmute_copy(&pdata), ::core::mem::transmute(&pimalloc), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&codepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1213,7 +1213,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlob(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&codepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1224,7 +1224,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.LoadFile(::core::mem::transmute(&pfilename), ::core::mem::transmute_copy(&pcodepage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1235,7 +1235,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.CreateReadOnlyStreamFromBlob(::core::mem::transmute(&pblob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1246,7 +1246,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDefaultIncludeHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1257,7 +1257,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlobAsUtf8(::core::mem::transmute(&pblob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1268,7 +1268,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlobAsUtf16(::core::mem::transmute(&pblob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblobencoding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblobencoding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1289,7 +1289,7 @@ impl IDxcUtils_Vtbl {
             let this = (*this).get_impl();
             match this.BuildArguments(::core::mem::transmute(&psourcename), ::core::mem::transmute(&pentrypoint), ::core::mem::transmute(&ptargetprofile), ::core::mem::transmute_copy(&parguments), ::core::mem::transmute_copy(&argcount), ::core::mem::transmute_copy(&pdefines), ::core::mem::transmute_copy(&definecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppargs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppargs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1332,7 +1332,7 @@ impl IDxcValidator_Vtbl {
             let this = (*this).get_impl();
             match this.Validate(::core::mem::transmute(&pshader), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1355,7 +1355,7 @@ impl IDxcValidator2_Vtbl {
             let this = (*this).get_impl();
             match this.ValidateWithDebug(::core::mem::transmute(&pshader), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&poptdebugbitcode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1384,7 +1384,7 @@ impl IDxcVersionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1428,7 +1428,7 @@ impl IDxcVersionInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomVersionString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pversionstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pversionstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
@@ -37,7 +37,7 @@ impl ID3DDestructionNotifier_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterDestructionCallback(::core::mem::transmute(&callbackfn), ::core::mem::transmute_copy(&pdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcallbackid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcallbackid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
@@ -175,7 +175,7 @@ impl ID3D10Debug_Vtbl {
             let this = (*this).get_impl();
             match this.GetSwapChain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -689,7 +689,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBuffer(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -700,7 +700,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture1D(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture1d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture1d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -711,7 +711,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture2D(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture2d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture2d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -722,7 +722,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture3D(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -733,7 +733,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateShaderResourceView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsrview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsrview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -744,7 +744,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRenderTargetView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprtview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprtview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -755,7 +755,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDepthStencilView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdepthstencilview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdepthstencilview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -766,7 +766,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInputLayout(::core::mem::transmute_copy(&pinputelementdescs), ::core::mem::transmute_copy(&numelements), ::core::mem::transmute_copy(&pshaderbytecodewithinputsignature), ::core::mem::transmute_copy(&bytecodelength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinputlayout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinputlayout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -777,7 +777,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVertexShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvertexshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvertexshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -788,7 +788,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeometryShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgeometryshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgeometryshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -799,7 +799,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeometryShaderWithStreamOutput(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute_copy(&psodeclaration), ::core::mem::transmute_copy(&numentries), ::core::mem::transmute_copy(&outputstreamstride)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgeometryshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgeometryshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -810,7 +810,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePixelShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppixelshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppixelshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -821,7 +821,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlendState(::core::mem::transmute_copy(&pblendstatedesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppblendstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppblendstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -832,7 +832,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDepthStencilState(::core::mem::transmute_copy(&pdepthstencildesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdepthstencilstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdepthstencilstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -843,7 +843,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRasterizerState(::core::mem::transmute_copy(&prasterizerdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprasterizerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprasterizerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -854,7 +854,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSamplerState(::core::mem::transmute_copy(&psamplerdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsamplerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsamplerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -865,7 +865,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQuery(::core::mem::transmute_copy(&pquerydesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -876,7 +876,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePredicate(::core::mem::transmute_copy(&ppredicatedesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppredicate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppredicate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -887,7 +887,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCounter(::core::mem::transmute_copy(&pcounterdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcounter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcounter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -898,7 +898,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CheckFormatSupport(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformatsupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformatsupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -909,7 +909,7 @@ impl ID3D10Device_Vtbl {
             let this = (*this).get_impl();
             match this.CheckMultisampleQualityLevels(::core::mem::transmute_copy(&format), ::core::mem::transmute_copy(&samplecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumqualitylevels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumqualitylevels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1064,7 +1064,7 @@ impl ID3D10Device1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateShaderResourceView1(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsrview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsrview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1075,7 +1075,7 @@ impl ID3D10Device1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlendState1(::core::mem::transmute_copy(&pblendstatedesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppblendstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppblendstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1174,7 +1174,7 @@ impl ID3D10Effect_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1185,7 +1185,7 @@ impl ID3D10Effect_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1272,7 +1272,7 @@ impl ID3D10EffectBlendVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlendState(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppblendstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppblendstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1315,7 +1315,7 @@ impl ID3D10EffectConstantBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetConstantBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconstantbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconstantbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1331,7 +1331,7 @@ impl ID3D10EffectConstantBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextureBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexturebuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexturebuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1364,7 +1364,7 @@ impl ID3D10EffectDepthStencilVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetDepthStencilState(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdepthstencilstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdepthstencilstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1375,7 +1375,7 @@ impl ID3D10EffectDepthStencilVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackingStore(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdepthstencildesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdepthstencildesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1413,7 +1413,7 @@ impl ID3D10EffectDepthStencilViewVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetDepthStencil() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1575,7 +1575,7 @@ impl ID3D10EffectPass_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeStateBlockMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstateblockmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstateblockmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1629,7 +1629,7 @@ impl ID3D10EffectRasterizerVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetRasterizerState(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprasterizerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprasterizerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1640,7 +1640,7 @@ impl ID3D10EffectRasterizerVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackingStore(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prasterizerdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prasterizerdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1678,7 +1678,7 @@ impl ID3D10EffectRenderTargetViewVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1721,7 +1721,7 @@ impl ID3D10EffectSamplerVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetSampler(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsampler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsampler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1732,7 +1732,7 @@ impl ID3D10EffectSamplerVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackingStore(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psamplerdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psamplerdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1778,7 +1778,7 @@ impl ID3D10EffectScalarVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetFloat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1804,7 +1804,7 @@ impl ID3D10EffectScalarVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetInt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1830,7 +1830,7 @@ impl ID3D10EffectScalarVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetBool() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1888,7 +1888,7 @@ impl ID3D10EffectShaderResourceVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1935,7 +1935,7 @@ impl ID3D10EffectShaderVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetShaderDesc(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1946,7 +1946,7 @@ impl ID3D10EffectShaderVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetVertexShader(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1957,7 +1957,7 @@ impl ID3D10EffectShaderVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeometryShader(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1968,7 +1968,7 @@ impl ID3D10EffectShaderVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelShader(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1979,7 +1979,7 @@ impl ID3D10EffectShaderVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputSignatureElementDesc(::core::mem::transmute_copy(&shaderindex), ::core::mem::transmute_copy(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1990,7 +1990,7 @@ impl ID3D10EffectShaderVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputSignatureElementDesc(::core::mem::transmute_copy(&shaderindex), ::core::mem::transmute_copy(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2025,7 +2025,7 @@ impl ID3D10EffectStringVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2096,7 +2096,7 @@ impl ID3D10EffectTechnique_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeStateBlockMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstateblockmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstateblockmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2228,7 +2228,7 @@ impl ID3D10EffectVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2948,7 +2948,7 @@ impl ID3D10ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2969,7 +2969,7 @@ impl ID3D10ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2980,7 +2980,7 @@ impl ID3D10ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2991,7 +2991,7 @@ impl ID3D10ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3039,7 +3039,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3060,7 +3060,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3071,7 +3071,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3082,7 +3082,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3098,7 +3098,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDescByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3109,7 +3109,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetMovInstructionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3120,7 +3120,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetMovcInstructionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3131,7 +3131,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetConversionInstructionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3142,7 +3142,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitwiseInstructionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3153,7 +3153,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetGSInputPrimitive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprim = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprim, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3164,7 +3164,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.IsLevel9Shader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblevel9shader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblevel9shader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3175,7 +3175,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             let this = (*this).get_impl();
             match this.IsSampleFrequencyShader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsamplefrequency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsamplefrequency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3220,7 +3220,7 @@ impl ID3D10ShaderReflectionConstantBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3301,7 +3301,7 @@ impl ID3D10ShaderReflectionVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3387,7 +3387,7 @@ impl ID3D10StateBlock_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3488,7 +3488,7 @@ impl ID3D10Texture2D_Vtbl {
             let this = (*this).get_impl();
             match this.Map(::core::mem::transmute_copy(&subresource), ::core::mem::transmute_copy(&maptype), ::core::mem::transmute_copy(&mapflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmappedtex2d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmappedtex2d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3531,7 +3531,7 @@ impl ID3D10Texture3D_Vtbl {
             let this = (*this).get_impl();
             match this.Map(::core::mem::transmute_copy(&subresource), ::core::mem::transmute_copy(&maptype), ::core::mem::transmute_copy(&mapflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmappedtex3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmappedtex3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
@@ -31,7 +31,7 @@ impl ID3D11AuthenticatedChannel_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcertificatesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcertificatesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl ID3D11AuthenticatedChannel_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificate(::core::mem::transmute_copy(&certificatesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcertificate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcertificate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -177,7 +177,7 @@ impl ID3D11ClassLinkage_Vtbl {
             let this = (*this).get_impl();
             match this.GetClassInstance(::core::mem::transmute(&pclassinstancename), ::core::mem::transmute_copy(&instanceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -188,7 +188,7 @@ impl ID3D11ClassLinkage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClassInstance(::core::mem::transmute(&pclasstypename), ::core::mem::transmute_copy(&constantbufferoffset), ::core::mem::transmute_copy(&constantvectoroffset), ::core::mem::transmute_copy(&textureoffset), ::core::mem::transmute_copy(&sampleroffset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl ID3D11CryptoSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcertificatesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcertificatesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -287,7 +287,7 @@ impl ID3D11CryptoSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificate(::core::mem::transmute_copy(&certificatesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcertificate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcertificate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl ID3D11Debug_Vtbl {
             let this = (*this).get_impl();
             match this.GetSwapChain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -489,7 +489,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBuffer(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -500,7 +500,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture1D(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture1d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture1d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -511,7 +511,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture2D(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture2d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture2d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -522,7 +522,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture3D(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -533,7 +533,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateShaderResourceView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsrview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsrview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -544,7 +544,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUnorderedAccessView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuaview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuaview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -555,7 +555,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRenderTargetView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprtview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprtview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -566,7 +566,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDepthStencilView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdepthstencilview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdepthstencilview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -577,7 +577,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInputLayout(::core::mem::transmute_copy(&pinputelementdescs), ::core::mem::transmute_copy(&numelements), ::core::mem::transmute_copy(&pshaderbytecodewithinputsignature), ::core::mem::transmute_copy(&bytecodelength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinputlayout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinputlayout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -588,7 +588,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVertexShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute(&pclasslinkage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvertexshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvertexshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -599,7 +599,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeometryShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute(&pclasslinkage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgeometryshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgeometryshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -610,7 +610,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeometryShaderWithStreamOutput(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute_copy(&psodeclaration), ::core::mem::transmute_copy(&numentries), ::core::mem::transmute_copy(&pbufferstrides), ::core::mem::transmute_copy(&numstrides), ::core::mem::transmute_copy(&rasterizedstream), ::core::mem::transmute(&pclasslinkage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgeometryshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgeometryshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -621,7 +621,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePixelShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute(&pclasslinkage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppixelshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppixelshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -632,7 +632,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateHullShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute(&pclasslinkage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphullshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphullshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -643,7 +643,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDomainShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute(&pclasslinkage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdomainshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdomainshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -654,7 +654,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateComputeShader(::core::mem::transmute_copy(&pshaderbytecode), ::core::mem::transmute_copy(&bytecodelength), ::core::mem::transmute(&pclasslinkage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomputeshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomputeshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -665,7 +665,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClassLinkage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplinkage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplinkage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -676,7 +676,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlendState(::core::mem::transmute_copy(&pblendstatedesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppblendstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppblendstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -687,7 +687,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDepthStencilState(::core::mem::transmute_copy(&pdepthstencildesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdepthstencilstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdepthstencilstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -698,7 +698,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRasterizerState(::core::mem::transmute_copy(&prasterizerdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprasterizerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprasterizerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -709,7 +709,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSamplerState(::core::mem::transmute_copy(&psamplerdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsamplerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsamplerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -720,7 +720,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQuery(::core::mem::transmute_copy(&pquerydesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -731,7 +731,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePredicate(::core::mem::transmute_copy(&ppredicatedesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppredicate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppredicate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -742,7 +742,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCounter(::core::mem::transmute_copy(&pcounterdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcounter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcounter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -753,7 +753,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeferredContext(::core::mem::transmute_copy(&contextflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdeferredcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdeferredcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -769,7 +769,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CheckFormatSupport(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformatsupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformatsupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -780,7 +780,7 @@ impl ID3D11Device_Vtbl {
             let this = (*this).get_impl();
             match this.CheckMultisampleQualityLevels(::core::mem::transmute_copy(&format), ::core::mem::transmute_copy(&samplecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumqualitylevels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumqualitylevels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -919,7 +919,7 @@ impl ID3D11Device1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeferredContext1(::core::mem::transmute_copy(&contextflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdeferredcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdeferredcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -930,7 +930,7 @@ impl ID3D11Device1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlendState1(::core::mem::transmute_copy(&pblendstatedesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppblendstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppblendstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -941,7 +941,7 @@ impl ID3D11Device1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRasterizerState1(::core::mem::transmute_copy(&prasterizerdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprasterizerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprasterizerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -999,7 +999,7 @@ impl ID3D11Device2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeferredContext2(::core::mem::transmute_copy(&contextflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdeferredcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdeferredcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1015,7 +1015,7 @@ impl ID3D11Device2_Vtbl {
             let this = (*this).get_impl();
             match this.CheckMultisampleQualityLevels1(::core::mem::transmute_copy(&format), ::core::mem::transmute_copy(&samplecount), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumqualitylevels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumqualitylevels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1057,7 +1057,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture2D1(::core::mem::transmute_copy(&pdesc1), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture2d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture2d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1068,7 +1068,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTexture3D1(::core::mem::transmute_copy(&pdesc1), ::core::mem::transmute_copy(&pinitialdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1079,7 +1079,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRasterizerState2(::core::mem::transmute_copy(&prasterizerdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprasterizerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprasterizerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1090,7 +1090,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateShaderResourceView1(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsrview1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsrview1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1101,7 +1101,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUnorderedAccessView1(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuaview1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuaview1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1112,7 +1112,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRenderTargetView1(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprtview1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprtview1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1123,7 +1123,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQuery1(::core::mem::transmute_copy(&pquerydesc1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppquery1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppquery1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1139,7 +1139,7 @@ impl ID3D11Device3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDeferredContext3(::core::mem::transmute_copy(&contextflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdeferredcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdeferredcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1189,7 +1189,7 @@ impl ID3D11Device4_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterDeviceRemovedEvent(::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1437,7 +1437,7 @@ impl ID3D11DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.Map(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&subresource), ::core::mem::transmute_copy(&maptype), ::core::mem::transmute_copy(&mapflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmappedresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmappedresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1943,7 +1943,7 @@ impl ID3D11DeviceContext_Vtbl {
             let this = (*this).get_impl();
             match this.FinishCommandList(::core::mem::transmute_copy(&restoredeferredcontextstate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcommandlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcommandlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2394,7 +2394,7 @@ impl ID3D11Fence_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSharedHandle(::core::mem::transmute_copy(&pattributes), ::core::mem::transmute_copy(&dwaccess), ::core::mem::transmute(&lpname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2447,7 +2447,7 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
             let this = (*this).get_impl();
             match this.SetInputSignature(::core::mem::transmute_copy(&pinputparameters), ::core::mem::transmute_copy(&cinputparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinputnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinputnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2458,7 +2458,7 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
             let this = (*this).get_impl();
             match this.SetOutputSignature(::core::mem::transmute_copy(&poutputparameters), ::core::mem::transmute_copy(&coutputparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutputnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutputnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2469,7 +2469,7 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
             let this = (*this).get_impl();
             match this.CallFunction(::core::mem::transmute(&pmoduleinstancenamespace), ::core::mem::transmute(&pmodulewithfunctionprototype), ::core::mem::transmute(&pfunctionname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2490,7 +2490,7 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperrorbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperrorbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2501,7 +2501,7 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateHlsl(::core::mem::transmute_copy(&uflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2537,7 +2537,7 @@ impl ID3D11FunctionParameterReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2569,7 +2569,7 @@ impl ID3D11FunctionReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2590,7 +2590,7 @@ impl ID3D11FunctionReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2606,7 +2606,7 @@ impl ID3D11FunctionReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDescByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2934,7 +2934,7 @@ impl ID3D11LibraryReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3013,7 +3013,7 @@ impl ID3D11Module_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute(&pnamespace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmoduleinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmoduleinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3423,7 +3423,7 @@ impl ID3D11ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3444,7 +3444,7 @@ impl ID3D11ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3455,7 +3455,7 @@ impl ID3D11ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3466,7 +3466,7 @@ impl ID3D11ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3477,7 +3477,7 @@ impl ID3D11ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetPatchConstantParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3493,7 +3493,7 @@ impl ID3D11ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDescByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3539,7 +3539,7 @@ impl ID3D11ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinFeatureLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3642,7 +3642,7 @@ impl ID3D11ShaderReflectionType_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3730,7 +3730,7 @@ impl ID3D11ShaderReflectionVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3823,7 +3823,7 @@ impl ID3D11ShaderTrace_Vtbl {
             let this = (*this).get_impl();
             match this.TraceReady() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptestcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptestcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3839,7 +3839,7 @@ impl ID3D11ShaderTrace_Vtbl {
             let this = (*this).get_impl();
             match this.GetTraceStats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptracestats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptracestats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3855,7 +3855,7 @@ impl ID3D11ShaderTrace_Vtbl {
             let this = (*this).get_impl();
             match this.GetInitialRegisterContents(::core::mem::transmute_copy(&pregister)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3866,7 +3866,7 @@ impl ID3D11ShaderTrace_Vtbl {
             let this = (*this).get_impl();
             match this.GetStep(::core::mem::transmute_copy(&stepindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptracestep = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptracestep, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3909,7 +3909,7 @@ impl ID3D11ShaderTraceFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateShaderTrace(::core::mem::transmute(&pshader), ::core::mem::transmute_copy(&ptracedesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshadertrace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshadertrace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4474,7 +4474,7 @@ impl ID3D11VideoContext_Vtbl {
             let this = (*this).get_impl();
             match this.ConfigureAuthenticatedChannel(::core::mem::transmute(&pchannel), ::core::mem::transmute_copy(&inputsize), ::core::mem::transmute_copy(&pinput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4588,7 +4588,7 @@ impl ID3D11VideoContext1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataForNewHardwareKey(::core::mem::transmute(&pcryptosession), ::core::mem::transmute_copy(&privateinputsize), ::core::mem::transmute_copy(&pprivatinputdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprivateoutputdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprivateoutputdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4599,7 +4599,7 @@ impl ID3D11VideoContext1_Vtbl {
             let this = (*this).get_impl();
             match this.CheckCryptoSessionStatus(::core::mem::transmute(&pcryptosession)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4660,7 +4660,7 @@ impl ID3D11VideoContext1_Vtbl {
             let this = (*this).get_impl();
             match this.VideoProcessorGetBehaviorHints(::core::mem::transmute(&pvideoprocessor), ::core::mem::transmute_copy(&outputwidth), ::core::mem::transmute_copy(&outputheight), ::core::mem::transmute_copy(&outputformat), ::core::mem::transmute_copy(&streamcount), ::core::mem::transmute_copy(&pstreams)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbehaviorhints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbehaviorhints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4782,7 +4782,7 @@ impl ID3D11VideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetDriverHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdriverhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdriverhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4845,7 +4845,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoDecoder(::core::mem::transmute_copy(&pvideodesc), ::core::mem::transmute_copy(&pconfig)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdecoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdecoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4856,7 +4856,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoProcessor(::core::mem::transmute(&penum), ::core::mem::transmute_copy(&rateconversionindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvideoprocessor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvideoprocessor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4867,7 +4867,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAuthenticatedChannel(::core::mem::transmute_copy(&channeltype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppauthenticatedchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppauthenticatedchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4878,7 +4878,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCryptoSession(::core::mem::transmute_copy(&pcryptotype), ::core::mem::transmute_copy(&pdecoderprofile), ::core::mem::transmute_copy(&pkeyexchangetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcryptosession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcryptosession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4889,7 +4889,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoDecoderOutputView(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvdovview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvdovview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4900,7 +4900,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoProcessorInputView(::core::mem::transmute(&presource), ::core::mem::transmute(&penum), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvpiview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvpiview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4911,7 +4911,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoProcessorOutputView(::core::mem::transmute(&presource), ::core::mem::transmute(&penum), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvpoview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvpoview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4922,7 +4922,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoProcessorEnumerator(::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4938,7 +4938,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoDecoderProfile(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdecoderprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdecoderprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4949,7 +4949,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CheckVideoDecoderFormat(::core::mem::transmute_copy(&pdecoderprofile), ::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4960,7 +4960,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoDecoderConfigCount(::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4971,7 +4971,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoDecoderConfig(::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4982,7 +4982,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentProtectionCaps(::core::mem::transmute_copy(&pcryptotype), ::core::mem::transmute_copy(&pdecoderprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4993,7 +4993,7 @@ impl ID3D11VideoDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CheckCryptoKeyExchange(::core::mem::transmute_copy(&pcryptotype), ::core::mem::transmute_copy(&pdecoderprofile), ::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkeyexchangetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkeyexchangetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5056,7 +5056,7 @@ impl ID3D11VideoDevice1_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoDecoderCaps(::core::mem::transmute_copy(&pdecoderprofile), ::core::mem::transmute_copy(&samplewidth), ::core::mem::transmute_copy(&sampleheight), ::core::mem::transmute_copy(&pframerate), ::core::mem::transmute_copy(&bitrate), ::core::mem::transmute_copy(&pcryptotype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdecodercaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdecodercaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5072,7 +5072,7 @@ impl ID3D11VideoDevice1_Vtbl {
             let this = (*this).get_impl();
             match this.RecommendVideoDecoderDownsampleParameters(::core::mem::transmute_copy(&pinputdesc), ::core::mem::transmute_copy(&inputcolorspace), ::core::mem::transmute_copy(&pinputconfig), ::core::mem::transmute_copy(&pframerate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *precommendedoutputdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precommendedoutputdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5169,7 +5169,7 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorContentDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontentdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontentdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5180,7 +5180,7 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.CheckVideoProcessorFormat(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5191,7 +5191,7 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5202,7 +5202,7 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorRateConversionCaps(::core::mem::transmute_copy(&typeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5213,7 +5213,7 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorCustomRate(::core::mem::transmute_copy(&typeindex), ::core::mem::transmute_copy(&customrateindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5224,7 +5224,7 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorFilterRange(::core::mem::transmute_copy(&filter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5258,7 +5258,7 @@ impl ID3D11VideoProcessorEnumerator1_Vtbl {
             let this = (*this).get_impl();
             match this.CheckVideoProcessorFormatConversion(::core::mem::transmute_copy(&inputformat), ::core::mem::transmute_copy(&inputcolorspace), ::core::mem::transmute_copy(&outputformat), ::core::mem::transmute_copy(&outputcolorspace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
@@ -96,7 +96,7 @@ impl ID3D12CommandQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimestampFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrequency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrequency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -715,7 +715,7 @@ impl ID3D12Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSharedHandle(::core::mem::transmute(&pobject), ::core::mem::transmute_copy(&pattributes), ::core::mem::transmute_copy(&access), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -731,7 +731,7 @@ impl ID3D12Device_Vtbl {
             let this = (*this).get_impl();
             match this.OpenSharedHandleByName(::core::mem::transmute(&name), ::core::mem::transmute_copy(&access)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnthandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnthandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1070,7 +1070,7 @@ impl ID3D12Device6_Vtbl {
             let this = (*this).get_impl();
             match this.SetBackgroundProcessingMode(::core::mem::transmute_copy(&mode), ::core::mem::transmute_copy(&measurementsaction), ::core::mem::transmute_copy(&heventtosignaluponcompletion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbfurthermeasurementsdesired = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbfurthermeasurementsdesired, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1229,7 +1229,7 @@ impl ID3D12DeviceRemovedExtendedData_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutoBreadcrumbsOutput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1240,7 +1240,7 @@ impl ID3D12DeviceRemovedExtendedData_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageFaultAllocationOutput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1268,7 +1268,7 @@ impl ID3D12DeviceRemovedExtendedData1_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutoBreadcrumbsOutput1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1279,7 +1279,7 @@ impl ID3D12DeviceRemovedExtendedData1_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageFaultAllocationOutput1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1307,7 +1307,7 @@ impl ID3D12DeviceRemovedExtendedData2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageFaultAllocationOutput2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1453,7 +1453,7 @@ impl ID3D12FunctionParameterReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1485,7 +1485,7 @@ impl ID3D12FunctionReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1506,7 +1506,7 @@ impl ID3D12FunctionReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1522,7 +1522,7 @@ impl ID3D12FunctionReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDescByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2487,7 +2487,7 @@ impl ID3D12LibraryReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2698,7 +2698,7 @@ impl ID3D12PipelineState_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedBlob() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppblob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppblob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3003,7 +3003,7 @@ impl ID3D12ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3024,7 +3024,7 @@ impl ID3D12ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3035,7 +3035,7 @@ impl ID3D12ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3046,7 +3046,7 @@ impl ID3D12ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3057,7 +3057,7 @@ impl ID3D12ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetPatchConstantParameterDesc(::core::mem::transmute_copy(&parameterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3073,7 +3073,7 @@ impl ID3D12ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceBindingDescByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3119,7 +3119,7 @@ impl ID3D12ShaderReflection_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinFeatureLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3222,7 +3222,7 @@ impl ID3D12ShaderReflectionType_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3310,7 +3310,7 @@ impl ID3D12ShaderReflectionVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl ID3D12VersionedRootSignatureDeserializer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootSignatureDescAtVersion(::core::mem::transmute_copy(&converttoversion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
@@ -241,7 +241,7 @@ impl IDirect3DCubeTexture9_Vtbl {
             let this = (*this).get_impl();
             match this.GetCubeMapSurface(::core::mem::transmute_copy(&facetype), ::core::mem::transmute_copy(&level)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcubemapsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcubemapsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -419,7 +419,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirect3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppd3d9 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppd3d9, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -465,7 +465,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetSwapChain(::core::mem::transmute_copy(&iswapchain)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -491,7 +491,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackBuffer(::core::mem::transmute_copy(&iswapchain), ::core::mem::transmute_copy(&ibackbuffer), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbackbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbackbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -597,7 +597,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderTarget(::core::mem::transmute_copy(&rendertargetindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprendertarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprendertarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -613,7 +613,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDepthStencilSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppzstencilsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppzstencilsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -714,7 +714,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStateBlock(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -730,7 +730,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.EndStateBlock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -751,7 +751,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetTexture(::core::mem::transmute_copy(&stage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -867,7 +867,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVertexDeclaration(::core::mem::transmute_copy(&pvertexelements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdecl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdecl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -883,7 +883,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetVertexDeclaration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdecl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdecl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -904,7 +904,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVertexShader(::core::mem::transmute_copy(&pfunction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -920,7 +920,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetVertexShader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -986,7 +986,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppindexdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppindexdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -997,7 +997,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePixelShader(::core::mem::transmute_copy(&pfunction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1013,7 +1013,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelShader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1069,7 +1069,7 @@ impl IDirect3DDevice9_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQuery(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1366,7 +1366,7 @@ impl IDirect3DPixelShader9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1402,7 +1402,7 @@ impl IDirect3DQuery9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1459,7 +1459,7 @@ impl IDirect3DResource9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1529,7 +1529,7 @@ impl IDirect3DStateBlock9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1644,7 +1644,7 @@ impl IDirect3DSwapChain9_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackBuffer(::core::mem::transmute_copy(&ibackbuffer), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbackbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbackbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1665,7 +1665,7 @@ impl IDirect3DSwapChain9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1751,7 +1751,7 @@ impl IDirect3DTexture9_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurfaceLevel(::core::mem::transmute_copy(&level)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsurfacelevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsurfacelevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1831,7 +1831,7 @@ impl IDirect3DVertexDeclaration9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1864,7 +1864,7 @@ impl IDirect3DVertexShader9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1903,7 +1903,7 @@ impl IDirect3DVolume9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1980,7 +1980,7 @@ impl IDirect3DVolumeTexture9_Vtbl {
             let this = (*this).get_impl();
             match this.GetVolumeLevel(::core::mem::transmute_copy(&level)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvolumelevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvolumelevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
@@ -408,7 +408,7 @@ impl IDCompositionDelegatedInkTrail_Vtbl {
             let this = (*this).get_impl();
             match this.AddTrailPoints(::core::mem::transmute_copy(&inkpoints), ::core::mem::transmute_copy(&inkpointscount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *generationid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(generationid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -419,7 +419,7 @@ impl IDCompositionDelegatedInkTrail_Vtbl {
             let this = (*this).get_impl();
             match this.AddTrailPointsWithPrediction(::core::mem::transmute_copy(&inkpoints), ::core::mem::transmute_copy(&inkpointscount), ::core::mem::transmute_copy(&predictedinkpoints), ::core::mem::transmute_copy(&predictedinkpointscount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *generationid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(generationid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -463,7 +463,7 @@ impl IDCompositionDesktopDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTargetForHwnd(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&topmost)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *target = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(target, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -474,7 +474,7 @@ impl IDCompositionDesktopDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurfaceFromHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -485,7 +485,7 @@ impl IDCompositionDesktopDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurfaceFromHwnd(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -549,7 +549,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameStatistics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *statistics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(statistics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -560,7 +560,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTargetForHwnd(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&topmost)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *target = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(target, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -571,7 +571,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVisual() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -582,7 +582,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurface(::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&alphamode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -593,7 +593,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVirtualSurface(::core::mem::transmute_copy(&initialwidth), ::core::mem::transmute_copy(&initialheight), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&alphamode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *virtualsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(virtualsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -604,7 +604,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurfaceFromHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -615,7 +615,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurfaceFromHwnd(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -626,7 +626,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTranslateTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *translatetransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(translatetransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -637,7 +637,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateScaleTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scaletransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scaletransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRotateTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rotatetransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rotatetransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -659,7 +659,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSkewTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *skewtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(skewtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -670,7 +670,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMatrixTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrixtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrixtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -681,7 +681,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransformGroup(::core::mem::transmute_copy(&transforms), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -692,7 +692,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTranslateTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *translatetransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(translatetransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -703,7 +703,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateScaleTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scaletransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scaletransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -714,7 +714,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRotateTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rotatetransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rotatetransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -725,7 +725,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMatrixTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrixtransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrixtransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -736,7 +736,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransform3DGroup(::core::mem::transmute_copy(&transforms3d), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform3dgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform3dgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -747,7 +747,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEffectGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *effectgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(effectgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -758,7 +758,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRectangleClip() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -769,7 +769,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAnimation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *animation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(animation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -780,7 +780,7 @@ impl IDCompositionDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CheckDeviceState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -862,7 +862,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameStatistics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *statistics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(statistics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -873,7 +873,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVisual() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -884,7 +884,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurfaceFactory(::core::mem::transmute(&renderingdevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surfacefactory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surfacefactory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -895,7 +895,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurface(::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&alphamode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -906,7 +906,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVirtualSurface(::core::mem::transmute_copy(&initialwidth), ::core::mem::transmute_copy(&initialheight), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&alphamode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *virtualsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(virtualsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -917,7 +917,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTranslateTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *translatetransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(translatetransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -928,7 +928,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateScaleTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scaletransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scaletransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -939,7 +939,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRotateTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rotatetransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rotatetransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -950,7 +950,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSkewTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *skewtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(skewtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -961,7 +961,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMatrixTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrixtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrixtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -972,7 +972,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransformGroup(::core::mem::transmute_copy(&transforms), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -983,7 +983,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTranslateTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *translatetransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(translatetransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -994,7 +994,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateScaleTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scaletransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scaletransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1005,7 +1005,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRotateTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rotatetransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rotatetransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1016,7 +1016,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMatrixTransform3D() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrixtransform3d = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrixtransform3d, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1027,7 +1027,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransform3DGroup(::core::mem::transmute_copy(&transforms3d), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform3dgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform3dgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1038,7 +1038,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEffectGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *effectgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(effectgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1049,7 +1049,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRectangleClip() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1060,7 +1060,7 @@ impl IDCompositionDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAnimation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *animation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(animation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1121,7 +1121,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGaussianBlurEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *gaussianblureffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gaussianblureffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1132,7 +1132,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBrightnessEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *brightnesseffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(brightnesseffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1143,7 +1143,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorMatrixEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *colormatrixeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colormatrixeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1154,7 +1154,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateShadowEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *shadoweffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(shadoweffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1165,7 +1165,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateHueRotationEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *huerotationeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(huerotationeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1176,7 +1176,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSaturationEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *saturationeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(saturationeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1187,7 +1187,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTurbulenceEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *turbulenceeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(turbulenceeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1198,7 +1198,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearTransferEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lineartransfereffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lineartransfereffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1209,7 +1209,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTableTransferEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tabletransfereffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tabletransfereffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1220,7 +1220,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCompositeEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *compositeeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(compositeeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1231,7 +1231,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlendEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blendeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blendeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1242,7 +1242,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateArithmeticCompositeEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *arithmeticcompositeeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(arithmeticcompositeeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1253,7 +1253,7 @@ impl IDCompositionDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAffineTransform2DEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *affinetransform2deffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(affinetransform2deffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1444,7 +1444,7 @@ impl IDCompositionInkTrailDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDelegatedInkTrail() {
                 ::core::result::Result::Ok(ok__) => {
-                    *inktrail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inktrail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1455,7 +1455,7 @@ impl IDCompositionInkTrailDevice_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDelegatedInkTrailForSwapChain(::core::mem::transmute(&swapchain)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inktrail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inktrail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2476,7 +2476,7 @@ impl IDCompositionSurfaceFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSurface(::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&alphamode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *surface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(surface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2487,7 +2487,7 @@ impl IDCompositionSurfaceFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVirtualSurface(::core::mem::transmute_copy(&initialwidth), ::core::mem::transmute_copy(&initialheight), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&alphamode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *virtualsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(virtualsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
@@ -95,7 +95,7 @@ impl IDirectDraw_Vtbl {
             let this = (*this).get_impl();
             match this.DuplicateSurface(::core::mem::transmute(&param0)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -136,7 +136,7 @@ impl IDirectDraw_Vtbl {
             let this = (*this).get_impl();
             match this.GetGDISurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -264,7 +264,7 @@ impl IDirectDraw2_Vtbl {
             let this = (*this).get_impl();
             match this.DuplicateSurface(::core::mem::transmute(&param0)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl IDirectDraw2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGDISurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -443,7 +443,7 @@ impl IDirectDraw4_Vtbl {
             let this = (*this).get_impl();
             match this.DuplicateSurface(::core::mem::transmute(&param0)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -484,7 +484,7 @@ impl IDirectDraw4_Vtbl {
             let this = (*this).get_impl();
             match this.GetGDISurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IDirectDraw4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurfaceFromDC(::core::mem::transmute_copy(&param0)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -654,7 +654,7 @@ impl IDirectDraw7_Vtbl {
             let this = (*this).get_impl();
             match this.DuplicateSurface(::core::mem::transmute(&param0)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -695,7 +695,7 @@ impl IDirectDraw7_Vtbl {
             let this = (*this).get_impl();
             match this.GetGDISurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -751,7 +751,7 @@ impl IDirectDraw7_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurfaceFromDC(::core::mem::transmute_copy(&param0)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param1 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param1, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1113,7 +1113,7 @@ impl IDirectDrawSurface_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1144,7 +1144,7 @@ impl IDirectDrawSurface_Vtbl {
             let this = (*this).get_impl();
             match this.GetPalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1375,7 +1375,7 @@ impl IDirectDrawSurface2_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1406,7 +1406,7 @@ impl IDirectDrawSurface2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1656,7 +1656,7 @@ impl IDirectDrawSurface3_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1687,7 +1687,7 @@ impl IDirectDrawSurface3_Vtbl {
             let this = (*this).get_impl();
             match this.GetPalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1948,7 +1948,7 @@ impl IDirectDrawSurface4_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1979,7 +1979,7 @@ impl IDirectDrawSurface4_Vtbl {
             let this = (*this).get_impl();
             match this.GetPalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2274,7 +2274,7 @@ impl IDirectDrawSurface7_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2305,7 +2305,7 @@ impl IDirectDrawSurface7_Vtbl {
             let this = (*this).get_impl();
             match this.GetPalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
@@ -97,7 +97,7 @@ impl IDirectManipulationContent_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -205,7 +205,7 @@ impl IDirectManipulationDragDropBehavior_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -307,7 +307,7 @@ impl IDirectManipulationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessInput(::core::mem::transmute_copy(&message)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -492,7 +492,7 @@ impl IDirectManipulationUpdateManager_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterWaitHandleCallback(::core::mem::transmute_copy(&handle), ::core::mem::transmute(&eventhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -585,7 +585,7 @@ impl IDirectManipulationViewport_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -606,7 +606,7 @@ impl IDirectManipulationViewport_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewportRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *viewport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(viewport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -682,7 +682,7 @@ impl IDirectManipulationViewport_Vtbl {
             let this = (*this).get_impl();
             match this.AddEventHandler(::core::mem::transmute_copy(&window), ::core::mem::transmute(&eventhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -765,7 +765,7 @@ impl IDirectManipulationViewport2_Vtbl {
             let this = (*this).get_impl();
             match this.AddBehavior(::core::mem::transmute(&behavior)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
@@ -49,7 +49,7 @@ impl IDWriteBitmapRenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.DrawGlyphRun(::core::mem::transmute_copy(&baselineoriginx), ::core::mem::transmute_copy(&baselineoriginy), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute(&renderingparams), ::core::mem::transmute_copy(&textcolor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *blackboxrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blackboxrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -75,7 +75,7 @@ impl IDWriteBitmapRenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -91,7 +91,7 @@ impl IDWriteBitmapRenderTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -163,7 +163,7 @@ impl IDWriteColorGlyphRunEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasrun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasrun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -174,7 +174,7 @@ impl IDWriteColorGlyphRunEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentRun() {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorglyphrun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorglyphrun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl IDWriteColorGlyphRunEnumerator1_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentRun2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorglyphrun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorglyphrun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -255,7 +255,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomFontCollection(::core::mem::transmute(&collectionloader), ::core::mem::transmute_copy(&collectionkey), ::core::mem::transmute_copy(&collectionkeysize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFileReference(::core::mem::transmute(&filepath), ::core::mem::transmute_copy(&lastwritetime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -287,7 +287,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomFontFileReference(::core::mem::transmute_copy(&fontfilereferencekey), ::core::mem::transmute_copy(&fontfilereferencekeysize), ::core::mem::transmute(&fontfileloader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFace(::core::mem::transmute_copy(&fontfacetype), ::core::mem::transmute_copy(&numberoffiles), ::core::mem::transmute_copy(&fontfiles), ::core::mem::transmute_copy(&faceindex), ::core::mem::transmute_copy(&fontfacesimulationflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -309,7 +309,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRenderingParams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -320,7 +320,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMonitorRenderingParams(::core::mem::transmute_copy(&monitor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -331,7 +331,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomRenderingParams(::core::mem::transmute_copy(&gamma), ::core::mem::transmute_copy(&enhancedcontrast), ::core::mem::transmute_copy(&cleartypelevel), ::core::mem::transmute_copy(&pixelgeometry), ::core::mem::transmute_copy(&renderingmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -352,7 +352,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTextFormat(::core::mem::transmute(&fontfamilyname), ::core::mem::transmute(&fontcollection), ::core::mem::transmute_copy(&fontweight), ::core::mem::transmute_copy(&fontstyle), ::core::mem::transmute_copy(&fontstretch), ::core::mem::transmute_copy(&fontsize), ::core::mem::transmute(&localename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *textformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -363,7 +363,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypography() {
                 ::core::result::Result::Ok(ok__) => {
-                    *typography = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typography, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -374,7 +374,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetGdiInterop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *gdiinterop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gdiinterop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -385,7 +385,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTextLayout(::core::mem::transmute(&string), ::core::mem::transmute_copy(&stringlength), ::core::mem::transmute(&textformat), ::core::mem::transmute_copy(&maxwidth), ::core::mem::transmute_copy(&maxheight)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *textlayout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textlayout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -396,7 +396,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGdiCompatibleTextLayout(::core::mem::transmute(&string), ::core::mem::transmute_copy(&stringlength), ::core::mem::transmute(&textformat), ::core::mem::transmute_copy(&layoutwidth), ::core::mem::transmute_copy(&layoutheight), ::core::mem::transmute_copy(&pixelsperdip), ::core::mem::transmute_copy(&transform), ::core::mem::transmute_copy(&usegdinatural)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *textlayout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textlayout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -407,7 +407,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEllipsisTrimmingSign(::core::mem::transmute(&textformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *trimmingsign = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(trimmingsign, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -418,7 +418,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTextAnalyzer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *textanalyzer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textanalyzer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNumberSubstitution(::core::mem::transmute_copy(&substitutionmethod), ::core::mem::transmute(&localename), ::core::mem::transmute_copy(&ignoreuseroverride)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *numbersubstitution = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numbersubstitution, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl IDWriteFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGlyphRunAnalysis(::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute_copy(&pixelsperdip), ::core::mem::transmute_copy(&transform), ::core::mem::transmute_copy(&renderingmode), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute_copy(&baselineoriginx), ::core::mem::transmute_copy(&baselineoriginy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphrunanalysis = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphrunanalysis, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -495,7 +495,7 @@ impl IDWriteFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomRenderingParams2(::core::mem::transmute_copy(&gamma), ::core::mem::transmute_copy(&enhancedcontrast), ::core::mem::transmute_copy(&enhancedcontrastgrayscale), ::core::mem::transmute_copy(&cleartypelevel), ::core::mem::transmute_copy(&pixelgeometry), ::core::mem::transmute_copy(&renderingmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -529,7 +529,7 @@ impl IDWriteFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemFontFallback() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IDWriteFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFallbackBuilder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfallbackbuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfallbackbuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -551,7 +551,7 @@ impl IDWriteFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.TranslateColorGlyphRun(::core::mem::transmute_copy(&baselineoriginx), ::core::mem::transmute_copy(&baselineoriginy), ::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute_copy(&glyphrundescription), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute_copy(&worldtodevicetransform), ::core::mem::transmute_copy(&colorpaletteindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorlayers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorlayers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -562,7 +562,7 @@ impl IDWriteFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomRenderingParams3(::core::mem::transmute_copy(&gamma), ::core::mem::transmute_copy(&enhancedcontrast), ::core::mem::transmute_copy(&grayscaleenhancedcontrast), ::core::mem::transmute_copy(&cleartypelevel), ::core::mem::transmute_copy(&pixelgeometry), ::core::mem::transmute_copy(&renderingmode), ::core::mem::transmute_copy(&gridfitmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -573,7 +573,7 @@ impl IDWriteFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGlyphRunAnalysis2(::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute_copy(&transform), ::core::mem::transmute_copy(&renderingmode), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute_copy(&gridfitmode), ::core::mem::transmute_copy(&antialiasmode), ::core::mem::transmute_copy(&baselineoriginx), ::core::mem::transmute_copy(&baselineoriginy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphrunanalysis = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphrunanalysis, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -614,7 +614,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGlyphRunAnalysis3(::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute_copy(&transform), ::core::mem::transmute_copy(&renderingmode), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute_copy(&gridfitmode), ::core::mem::transmute_copy(&antialiasmode), ::core::mem::transmute_copy(&baselineoriginx), ::core::mem::transmute_copy(&baselineoriginy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphrunanalysis = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphrunanalysis, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -625,7 +625,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomRenderingParams4(::core::mem::transmute_copy(&gamma), ::core::mem::transmute_copy(&enhancedcontrast), ::core::mem::transmute_copy(&grayscaleenhancedcontrast), ::core::mem::transmute_copy(&cleartypelevel), ::core::mem::transmute_copy(&pixelgeometry), ::core::mem::transmute_copy(&renderingmode), ::core::mem::transmute_copy(&gridfitmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -636,7 +636,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFaceReference(::core::mem::transmute(&fontfile), ::core::mem::transmute_copy(&faceindex), ::core::mem::transmute_copy(&fontsimulations)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -647,7 +647,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFaceReference2(::core::mem::transmute(&filepath), ::core::mem::transmute_copy(&lastwritetime), ::core::mem::transmute_copy(&faceindex), ::core::mem::transmute_copy(&fontsimulations)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemFontSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontSetBuilder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontsetbuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontsetbuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontCollectionFromFontSet(::core::mem::transmute(&fontset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -696,7 +696,7 @@ impl IDWriteFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontDownloadQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontdownloadqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontdownloadqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -735,7 +735,7 @@ impl IDWriteFactory4_Vtbl {
             let this = (*this).get_impl();
             match this.TranslateColorGlyphRun2(::core::mem::transmute(&baselineorigin), ::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute_copy(&glyphrundescription), ::core::mem::transmute_copy(&desiredglyphimageformats), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute_copy(&worldanddpitransform), ::core::mem::transmute_copy(&colorpaletteindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorlayers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorlayers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -746,7 +746,7 @@ impl IDWriteFactory4_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeGlyphOrigins(::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute(&baselineorigin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphorigins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphorigins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -757,7 +757,7 @@ impl IDWriteFactory4_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeGlyphOrigins2(::core::mem::transmute_copy(&glyphrun), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute(&baselineorigin), ::core::mem::transmute_copy(&worldanddpitransform)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphorigins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphorigins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -792,7 +792,7 @@ impl IDWriteFactory5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontSetBuilder2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontsetbuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontsetbuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -803,7 +803,7 @@ impl IDWriteFactory5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInMemoryFontFileLoader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newloader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newloader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -814,7 +814,7 @@ impl IDWriteFactory5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateHttpFontFileLoader(::core::mem::transmute(&referrerurl), ::core::mem::transmute(&extraheaders)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newloader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newloader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -830,7 +830,7 @@ impl IDWriteFactory5_Vtbl {
             let this = (*this).get_impl();
             match this.UnpackFontFile(::core::mem::transmute_copy(&containertype), ::core::mem::transmute_copy(&filedata), ::core::mem::transmute_copy(&filedatasize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *unpackedfontstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(unpackedfontstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -869,7 +869,7 @@ impl IDWriteFactory6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFaceReference3(::core::mem::transmute(&fontfile), ::core::mem::transmute_copy(&faceindex), ::core::mem::transmute_copy(&fontsimulations), ::core::mem::transmute_copy(&fontaxisvalues), ::core::mem::transmute_copy(&fontaxisvaluecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -880,7 +880,7 @@ impl IDWriteFactory6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontResource(::core::mem::transmute(&fontfile), ::core::mem::transmute_copy(&faceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -891,7 +891,7 @@ impl IDWriteFactory6_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemFontSet2(::core::mem::transmute_copy(&includedownloadablefonts)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -902,7 +902,7 @@ impl IDWriteFactory6_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemFontCollection3(::core::mem::transmute_copy(&includedownloadablefonts), ::core::mem::transmute_copy(&fontfamilymodel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -913,7 +913,7 @@ impl IDWriteFactory6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontCollectionFromFontSet2(::core::mem::transmute(&fontset), ::core::mem::transmute_copy(&fontfamilymodel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -924,7 +924,7 @@ impl IDWriteFactory6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontSetBuilder3() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontsetbuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontsetbuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -935,7 +935,7 @@ impl IDWriteFactory6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTextFormat2(::core::mem::transmute(&fontfamilyname), ::core::mem::transmute(&fontcollection), ::core::mem::transmute_copy(&fontaxisvalues), ::core::mem::transmute_copy(&fontaxisvaluecount), ::core::mem::transmute_copy(&fontsize), ::core::mem::transmute(&localename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *textformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -971,7 +971,7 @@ impl IDWriteFactory7_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemFontSet3(::core::mem::transmute_copy(&includedownloadablefonts)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -982,7 +982,7 @@ impl IDWriteFactory7_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemFontCollection4(::core::mem::transmute_copy(&includedownloadablefonts), ::core::mem::transmute_copy(&fontfamilymodel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1022,7 +1022,7 @@ impl IDWriteFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFamily() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfamily = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfamily, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1053,7 +1053,7 @@ impl IDWriteFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetFaceNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *names = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(names, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1079,7 +1079,7 @@ impl IDWriteFont_Vtbl {
             let this = (*this).get_impl();
             match this.HasCharacter(::core::mem::transmute_copy(&unicodevalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *exists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1090,7 +1090,7 @@ impl IDWriteFont_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1197,7 +1197,7 @@ impl IDWriteFont3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFace2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1213,7 +1213,7 @@ impl IDWriteFont3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFaceReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1264,7 +1264,7 @@ impl IDWriteFontCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFamily(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfamily = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfamily, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1280,7 +1280,7 @@ impl IDWriteFontCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFromFontFace(::core::mem::transmute(&fontface)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *font = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(font, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1313,7 +1313,7 @@ impl IDWriteFontCollection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1324,7 +1324,7 @@ impl IDWriteFontCollection1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFamily2(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfamily = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfamily, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1357,7 +1357,7 @@ impl IDWriteFontCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFamily3(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfamily = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfamily, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1368,7 +1368,7 @@ impl IDWriteFontCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingFonts(::core::mem::transmute(&familyname), ::core::mem::transmute_copy(&fontaxisvalues), ::core::mem::transmute_copy(&fontaxisvaluecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1384,7 +1384,7 @@ impl IDWriteFontCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontSet2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1433,7 +1433,7 @@ impl IDWriteFontCollectionLoader_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEnumeratorFromKey(::core::mem::transmute(&factory), ::core::mem::transmute_copy(&collectionkey), ::core::mem::transmute_copy(&collectionkeysize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfileenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfileenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1481,7 +1481,7 @@ impl IDWriteFontDownloadQueue_Vtbl {
             let this = (*this).get_impl();
             match this.AddListener(::core::mem::transmute(&listener)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *token = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(token, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1614,7 +1614,7 @@ impl IDWriteFontFace_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecommendedRenderingMode(::core::mem::transmute_copy(&emsize), ::core::mem::transmute_copy(&pixelsperdip), ::core::mem::transmute_copy(&measuringmode), ::core::mem::transmute(&renderingparams)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1625,7 +1625,7 @@ impl IDWriteFontFace_Vtbl {
             let this = (*this).get_impl();
             match this.GetGdiCompatibleMetrics(::core::mem::transmute_copy(&emsize), ::core::mem::transmute_copy(&pixelsperdip), ::core::mem::transmute_copy(&transform)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacemetrics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacemetrics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1689,7 +1689,7 @@ impl IDWriteFontFace1_Vtbl {
             let this = (*this).get_impl();
             match this.GetGdiCompatibleMetrics2(::core::mem::transmute_copy(&emsize), ::core::mem::transmute_copy(&pixelsperdip), ::core::mem::transmute_copy(&transform)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontmetrics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontmetrics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1735,7 +1735,7 @@ impl IDWriteFontFace1_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecommendedRenderingMode2(::core::mem::transmute_copy(&fontemsize), ::core::mem::transmute_copy(&dpix), ::core::mem::transmute_copy(&dpiy), ::core::mem::transmute_copy(&transform), ::core::mem::transmute_copy(&issideways), ::core::mem::transmute_copy(&outlinethreshold), ::core::mem::transmute_copy(&measuringmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *renderingmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(renderingmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1849,7 +1849,7 @@ impl IDWriteFontFace3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFaceReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1880,7 +1880,7 @@ impl IDWriteFontFace3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFamilyNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *names = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(names, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1891,7 +1891,7 @@ impl IDWriteFontFace3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFaceNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *names = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(names, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1927,7 +1927,7 @@ impl IDWriteFontFace3_Vtbl {
             let this = (*this).get_impl();
             match this.AreCharactersLocal(::core::mem::transmute(&characters), ::core::mem::transmute_copy(&charactercount), ::core::mem::transmute_copy(&enqueueifnotlocal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *islocal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(islocal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1938,7 +1938,7 @@ impl IDWriteFontFace3_Vtbl {
             let this = (*this).get_impl();
             match this.AreGlyphsLocal(::core::mem::transmute_copy(&glyphindices), ::core::mem::transmute_copy(&glyphcount), ::core::mem::transmute_copy(&enqueueifnotlocal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *islocal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(islocal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1983,7 +1983,7 @@ impl IDWriteFontFace4_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphImageFormats(::core::mem::transmute_copy(&glyphid), ::core::mem::transmute_copy(&pixelsperemfirst), ::core::mem::transmute_copy(&pixelsperemlast)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphimageformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphimageformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2049,7 +2049,7 @@ impl IDWriteFontFace5_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2088,7 +2088,7 @@ impl IDWriteFontFace6_Vtbl {
             let this = (*this).get_impl();
             match this.GetFamilyNames2(::core::mem::transmute_copy(&fontfamilymodel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *names = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(names, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2099,7 +2099,7 @@ impl IDWriteFontFace6_Vtbl {
             let this = (*this).get_impl();
             match this.GetFaceNames2(::core::mem::transmute_copy(&fontfamilymodel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *names = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(names, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2142,7 +2142,7 @@ impl IDWriteFontFaceReference_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2153,7 +2153,7 @@ impl IDWriteFontFaceReference_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFaceWithSimulations(::core::mem::transmute_copy(&fontfacesimulationflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2179,7 +2179,7 @@ impl IDWriteFontFaceReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2200,7 +2200,7 @@ impl IDWriteFontFaceReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastwritetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastwritetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2269,7 +2269,7 @@ impl IDWriteFontFaceReference1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFace2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2354,7 +2354,7 @@ impl IDWriteFontFallbackBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFallback() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2384,7 +2384,7 @@ impl IDWriteFontFamily_Vtbl {
             let this = (*this).get_impl();
             match this.GetFamilyNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *names = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(names, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2395,7 +2395,7 @@ impl IDWriteFontFamily_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstMatchingFont(::core::mem::transmute_copy(&weight), ::core::mem::transmute_copy(&stretch), ::core::mem::transmute_copy(&style)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchingfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchingfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2406,7 +2406,7 @@ impl IDWriteFontFamily_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingFonts(::core::mem::transmute_copy(&weight), ::core::mem::transmute_copy(&stretch), ::core::mem::transmute_copy(&style)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchingfonts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchingfonts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2441,7 +2441,7 @@ impl IDWriteFontFamily1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFont2(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *font = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(font, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2452,7 +2452,7 @@ impl IDWriteFontFamily1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFaceReference(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2481,7 +2481,7 @@ impl IDWriteFontFamily2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingFonts2(::core::mem::transmute_copy(&fontaxisvalues), ::core::mem::transmute_copy(&fontaxisvaluecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchingfonts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchingfonts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2492,7 +2492,7 @@ impl IDWriteFontFamily2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2529,7 +2529,7 @@ impl IDWriteFontFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetLoader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfileloader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfileloader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2566,7 +2566,7 @@ impl IDWriteFontFileEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrentfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrentfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2577,7 +2577,7 @@ impl IDWriteFontFileEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentFontFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2604,7 +2604,7 @@ impl IDWriteFontFileLoader_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStreamFromKey(::core::mem::transmute_copy(&fontfilereferencekey), ::core::mem::transmute_copy(&fontfilereferencekeysize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfilestream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfilestream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2640,7 +2640,7 @@ impl IDWriteFontFileStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2651,7 +2651,7 @@ impl IDWriteFontFileStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastWriteTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastwritetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastwritetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2682,7 +2682,7 @@ impl IDWriteFontList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2698,7 +2698,7 @@ impl IDWriteFontList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFont(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *font = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(font, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2733,7 +2733,7 @@ impl IDWriteFontList1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFont2(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *font = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(font, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2744,7 +2744,7 @@ impl IDWriteFontList1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFaceReference(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2772,7 +2772,7 @@ impl IDWriteFontList2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2809,7 +2809,7 @@ impl IDWriteFontResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2845,7 +2845,7 @@ impl IDWriteFontResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetAxisNames(::core::mem::transmute_copy(&axisindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *names = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(names, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2871,7 +2871,7 @@ impl IDWriteFontResource_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFace(::core::mem::transmute_copy(&fontsimulations), ::core::mem::transmute_copy(&fontaxisvalues), ::core::mem::transmute_copy(&fontaxisvaluecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2882,7 +2882,7 @@ impl IDWriteFontResource_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFaceReference(::core::mem::transmute_copy(&fontsimulations), ::core::mem::transmute_copy(&fontaxisvalues), ::core::mem::transmute_copy(&fontaxisvaluecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2936,7 +2936,7 @@ impl IDWriteFontSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFaceReference(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2957,7 +2957,7 @@ impl IDWriteFontSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyValues(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *values = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(values, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2968,7 +2968,7 @@ impl IDWriteFontSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyValues2(::core::mem::transmute_copy(&propertyid), ::core::mem::transmute(&preferredlocalenames)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *values = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(values, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2984,7 +2984,7 @@ impl IDWriteFontSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyOccurrenceCount(::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyoccurrencecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyoccurrencecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2995,7 +2995,7 @@ impl IDWriteFontSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingFonts(::core::mem::transmute(&familyname), ::core::mem::transmute_copy(&fontweight), ::core::mem::transmute_copy(&fontstretch), ::core::mem::transmute_copy(&fontstyle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filteredset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filteredset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3006,7 +3006,7 @@ impl IDWriteFontSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingFonts2(::core::mem::transmute_copy(&properties), ::core::mem::transmute_copy(&propertycount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filteredset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filteredset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3056,7 +3056,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingFonts3(::core::mem::transmute_copy(&fontproperty), ::core::mem::transmute_copy(&fontaxisvalues), ::core::mem::transmute_copy(&fontaxisvaluecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchingfonts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchingfonts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3067,7 +3067,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstFontResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filteredfontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filteredfontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3078,7 +3078,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredFonts(::core::mem::transmute_copy(&indices), ::core::mem::transmute_copy(&indexcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filteredfontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filteredfontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3089,7 +3089,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredFonts2(::core::mem::transmute_copy(&fontaxisranges), ::core::mem::transmute_copy(&fontaxisrangecount), ::core::mem::transmute_copy(&selectanyrange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filteredfontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filteredfontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3100,7 +3100,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredFonts3(::core::mem::transmute_copy(&properties), ::core::mem::transmute_copy(&propertycount), ::core::mem::transmute_copy(&selectanyproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filteredfontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filteredfontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3131,7 +3131,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFaceReference2(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfacereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfacereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3142,7 +3142,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontResource(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3153,7 +3153,7 @@ impl IDWriteFontSet1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFace(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3271,7 +3271,7 @@ impl IDWriteFontSetBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3351,7 +3351,7 @@ impl IDWriteGdiInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFromLOGFONT(::core::mem::transmute_copy(&logfont)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *font = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(font, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3367,7 +3367,7 @@ impl IDWriteGdiInterop_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertFontFaceToLOGFONT(::core::mem::transmute(&font)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *logfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(logfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3378,7 +3378,7 @@ impl IDWriteGdiInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFaceFromHdc(::core::mem::transmute_copy(&hdc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3389,7 +3389,7 @@ impl IDWriteGdiInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapRenderTarget(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rendertarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rendertarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3425,7 +3425,7 @@ impl IDWriteGdiInterop1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFromLOGFONT2(::core::mem::transmute_copy(&logfont), ::core::mem::transmute(&fontcollection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *font = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(font, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3436,7 +3436,7 @@ impl IDWriteGdiInterop1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontSignature(::core::mem::transmute(&fontface)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3447,7 +3447,7 @@ impl IDWriteGdiInterop1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontSignature2(::core::mem::transmute(&font)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3458,7 +3458,7 @@ impl IDWriteGdiInterop1_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingFontsByLOGFONT(::core::mem::transmute_copy(&logfont), ::core::mem::transmute(&fontset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filteredset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filteredset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3492,7 +3492,7 @@ impl IDWriteGlyphRunAnalysis_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlphaTextureBounds(::core::mem::transmute_copy(&texturetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *texturebounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(texturebounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3531,7 +3531,7 @@ impl IDWriteInMemoryFontFileLoader_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInMemoryFontFileReference(::core::mem::transmute(&factory), ::core::mem::transmute_copy(&fontdata), ::core::mem::transmute_copy(&fontdatasize), ::core::mem::transmute(&ownerobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3574,7 +3574,7 @@ impl IDWriteInlineObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetrics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *metrics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metrics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3585,7 +3585,7 @@ impl IDWriteInlineObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetOverhangMetrics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *overhangs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(overhangs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3624,7 +3624,7 @@ impl IDWriteLocalFontFileLoader_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilePathLengthFromKey(::core::mem::transmute_copy(&fontfilereferencekey), ::core::mem::transmute_copy(&fontfilereferencekeysize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filepathlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filepathlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3640,7 +3640,7 @@ impl IDWriteLocalFontFileLoader_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastWriteTimeFromKey(::core::mem::transmute_copy(&fontfilereferencekey), ::core::mem::transmute_copy(&fontfilereferencekeysize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastwritetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastwritetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3686,7 +3686,7 @@ impl IDWriteLocalizedStrings_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocaleNameLength(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3702,7 +3702,7 @@ impl IDWriteLocalizedStrings_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringLength(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3753,7 +3753,7 @@ impl IDWritePixelSnapping_Vtbl {
             let this = (*this).get_impl();
             match this.IsPixelSnappingDisabled(::core::mem::transmute_copy(&clientdrawingcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isdisabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isdisabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3764,7 +3764,7 @@ impl IDWritePixelSnapping_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTransform(::core::mem::transmute_copy(&clientdrawingcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3775,7 +3775,7 @@ impl IDWritePixelSnapping_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelsPerDip(::core::mem::transmute_copy(&clientdrawingcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pixelsperdip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pixelsperdip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3805,7 +3805,7 @@ impl IDWriteRemoteFontFileLoader_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRemoteStreamFromKey(::core::mem::transmute_copy(&fontfilereferencekey), ::core::mem::transmute_copy(&fontfilereferencekeysize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfilestream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfilestream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3816,7 +3816,7 @@ impl IDWriteRemoteFontFileLoader_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalityFromKey(::core::mem::transmute_copy(&fontfilereferencekey), ::core::mem::transmute_copy(&fontfilereferencekeysize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *locality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3827,7 +3827,7 @@ impl IDWriteRemoteFontFileLoader_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontFileReferenceFromUrl(::core::mem::transmute(&factory), ::core::mem::transmute(&baseurl), ::core::mem::transmute(&fontfileurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3861,7 +3861,7 @@ impl IDWriteRemoteFontFileStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalFileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *localfilesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localfilesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3882,7 +3882,7 @@ impl IDWriteRemoteFontFileStream_Vtbl {
             let this = (*this).get_impl();
             match this.BeginDownload(::core::mem::transmute_copy(&downloadoperationid), ::core::mem::transmute_copy(&filefragments), ::core::mem::transmute_copy(&fragmentcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *asyncresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(asyncresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4022,7 +4022,7 @@ impl IDWriteStringList_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocaleNameLength(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4038,7 +4038,7 @@ impl IDWriteStringList_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringLength(::core::mem::transmute_copy(&listindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4453,7 +4453,7 @@ impl IDWriteTextAnalyzer1_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphOrientationTransform(::core::mem::transmute_copy(&glyphorientationangle), ::core::mem::transmute_copy(&issideways)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4464,7 +4464,7 @@ impl IDWriteTextAnalyzer1_Vtbl {
             let this = (*this).get_impl();
             match this.GetScriptProperties(::core::mem::transmute(&scriptanalysis)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *scriptproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scriptproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4542,7 +4542,7 @@ impl IDWriteTextAnalyzer2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphOrientationTransform2(::core::mem::transmute_copy(&glyphorientationangle), ::core::mem::transmute_copy(&issideways), ::core::mem::transmute_copy(&originx), ::core::mem::transmute_copy(&originy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4684,7 +4684,7 @@ impl IDWriteTextFormat_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4819,7 +4819,7 @@ impl IDWriteTextFormat1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFallback() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4861,7 +4861,7 @@ impl IDWriteTextFormat2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLineSpacing2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *linespacingoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(linespacingoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5140,7 +5140,7 @@ impl IDWriteTextLayout_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetrics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *textmetrics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textmetrics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5151,7 +5151,7 @@ impl IDWriteTextLayout_Vtbl {
             let this = (*this).get_impl();
             match this.GetOverhangMetrics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *overhangs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(overhangs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5167,7 +5167,7 @@ impl IDWriteTextLayout_Vtbl {
             let this = (*this).get_impl();
             match this.DetermineMinWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5301,7 +5301,7 @@ impl IDWriteTextLayout2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetrics2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *textmetrics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textmetrics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5347,7 +5347,7 @@ impl IDWriteTextLayout2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFallback() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5397,7 +5397,7 @@ impl IDWriteTextLayout3_Vtbl {
             let this = (*this).get_impl();
             match this.GetLineSpacing2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *linespacingoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(linespacingoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5582,7 +5582,7 @@ impl IDWriteTypography_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFeature(::core::mem::transmute_copy(&fontfeatureindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfeature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfeature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
@@ -14,7 +14,7 @@ impl IDXGIAdapter_Vtbl {
             let this = (*this).get_impl();
             match this.EnumOutputs(::core::mem::transmute_copy(&output)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25,7 +25,7 @@ impl IDXGIAdapter_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36,7 +36,7 @@ impl IDXGIAdapter_Vtbl {
             let this = (*this).get_impl();
             match this.CheckInterfaceSupport(::core::mem::transmute_copy(&interfacename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pumdversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pumdversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -67,7 +67,7 @@ impl IDXGIAdapter1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -93,7 +93,7 @@ impl IDXGIAdapter2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IDXGIAdapter3_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterHardwareContentProtectionTeardownStatusEvent(::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -140,7 +140,7 @@ impl IDXGIAdapter3_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVideoMemoryInfo(::core::mem::transmute_copy(&nodeindex), ::core::mem::transmute_copy(&memorysegmentgroup)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvideomemoryinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvideomemoryinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -156,7 +156,7 @@ impl IDXGIAdapter3_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterVideoMemoryBudgetChangeNotificationEvent(::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -195,7 +195,7 @@ impl IDXGIAdapter4_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc3() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -303,7 +303,7 @@ impl IDXGIDecodeSwapChain_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IDXGIDecodeSwapChain_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -370,7 +370,7 @@ impl IDXGIDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *padapter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(padapter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -396,7 +396,7 @@ impl IDXGIDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetGPUThreadPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -435,7 +435,7 @@ impl IDXGIDevice1_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumFrameLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmaxlatency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmaxlatency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -472,7 +472,7 @@ impl IDXGIDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.ReclaimResources(::core::mem::transmute_copy(&numresources), ::core::mem::transmute_copy(&ppresources)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdiscarded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdiscarded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -534,7 +534,7 @@ impl IDXGIDevice4_Vtbl {
             let this = (*this).get_impl();
             match this.ReclaimResources1(::core::mem::transmute_copy(&numresources), ::core::mem::transmute_copy(&ppresources)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -615,7 +615,7 @@ impl IDXGIFactory_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAdapters(::core::mem::transmute_copy(&adapter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppadapter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppadapter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -631,7 +631,7 @@ impl IDXGIFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindowAssociation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwindowhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwindowhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -642,7 +642,7 @@ impl IDXGIFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSwapChain(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&pdesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -653,7 +653,7 @@ impl IDXGIFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSoftwareAdapter(::core::mem::transmute_copy(&module)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppadapter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppadapter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -687,7 +687,7 @@ impl IDXGIFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAdapters1(::core::mem::transmute_copy(&adapter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppadapter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppadapter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -737,7 +737,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSwapChainForHwnd(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&pdesc), ::core::mem::transmute_copy(&pfullscreendesc), ::core::mem::transmute(&prestricttooutput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -748,7 +748,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSwapChainForCoreWindow(::core::mem::transmute(&pdevice), ::core::mem::transmute(&pwindow), ::core::mem::transmute_copy(&pdesc), ::core::mem::transmute(&prestricttooutput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -759,7 +759,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSharedResourceAdapterLuid(::core::mem::transmute_copy(&hresource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pluid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pluid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -770,7 +770,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterStereoStatusWindow(::core::mem::transmute_copy(&windowhandle), ::core::mem::transmute_copy(&wmsg)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -781,7 +781,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterStereoStatusEvent(::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -797,7 +797,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterOcclusionStatusWindow(::core::mem::transmute_copy(&windowhandle), ::core::mem::transmute_copy(&wmsg)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -808,7 +808,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterOcclusionStatusEvent(::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -824,7 +824,7 @@ impl IDXGIFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSwapChainForComposition(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&pdesc), ::core::mem::transmute(&prestricttooutput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl IDXGIFactory7_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterAdaptersChangedEvent(::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -990,7 +990,7 @@ impl IDXGIFactoryMedia_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSwapChainForCompositionSurfaceHandle(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&hsurface), ::core::mem::transmute_copy(&pdesc), ::core::mem::transmute(&prestricttooutput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1001,7 +1001,7 @@ impl IDXGIFactoryMedia_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDecodeSwapChainForCompositionSurfaceHandle(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&hsurface), ::core::mem::transmute_copy(&pdesc), ::core::mem::transmute(&pyuvdecodebuffers), ::core::mem::transmute(&prestricttooutput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1385,7 +1385,7 @@ impl IDXGIOutput_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1421,7 +1421,7 @@ impl IDXGIOutput_Vtbl {
             let this = (*this).get_impl();
             match this.GetGammaControlCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgammacaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgammacaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1437,7 +1437,7 @@ impl IDXGIOutput_Vtbl {
             let this = (*this).get_impl();
             match this.GetGammaControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1458,7 +1458,7 @@ impl IDXGIOutput_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameStatistics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1516,7 +1516,7 @@ impl IDXGIOutput1_Vtbl {
             let this = (*this).get_impl();
             match this.DuplicateOutput(::core::mem::transmute(&pdevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutputduplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutputduplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1568,7 +1568,7 @@ impl IDXGIOutput3_Vtbl {
             let this = (*this).get_impl();
             match this.CheckOverlaySupport(::core::mem::transmute_copy(&enumformat), ::core::mem::transmute(&pconcerneddevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1594,7 +1594,7 @@ impl IDXGIOutput4_Vtbl {
             let this = (*this).get_impl();
             match this.CheckOverlayColorSpaceSupport(::core::mem::transmute_copy(&format), ::core::mem::transmute_copy(&colorspace), ::core::mem::transmute(&pconcerneddevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1623,7 +1623,7 @@ impl IDXGIOutput5_Vtbl {
             let this = (*this).get_impl();
             match this.DuplicateOutput1(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&supportedformatscount), ::core::mem::transmute_copy(&psupportedformats)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutputduplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutputduplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1650,7 +1650,7 @@ impl IDXGIOutput6_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1661,7 +1661,7 @@ impl IDXGIOutput6_Vtbl {
             let this = (*this).get_impl();
             match this.CheckHardwareCompositionSupport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1723,7 +1723,7 @@ impl IDXGIOutputDuplication_Vtbl {
             let this = (*this).get_impl();
             match this.MapDesktopSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plockedrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plockedrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1772,7 +1772,7 @@ impl IDXGIResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetSharedHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psharedhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psharedhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1783,7 +1783,7 @@ impl IDXGIResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pusage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pusage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1799,7 +1799,7 @@ impl IDXGIResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetEvictionPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevictionpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevictionpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1832,7 +1832,7 @@ impl IDXGIResource1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSubresourceSurface(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1843,7 +1843,7 @@ impl IDXGIResource1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSharedHandle(::core::mem::transmute_copy(&pattributes), ::core::mem::transmute_copy(&dwaccess), ::core::mem::transmute(&lpname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1875,7 +1875,7 @@ impl IDXGISurface_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1917,7 +1917,7 @@ impl IDXGISurface1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDC(::core::mem::transmute_copy(&discard)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2001,7 +2001,7 @@ impl IDXGISwapChain_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2022,7 +2022,7 @@ impl IDXGISwapChain_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainingOutput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2033,7 +2033,7 @@ impl IDXGISwapChain_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameStatistics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2044,7 +2044,7 @@ impl IDXGISwapChain_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastPresentCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plastpresentcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plastpresentcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2092,7 +2092,7 @@ impl IDXGISwapChain1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDesc1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2103,7 +2103,7 @@ impl IDXGISwapChain1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullscreenDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2114,7 +2114,7 @@ impl IDXGISwapChain1_Vtbl {
             let this = (*this).get_impl();
             match this.GetHwnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2140,7 +2140,7 @@ impl IDXGISwapChain1_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictToOutput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprestricttooutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprestricttooutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2156,7 +2156,7 @@ impl IDXGISwapChain1_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2172,7 +2172,7 @@ impl IDXGISwapChain1_Vtbl {
             let this = (*this).get_impl();
             match this.GetRotation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *protation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(protation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2232,7 +2232,7 @@ impl IDXGISwapChain2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumFrameLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmaxlatency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmaxlatency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2253,7 +2253,7 @@ impl IDXGISwapChain2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatrixTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmatrix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmatrix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2296,7 +2296,7 @@ impl IDXGISwapChain3_Vtbl {
             let this = (*this).get_impl();
             match this.CheckColorSpaceSupport(::core::mem::transmute_copy(&colorspace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolorspacesupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolorspacesupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2357,7 +2357,7 @@ impl IDXGISwapChainMedia_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameStatisticsMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
@@ -49,7 +49,7 @@ impl IWICImagingFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageEncoder(::core::mem::transmute(&pd2ddevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwicimageencoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwicimageencoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
@@ -11,7 +11,7 @@ impl IWICBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.Lock(::core::mem::transmute_copy(&prclock), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppilock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppilock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -80,7 +80,7 @@ impl IWICBitmapCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidcontainerformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidcontainerformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -121,7 +121,7 @@ impl IWICBitmapCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DoesSupportAnimation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupportanimation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupportanimation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -132,7 +132,7 @@ impl IWICBitmapCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DoesSupportChromakey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupportchromakey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupportchromakey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -143,7 +143,7 @@ impl IWICBitmapCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DoesSupportLossless() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupportlossless = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupportlossless, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -154,7 +154,7 @@ impl IWICBitmapCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DoesSupportMultiframe() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupportmultiframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupportmultiframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -165,7 +165,7 @@ impl IWICBitmapCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MatchesMimeType(::core::mem::transmute(&wzmimetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmatches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmatches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -235,7 +235,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.QueryCapability(::core::mem::transmute(&pistream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcapability = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcapability, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -251,7 +251,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidcontainerformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidcontainerformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -262,7 +262,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetDecoderInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidecoderinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidecoderinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -278,7 +278,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataQueryReader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimetadataqueryreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimetadataqueryreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -289,7 +289,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreview() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnail() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppithumbnail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppithumbnail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -327,7 +327,7 @@ impl IWICBitmapDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrame(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -373,7 +373,7 @@ impl IWICBitmapDecoderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MatchesPattern(::core::mem::transmute(&pistream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmatches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmatches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -384,7 +384,7 @@ impl IWICBitmapDecoderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapdecoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapdecoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl IWICBitmapEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidcontainerformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidcontainerformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl IWICBitmapEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetEncoderInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiencoderinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiencoderinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -481,7 +481,7 @@ impl IWICBitmapEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataQueryWriter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimetadataquerywriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimetadataquerywriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -519,7 +519,7 @@ impl IWICBitmapEncoderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapencoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapencoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -561,7 +561,7 @@ impl IWICBitmapFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataQueryReader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimetadataqueryreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimetadataqueryreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -577,7 +577,7 @@ impl IWICBitmapFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnail() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppithumbnail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppithumbnail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -668,7 +668,7 @@ impl IWICBitmapFrameEncode_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataQueryWriter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimetadataquerywriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimetadataquerywriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -712,7 +712,7 @@ impl IWICBitmapLock_Vtbl {
             let this = (*this).get_impl();
             match this.GetStride() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbstride = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbstride, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -728,7 +728,7 @@ impl IWICBitmapLock_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppixelformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppixelformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -783,7 +783,7 @@ impl IWICBitmapSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppixelformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppixelformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -849,7 +849,7 @@ impl IWICBitmapSourceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.DoesSupportTransform(::core::mem::transmute_copy(&dsttransform)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfissupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfissupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -898,7 +898,7 @@ impl IWICColorContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -914,7 +914,7 @@ impl IWICColorContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetExifColorSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -971,7 +971,7 @@ impl IWICComponentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMetadataReader(::core::mem::transmute_copy(&guidmetadataformat), ::core::mem::transmute_copy(&pguidvendor), ::core::mem::transmute_copy(&dwoptions), ::core::mem::transmute(&pistream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppireader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppireader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -982,7 +982,7 @@ impl IWICComponentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMetadataReaderFromContainer(::core::mem::transmute_copy(&guidcontainerformat), ::core::mem::transmute_copy(&pguidvendor), ::core::mem::transmute_copy(&dwoptions), ::core::mem::transmute(&pistream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppireader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppireader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -993,7 +993,7 @@ impl IWICComponentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMetadataWriter(::core::mem::transmute_copy(&guidmetadataformat), ::core::mem::transmute_copy(&pguidvendor), ::core::mem::transmute_copy(&dwmetadataoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1004,7 +1004,7 @@ impl IWICComponentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMetadataWriterFromReader(::core::mem::transmute(&pireader), ::core::mem::transmute_copy(&pguidvendor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1015,7 +1015,7 @@ impl IWICComponentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQueryReaderFromBlockReader(::core::mem::transmute(&piblockreader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiqueryreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiqueryreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1026,7 +1026,7 @@ impl IWICComponentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQueryWriterFromBlockWriter(::core::mem::transmute(&piblockwriter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiquerywriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiquerywriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1037,7 +1037,7 @@ impl IWICComponentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncoderPropertyBag(::core::mem::transmute_copy(&ppropoptions), ::core::mem::transmute_copy(&ccount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1076,7 +1076,7 @@ impl IWICComponentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1087,7 +1087,7 @@ impl IWICComponentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1098,7 +1098,7 @@ impl IWICComponentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSigningStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1114,7 +1114,7 @@ impl IWICComponentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetVendorGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidvendor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidvendor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1166,7 +1166,7 @@ impl IWICDdsDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1177,7 +1177,7 @@ impl IWICDdsDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrame(::core::mem::transmute_copy(&arrayindex), ::core::mem::transmute_copy(&miplevel), ::core::mem::transmute_copy(&sliceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1214,7 +1214,7 @@ impl IWICDdsEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1257,7 +1257,7 @@ impl IWICDdsFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformatinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformatinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1334,7 +1334,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentParameterSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcurrentparameterset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcurrentparameterset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1350,7 +1350,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetExposureCompensation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1376,7 +1376,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamedWhitePoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwhitepoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwhitepoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1392,7 +1392,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetWhitePointKelvin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwhitepointkelvin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwhitepointkelvin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1413,7 +1413,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetContrast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontrast = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontrast, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1429,7 +1429,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetGamma() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgamma = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgamma, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1445,7 +1445,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetSharpness() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psharpness = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psharpness, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1461,7 +1461,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetSaturation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psaturation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psaturation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1477,7 +1477,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetTint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1493,7 +1493,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetNoiseReduction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnoisereduction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnoisereduction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1524,7 +1524,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetRotation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *protation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(protation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1540,7 +1540,7 @@ impl IWICDevelopRaw_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prendermode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prendermode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1640,7 +1640,7 @@ impl IWICEnumMetadataItem_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienummetadataitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienummetadataitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1675,7 +1675,7 @@ impl IWICFastMetadataEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataQueryWriter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimetadataquerywriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimetadataquerywriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1711,7 +1711,7 @@ impl IWICFormatConverter_Vtbl {
             let this = (*this).get_impl();
             match this.CanConvert(::core::mem::transmute_copy(&srcpixelformat), ::core::mem::transmute_copy(&dstpixelformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcanconvert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcanconvert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1744,7 +1744,7 @@ impl IWICFormatConverterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiconverter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiconverter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1798,7 +1798,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDecoderFromFilename(::core::mem::transmute(&wzfilename), ::core::mem::transmute_copy(&pguidvendor), ::core::mem::transmute_copy(&dwdesiredaccess), ::core::mem::transmute_copy(&metadataoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidecoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidecoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1809,7 +1809,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDecoderFromStream(::core::mem::transmute(&pistream), ::core::mem::transmute_copy(&pguidvendor), ::core::mem::transmute_copy(&metadataoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidecoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidecoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1820,7 +1820,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDecoderFromFileHandle(::core::mem::transmute_copy(&hfile), ::core::mem::transmute_copy(&pguidvendor), ::core::mem::transmute_copy(&metadataoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidecoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidecoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1831,7 +1831,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateComponentInfo(::core::mem::transmute_copy(&clsidcomponent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1842,7 +1842,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDecoder(::core::mem::transmute_copy(&guidcontainerformat), ::core::mem::transmute_copy(&pguidvendor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidecoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidecoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1853,7 +1853,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncoder(::core::mem::transmute_copy(&guidcontainerformat), ::core::mem::transmute_copy(&pguidvendor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiencoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiencoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1864,7 +1864,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipalette = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipalette, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1875,7 +1875,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFormatConverter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiformatconverter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiformatconverter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1886,7 +1886,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapScaler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapscaler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapscaler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1897,7 +1897,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapClipper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapclipper = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapclipper, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1908,7 +1908,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFlipRotator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmapfliprotator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmapfliprotator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1919,7 +1919,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwicstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwicstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1930,7 +1930,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiccolorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiccolorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1941,7 +1941,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorTransformer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwiccolortransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwiccolortransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1952,7 +1952,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmap(::core::mem::transmute_copy(&uiwidth), ::core::mem::transmute_copy(&uiheight), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&option)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1963,7 +1963,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromSource(::core::mem::transmute(&pibitmapsource), ::core::mem::transmute_copy(&option)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1974,7 +1974,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromSourceRect(::core::mem::transmute(&pibitmapsource), ::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1985,7 +1985,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromMemory(::core::mem::transmute_copy(&uiwidth), ::core::mem::transmute_copy(&uiheight), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&cbstride), ::core::mem::transmute_copy(&cbbuffersize), ::core::mem::transmute_copy(&pbbuffer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1996,7 +1996,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromHBITMAP(::core::mem::transmute_copy(&hbitmap), ::core::mem::transmute_copy(&hpalette), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2007,7 +2007,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBitmapFromHICON(::core::mem::transmute_copy(&hicon)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppibitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppibitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2018,7 +2018,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateComponentEnumerator(::core::mem::transmute_copy(&componenttypes), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2029,7 +2029,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFastMetadataEncoderFromDecoder(::core::mem::transmute(&pidecoder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifastencoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifastencoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2040,7 +2040,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFastMetadataEncoderFromFrameDecode(::core::mem::transmute(&piframedecoder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifastencoder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifastencoder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2051,7 +2051,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQueryWriter(::core::mem::transmute_copy(&guidmetadataformat), ::core::mem::transmute_copy(&pguidvendor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiquerywriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiquerywriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2062,7 +2062,7 @@ impl IWICImagingFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQueryWriterFromReader(::core::mem::transmute(&piqueryreader), ::core::mem::transmute_copy(&pguidvendor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiquerywriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiquerywriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2124,7 +2124,7 @@ impl IWICJpegFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.DoesSupportIndexing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfindexingsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfindexingsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2145,7 +2145,7 @@ impl IWICJpegFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetAcHuffmanTable(::core::mem::transmute_copy(&scanindex), ::core::mem::transmute_copy(&tableindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pachuffmantable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pachuffmantable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2156,7 +2156,7 @@ impl IWICJpegFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetDcHuffmanTable(::core::mem::transmute_copy(&scanindex), ::core::mem::transmute_copy(&tableindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdchuffmantable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdchuffmantable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2167,7 +2167,7 @@ impl IWICJpegFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetQuantizationTable(::core::mem::transmute_copy(&scanindex), ::core::mem::transmute_copy(&tableindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pquantizationtable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pquantizationtable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2178,7 +2178,7 @@ impl IWICJpegFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameHeader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pframeheader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pframeheader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2189,7 +2189,7 @@ impl IWICJpegFrameDecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetScanHeader(::core::mem::transmute_copy(&scanindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pscanheader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pscanheader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2240,7 +2240,7 @@ impl IWICJpegFrameEncode_Vtbl {
             let this = (*this).get_impl();
             match this.GetAcHuffmanTable(::core::mem::transmute_copy(&scanindex), ::core::mem::transmute_copy(&tableindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pachuffmantable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pachuffmantable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2251,7 +2251,7 @@ impl IWICJpegFrameEncode_Vtbl {
             let this = (*this).get_impl();
             match this.GetDcHuffmanTable(::core::mem::transmute_copy(&scanindex), ::core::mem::transmute_copy(&tableindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdchuffmantable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdchuffmantable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2262,7 +2262,7 @@ impl IWICJpegFrameEncode_Vtbl {
             let this = (*this).get_impl();
             match this.GetQuantizationTable(::core::mem::transmute_copy(&scanindex), ::core::mem::transmute_copy(&tableindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pquantizationtable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pquantizationtable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2302,7 +2302,7 @@ impl IWICMetadataBlockReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidcontainerformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidcontainerformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2313,7 +2313,7 @@ impl IWICMetadataBlockReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2324,7 +2324,7 @@ impl IWICMetadataBlockReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetReaderByIndex(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimetadatareader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimetadatareader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2335,7 +2335,7 @@ impl IWICMetadataBlockReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienummetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienummetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2376,7 +2376,7 @@ impl IWICMetadataBlockWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetWriterByIndex(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimetadatawriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimetadatawriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2430,7 +2430,7 @@ impl IWICMetadataHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidmetadataformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidmetadataformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2456,7 +2456,7 @@ impl IWICMetadataHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DoesRequireFullStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrequiresfullstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrequiresfullstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2467,7 +2467,7 @@ impl IWICMetadataHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DoesSupportPadding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupportspadding = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupportspadding, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2478,7 +2478,7 @@ impl IWICMetadataHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DoesRequireFixedSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pffixedsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pffixedsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2516,7 +2516,7 @@ impl IWICMetadataQueryReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidcontainerformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidcontainerformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2537,7 +2537,7 @@ impl IWICMetadataQueryReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2604,7 +2604,7 @@ impl IWICMetadataReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidmetadataformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidmetadataformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2615,7 +2615,7 @@ impl IWICMetadataReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataHandlerInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppihandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppihandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2626,7 +2626,7 @@ impl IWICMetadataReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2647,7 +2647,7 @@ impl IWICMetadataReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienummetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienummetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2688,7 +2688,7 @@ impl IWICMetadataReaderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MatchesPattern(::core::mem::transmute_copy(&guidcontainerformat), ::core::mem::transmute(&pistream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmatches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmatches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2699,7 +2699,7 @@ impl IWICMetadataReaderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppireader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppireader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2780,7 +2780,7 @@ impl IWICMetadataWriterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2839,7 +2839,7 @@ impl IWICPalette_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pepalettetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pepalettetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2850,7 +2850,7 @@ impl IWICPalette_Vtbl {
             let this = (*this).get_impl();
             match this.GetColorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2866,7 +2866,7 @@ impl IWICPalette_Vtbl {
             let this = (*this).get_impl();
             match this.IsBlackWhite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisblackwhite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisblackwhite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2877,7 +2877,7 @@ impl IWICPalette_Vtbl {
             let this = (*this).get_impl();
             match this.IsGrayscale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisgrayscale = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisgrayscale, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2888,7 +2888,7 @@ impl IWICPalette_Vtbl {
             let this = (*this).get_impl();
             match this.HasAlpha() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfhasalpha = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfhasalpha, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2957,7 +2957,7 @@ impl IWICPixelFormatInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2968,7 +2968,7 @@ impl IWICPixelFormatInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetColorContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppicolorcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppicolorcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2979,7 +2979,7 @@ impl IWICPixelFormatInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitsPerPixel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puibitsperpixel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puibitsperpixel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2990,7 +2990,7 @@ impl IWICPixelFormatInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puichannelcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puichannelcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3029,7 +3029,7 @@ impl IWICPixelFormatInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.SupportsTransparency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupportstransparency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupportstransparency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3040,7 +3040,7 @@ impl IWICPixelFormatInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumericRepresentation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumericrepresentation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumericrepresentation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3133,7 +3133,7 @@ impl IWICPlanarFormatConverter_Vtbl {
             let this = (*this).get_impl();
             match this.CanConvert(::core::mem::transmute_copy(&psrcpixelformats), ::core::mem::transmute_copy(&csrcplanes), ::core::mem::transmute_copy(&dstpixelformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcanconvert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcanconvert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3179,7 +3179,7 @@ impl IWICProgressiveLevelControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetLevelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclevels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclevels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3190,7 +3190,7 @@ impl IWICProgressiveLevelControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3273,7 +3273,7 @@ impl IWICStreamProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3284,7 +3284,7 @@ impl IWICStreamProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetPersistOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwpersistoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwpersistoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3295,7 +3295,7 @@ impl IWICStreamProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredVendorGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidpreferredvendor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidpreferredvendor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
@@ -125,7 +125,7 @@ impl IBidiRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -141,7 +141,7 @@ impl IBidiRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtotal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtotal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -181,7 +181,7 @@ impl IBidiRequestContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -192,7 +192,7 @@ impl IBidiRequestContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -277,7 +277,7 @@ impl IBidiSpl2_Vtbl {
             let this = (*this).get_impl();
             match this.SendRecvXMLString(::core::mem::transmute(&bstrrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -288,7 +288,7 @@ impl IBidiSpl2_Vtbl {
             let this = (*this).get_impl();
             match this.SendRecvXMLStream(::core::mem::transmute(&psrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -322,7 +322,7 @@ impl IFixedDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -333,7 +333,7 @@ impl IFixedDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintTicket() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprintticket = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprintticket, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -371,7 +371,7 @@ impl IFixedDocumentSequence_Vtbl {
             let this = (*this).get_impl();
             match this.GetUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -382,7 +382,7 @@ impl IFixedDocumentSequence_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintTicket() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprintticket = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprintticket, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -424,7 +424,7 @@ impl IFixedPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintTicket() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprintticket = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprintticket, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -435,7 +435,7 @@ impl IFixedPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetPagePart(::core::mem::transmute(&uri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -446,7 +446,7 @@ impl IFixedPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetWriteStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwritestream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwritestream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -472,7 +472,7 @@ impl IFixedPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetXpsPartIterator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pxpspartit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pxpspartit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -536,7 +536,7 @@ impl IImgErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeveloperDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -547,7 +547,7 @@ impl IImgErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserErrorId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *perrorid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(perrorid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -558,7 +558,7 @@ impl IImgErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserParameterCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcuserparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcuserparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -569,7 +569,7 @@ impl IImgErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserParameter(::core::mem::transmute_copy(&cparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrparam = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrparam, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -580,7 +580,7 @@ impl IImgErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserFallback() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -591,7 +591,7 @@ impl IImgErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetExceptionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pexceptionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pexceptionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -602,7 +602,7 @@ impl IImgErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DetachErrorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *perrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(perrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -667,7 +667,7 @@ impl IPartBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -678,7 +678,7 @@ impl IPartBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -689,7 +689,7 @@ impl IPartBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartCompression() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcompression = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcompression, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -796,7 +796,7 @@ impl IPartFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontRestriction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prestriction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prestriction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -823,7 +823,7 @@ impl IPartImage_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -885,7 +885,7 @@ impl IPartThumbnail_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnailProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -962,7 +962,7 @@ impl IPrintAsyncNotify_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePrintAsyncNotifyChannel(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2), ::core::mem::transmute_copy(&param3), ::core::mem::transmute(&param4)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param5 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param5, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -973,7 +973,7 @@ impl IPrintAsyncNotify_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePrintAsyncNotifyRegistration(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2), ::core::mem::transmute(&param3)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *param4 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param4, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1110,7 +1110,7 @@ impl IPrintAsyncNotifyServerReferral_Vtbl {
             let this = (*this).get_impl();
             match this.GetServerReferral() {
                 ::core::result::Result::Ok(ok__) => {
-                    *param0 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(param0, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1193,7 +1193,7 @@ impl IPrintCoreHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetOption(::core::mem::transmute_copy(&pdevmode), ::core::mem::transmute_copy(&cbsize), ::core::mem::transmute(&pszfeaturerequested)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1313,7 +1313,7 @@ impl IPrintCoreHelperUni_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDefaultGDLSnapshot(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsnapshotstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsnapshotstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1377,7 +1377,7 @@ impl IPrintCoreUI2_Vtbl {
             let this = (*this).get_impl();
             match this.SetOptions(::core::mem::transmute_copy(&poemuiobj), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&pmszfeatureoptionbuf), ::core::mem::transmute_copy(&cbin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1461,7 +1461,7 @@ impl IPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1472,7 +1472,7 @@ impl IPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1483,7 +1483,7 @@ impl IPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.PrintedPages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1494,7 +1494,7 @@ impl IPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.TotalPages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulpages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulpages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1505,7 +1505,7 @@ impl IPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1516,7 +1516,7 @@ impl IPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.SubmissionTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psubmissiontime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psubmissiontime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1558,7 +1558,7 @@ impl IPrintJobCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1569,7 +1569,7 @@ impl IPrintJobCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1580,7 +1580,7 @@ impl IPrintJobCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1940,7 +1940,7 @@ impl IPrintPipelinePropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&pszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2014,7 +2014,7 @@ impl IPrintReadStream_Vtbl {
             let this = (*this).get_impl();
             match this.Seek(::core::mem::transmute_copy(&dlibmove), ::core::mem::transmute_copy(&dworigin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plibnewposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plibnewposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2046,7 +2046,7 @@ impl IPrintReadStreamFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2128,7 +2128,7 @@ impl IPrintSchemaCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeatureByKeyName(::core::mem::transmute(&bstrkeyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfeature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfeature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2139,7 +2139,7 @@ impl IPrintSchemaCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeature(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrnamespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfeature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfeature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2150,7 +2150,7 @@ impl IPrintSchemaCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.PageImageableSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppageimageablesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppageimageablesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2161,7 +2161,7 @@ impl IPrintSchemaCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.JobCopiesAllDocumentsMinValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puljobcopiesalldocumentsminvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puljobcopiesalldocumentsminvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2172,7 +2172,7 @@ impl IPrintSchemaCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.JobCopiesAllDocumentsMaxValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puljobcopiesalldocumentsmaxvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puljobcopiesalldocumentsmaxvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2183,7 +2183,7 @@ impl IPrintSchemaCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedOptionInPrintTicket(::core::mem::transmute(&pfeature)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2194,7 +2194,7 @@ impl IPrintSchemaCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptions(::core::mem::transmute(&pfeature)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoptioncollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoptioncollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2229,7 +2229,7 @@ impl IPrintSchemaCapabilities2_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameterDefinition(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrnamespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparameterdefinition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparameterdefinition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2255,7 +2255,7 @@ impl IPrintSchemaDisplayableElement_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2283,7 +2283,7 @@ impl IPrintSchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.XmlNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppxmlnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppxmlnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2294,7 +2294,7 @@ impl IPrintSchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2305,7 +2305,7 @@ impl IPrintSchemaElement_Vtbl {
             let this = (*this).get_impl();
             match this.NamespaceUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnamespaceuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnamespaceuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2340,7 +2340,7 @@ impl IPrintSchemaFeature_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedOption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2356,7 +2356,7 @@ impl IPrintSchemaFeature_Vtbl {
             let this = (*this).get_impl();
             match this.SelectionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pselectiontype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pselectiontype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2367,7 +2367,7 @@ impl IPrintSchemaFeature_Vtbl {
             let this = (*this).get_impl();
             match this.GetOption(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrnamespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2378,7 +2378,7 @@ impl IPrintSchemaFeature_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbshow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbshow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2411,7 +2411,7 @@ impl IPrintSchemaNUpOption_Vtbl {
             let this = (*this).get_impl();
             match this.PagesPerSheet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulpagespersheet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulpagespersheet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2439,7 +2439,7 @@ impl IPrintSchemaOption_Vtbl {
             let this = (*this).get_impl();
             match this.Selected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisselected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisselected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2450,7 +2450,7 @@ impl IPrintSchemaOption_Vtbl {
             let this = (*this).get_impl();
             match this.Constrained() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psetting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psetting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2461,7 +2461,7 @@ impl IPrintSchemaOption_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyValue(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrnamespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppxmlvaluenode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppxmlvaluenode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2494,7 +2494,7 @@ impl IPrintSchemaOptionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2505,7 +2505,7 @@ impl IPrintSchemaOptionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2516,7 +2516,7 @@ impl IPrintSchemaOptionCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2552,7 +2552,7 @@ impl IPrintSchemaPageImageableSize_Vtbl {
             let this = (*this).get_impl();
             match this.ImageableSizeWidthInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulimageablesizewidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulimageablesizewidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2563,7 +2563,7 @@ impl IPrintSchemaPageImageableSize_Vtbl {
             let this = (*this).get_impl();
             match this.ImageableSizeHeightInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulimageablesizeheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulimageablesizeheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2574,7 +2574,7 @@ impl IPrintSchemaPageImageableSize_Vtbl {
             let this = (*this).get_impl();
             match this.OriginWidthInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puloriginwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puloriginwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2585,7 +2585,7 @@ impl IPrintSchemaPageImageableSize_Vtbl {
             let this = (*this).get_impl();
             match this.OriginHeightInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puloriginheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puloriginheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2596,7 +2596,7 @@ impl IPrintSchemaPageImageableSize_Vtbl {
             let this = (*this).get_impl();
             match this.ExtentWidthInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulextentwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulextentwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2607,7 +2607,7 @@ impl IPrintSchemaPageImageableSize_Vtbl {
             let this = (*this).get_impl();
             match this.ExtentHeightInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulextentheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulextentheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2642,7 +2642,7 @@ impl IPrintSchemaPageMediaSizeOption_Vtbl {
             let this = (*this).get_impl();
             match this.WidthInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2653,7 +2653,7 @@ impl IPrintSchemaPageMediaSizeOption_Vtbl {
             let this = (*this).get_impl();
             match this.HeightInMicrons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2687,7 +2687,7 @@ impl IPrintSchemaParameterDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.UserInputRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisrequired = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisrequired, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2698,7 +2698,7 @@ impl IPrintSchemaParameterDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.UnitType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrunittype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrunittype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2709,7 +2709,7 @@ impl IPrintSchemaParameterDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.DataType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2720,7 +2720,7 @@ impl IPrintSchemaParameterDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.RangeMin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prangemin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prangemin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2731,7 +2731,7 @@ impl IPrintSchemaParameterDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.RangeMax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prangemax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prangemax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2765,7 +2765,7 @@ impl IPrintSchemaParameterInitializer_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2807,7 +2807,7 @@ impl IPrintSchemaTicket_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeatureByKeyName(::core::mem::transmute(&bstrkeyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfeature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfeature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2818,7 +2818,7 @@ impl IPrintSchemaTicket_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeature(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrnamespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfeature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfeature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2829,7 +2829,7 @@ impl IPrintSchemaTicket_Vtbl {
             let this = (*this).get_impl();
             match this.ValidateAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasyncoperation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasyncoperation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2840,7 +2840,7 @@ impl IPrintSchemaTicket_Vtbl {
             let this = (*this).get_impl();
             match this.CommitAsync(::core::mem::transmute(&pprintticketcommit)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasyncoperation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasyncoperation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2856,7 +2856,7 @@ impl IPrintSchemaTicket_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2867,7 +2867,7 @@ impl IPrintSchemaTicket_Vtbl {
             let this = (*this).get_impl();
             match this.JobCopiesAllDocuments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puljobcopiesalldocuments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puljobcopiesalldocuments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2908,7 +2908,7 @@ impl IPrintSchemaTicket2_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameterInitializer(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrnamespaceuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparameterinitializer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparameterinitializer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2965,7 +2965,7 @@ impl IPrintTicketProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintCapabilities(::core::mem::transmute(&pprintticket)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3006,7 +3006,7 @@ impl IPrintTicketProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintDeviceCapabilities(::core::mem::transmute(&pprintticket)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevicecapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevicecapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3017,7 +3017,7 @@ impl IPrintTicketProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintDeviceResources(::core::mem::transmute(&pszlocalename), ::core::mem::transmute(&pprintticket)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdeviceresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdeviceresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3065,7 +3065,7 @@ impl IPrintWriteStream_Vtbl {
             let this = (*this).get_impl();
             match this.WriteBytes(::core::mem::transmute_copy(&pvbuffer), ::core::mem::transmute_copy(&cbbuffer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3157,7 +3157,7 @@ impl IPrinterExtensionContext_Vtbl {
             let this = (*this).get_impl();
             match this.PrinterQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3168,7 +3168,7 @@ impl IPrinterExtensionContext_Vtbl {
             let this = (*this).get_impl();
             match this.PrintSchemaTicket() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppticket = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppticket, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3179,7 +3179,7 @@ impl IPrinterExtensionContext_Vtbl {
             let this = (*this).get_impl();
             match this.DriverProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3190,7 +3190,7 @@ impl IPrinterExtensionContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3224,7 +3224,7 @@ impl IPrinterExtensionContextCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3235,7 +3235,7 @@ impl IPrinterExtensionContextCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3246,7 +3246,7 @@ impl IPrinterExtensionContextCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3313,7 +3313,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.BidiNotification() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbidinotification = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbidinotification, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3324,7 +3324,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ReasonId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preasonid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preasonid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3335,7 +3335,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Request() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3346,7 +3346,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.SourceApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3357,7 +3357,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.DetailedReasonId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdetailedreasonid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdetailedreasonid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3368,7 +3368,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.WindowModal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmodal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmodal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3379,7 +3379,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.WindowParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3480,7 +3480,7 @@ impl IPrinterPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetBool(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3496,7 +3496,7 @@ impl IPrinterPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetInt32(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl IPrinterPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetString(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3538,7 +3538,7 @@ impl IPrinterPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetReadStream(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3549,7 +3549,7 @@ impl IPrinterPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetWriteStream(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3590,7 +3590,7 @@ impl IPrinterQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phprinter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phprinter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3601,7 +3601,7 @@ impl IPrinterQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3617,7 +3617,7 @@ impl IPrinterQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3650,7 +3650,7 @@ impl IPrinterQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.SendBidiSetRequestAsync(::core::mem::transmute(&bstrbidirequest), ::core::mem::transmute(&pcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasyncoperation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasyncoperation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3661,7 +3661,7 @@ impl IPrinterQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrinterQueueView(::core::mem::transmute_copy(&ulviewoffset), ::core::mem::transmute_copy(&ulviewsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppjobview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppjobview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3756,7 +3756,7 @@ impl IPrinterScriptContext_Vtbl {
             let this = (*this).get_impl();
             match this.DriverProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3767,7 +3767,7 @@ impl IPrinterScriptContext_Vtbl {
             let this = (*this).get_impl();
             match this.QueueProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3778,7 +3778,7 @@ impl IPrinterScriptContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3818,7 +3818,7 @@ impl IPrinterScriptablePropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetBool(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3834,7 +3834,7 @@ impl IPrinterScriptablePropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetInt32(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3850,7 +3850,7 @@ impl IPrinterScriptablePropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetString(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3866,7 +3866,7 @@ impl IPrinterScriptablePropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetBytes(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3882,7 +3882,7 @@ impl IPrinterScriptablePropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetReadStream(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3893,7 +3893,7 @@ impl IPrinterScriptablePropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetWriteStream(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3931,7 +3931,7 @@ impl IPrinterScriptablePropertyBag2_Vtbl {
             let this = (*this).get_impl();
             match this.GetReadStreamAsXML(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppxmlnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppxmlnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3958,7 +3958,7 @@ impl IPrinterScriptableSequentialStream_Vtbl {
             let this = (*this).get_impl();
             match this.Read(::core::mem::transmute_copy(&cbread)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3969,7 +3969,7 @@ impl IPrinterScriptableSequentialStream_Vtbl {
             let this = (*this).get_impl();
             match this.Write(::core::mem::transmute(&parray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4006,7 +4006,7 @@ impl IPrinterScriptableStream_Vtbl {
             let this = (*this).get_impl();
             match this.Seek(::core::mem::transmute_copy(&loffset), ::core::mem::transmute_copy(&streamseek)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4040,7 +4040,7 @@ impl IXpsDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnail() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppthumbnail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppthumbnail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4134,7 +4134,7 @@ impl IXpsDocumentProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetXpsPart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppixpspart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppixpspart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4204,7 +4204,7 @@ impl IXpsRasterizationFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRasterizer(::core::mem::transmute(&xpspage), ::core::mem::transmute_copy(&dpi), ::core::mem::transmute_copy(&nontextrenderingmode), ::core::mem::transmute_copy(&textrenderingmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppixpsrasterizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppixpsrasterizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4230,7 +4230,7 @@ impl IXpsRasterizationFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRasterizer(::core::mem::transmute(&xpspage), ::core::mem::transmute_copy(&dpi), ::core::mem::transmute_copy(&nontextrenderingmode), ::core::mem::transmute_copy(&textrenderingmode), ::core::mem::transmute_copy(&pixelformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppixpsrasterizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppixpsrasterizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4256,7 +4256,7 @@ impl IXpsRasterizationFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRasterizer(::core::mem::transmute(&xpspage), ::core::mem::transmute_copy(&dpix), ::core::mem::transmute_copy(&dpiy), ::core::mem::transmute_copy(&nontextrenderingmode), ::core::mem::transmute_copy(&textrenderingmode), ::core::mem::transmute_copy(&pixelformat), ::core::mem::transmute_copy(&backgroundcolor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppixpsrasterizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppixpsrasterizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4283,7 +4283,7 @@ impl IXpsRasterizer_Vtbl {
             let this = (*this).get_impl();
             match this.RasterizeRect(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height), ::core::mem::transmute(&notificationcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
@@ -31,7 +31,7 @@ impl IApoAuxiliaryInputConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.IsInputFormatSupported(::core::mem::transmute(&prequestedinputformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsupportedinputformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsupportedinputformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -102,7 +102,7 @@ impl IAudioMediaType_Vtbl {
             let this = (*this).get_impl();
             match this.IsCompressedFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcompressed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcompressed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -113,7 +113,7 @@ impl IAudioMediaType_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&piaudiotype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -129,7 +129,7 @@ impl IAudioMediaType_Vtbl {
             let this = (*this).get_impl();
             match this.GetUncompressedAudioFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puncompressedaudioformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puncompressedaudioformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -169,7 +169,7 @@ impl IAudioProcessingObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -180,7 +180,7 @@ impl IAudioProcessingObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegistrationProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppregprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppregprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -196,7 +196,7 @@ impl IAudioProcessingObject_Vtbl {
             let this = (*this).get_impl();
             match this.IsInputFormatSupported(::core::mem::transmute(&poppositeformat), ::core::mem::transmute(&prequestedinputformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsupportedinputformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsupportedinputformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -207,7 +207,7 @@ impl IAudioProcessingObject_Vtbl {
             let this = (*this).get_impl();
             match this.IsOutputFormatSupported(::core::mem::transmute(&poppositeformat), ::core::mem::transmute(&prequestedoutputformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsupportedoutputformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsupportedoutputformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -218,7 +218,7 @@ impl IAudioProcessingObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pu32channelcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pu32channelcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl IAudioProcessingObjectRTQueueService_Vtbl {
             let this = (*this).get_impl();
             match this.GetRealTimeWorkQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *workqueueid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(workqueueid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -382,7 +382,7 @@ impl IAudioProcessingObjectVBR_Vtbl {
             let this = (*this).get_impl();
             match this.CalcMaxInputFrames(::core::mem::transmute_copy(&u32maxoutputframecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pu32inputframecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pu32inputframecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -393,7 +393,7 @@ impl IAudioProcessingObjectVBR_Vtbl {
             let this = (*this).get_impl();
             match this.CalcMaxOutputFrames(::core::mem::transmute_copy(&u32maxinputframecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pu32outputframecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pu32outputframecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -482,7 +482,7 @@ impl IAudioSystemEffectsCustomFormats_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -493,7 +493,7 @@ impl IAudioSystemEffectsCustomFormats_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat(::core::mem::transmute_copy(&nformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -504,7 +504,7 @@ impl IAudioSystemEffectsCustomFormats_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatRepresentation(::core::mem::transmute_copy(&nformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwstrformatrep = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwstrformatrep, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
@@ -213,7 +213,7 @@ impl IDirectMusicCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstrument(::core::mem::transmute_copy(&dwpatch)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinstrument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinstrument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -343,7 +343,7 @@ impl IDirectMusicPort_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatencyClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -445,7 +445,7 @@ impl IDirectMusicPortDownload_Vtbl {
             let this = (*this).get_impl();
             match this.GetBuffer(::core::mem::transmute_copy(&dwdlid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidmdownload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidmdownload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -456,7 +456,7 @@ impl IDirectMusicPortDownload_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateBuffer(::core::mem::transmute_copy(&dwsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidmdownload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidmdownload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -571,7 +571,7 @@ impl IDirectMusicSynth_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatencyClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -719,7 +719,7 @@ impl IDirectMusicSynthSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatencyClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
@@ -24,7 +24,7 @@ impl IDirectSound_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdscaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdscaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35,7 +35,7 @@ impl IDirectSound_Vtbl {
             let this = (*this).get_impl();
             match this.DuplicateSoundBuffer(::core::mem::transmute(&pdsbufferoriginal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdsbufferduplicate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdsbufferduplicate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -56,7 +56,7 @@ impl IDirectSound_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpeakerConfig() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwspeakerconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwspeakerconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -119,7 +119,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pds3dbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pds3dbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -135,7 +135,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetConeOrientation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvorientation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvorientation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -146,7 +146,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetConeOutsideVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plconeoutsidevolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plconeoutsidevolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -157,7 +157,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxDistance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflmaxdistance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflmaxdistance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -168,7 +168,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinDistance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflmindistance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflmindistance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -179,7 +179,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IDirectSound3DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetVelocity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvelocity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvelocity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -306,7 +306,7 @@ impl IDirectSound3DListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plistener = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plistener, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl IDirectSound3DListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetDistanceFactor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfldistancefactor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfldistancefactor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -328,7 +328,7 @@ impl IDirectSound3DListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetDopplerFactor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfldopplerfactor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfldopplerfactor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -344,7 +344,7 @@ impl IDirectSound3DListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -355,7 +355,7 @@ impl IDirectSound3DListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetRolloffFactor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflrollofffactor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflrollofffactor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -366,7 +366,7 @@ impl IDirectSound3DListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetVelocity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvelocity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvelocity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -449,7 +449,7 @@ impl IDirectSound8_Vtbl {
             let this = (*this).get_impl();
             match this.VerifyCertification() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcertified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcertified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -489,7 +489,7 @@ impl IDirectSoundBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsbuffercaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsbuffercaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -510,7 +510,7 @@ impl IDirectSoundBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -521,7 +521,7 @@ impl IDirectSoundBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpan = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpan, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -532,7 +532,7 @@ impl IDirectSoundBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwfrequency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwfrequency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -543,7 +543,7 @@ impl IDirectSoundBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -682,7 +682,7 @@ impl IDirectSoundCapture_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsccaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsccaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -723,7 +723,7 @@ impl IDirectSoundCaptureBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdscbcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdscbcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -744,7 +744,7 @@ impl IDirectSoundCaptureBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -841,7 +841,7 @@ impl IDirectSoundCaptureFXAec_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdscfxaec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdscfxaec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -852,7 +852,7 @@ impl IDirectSoundCaptureFXAec_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -896,7 +896,7 @@ impl IDirectSoundCaptureFXNoiseSuppress_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdscfxnoisesuppress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdscfxnoisesuppress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -935,7 +935,7 @@ impl IDirectSoundFXChorus_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxchorus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxchorus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -968,7 +968,7 @@ impl IDirectSoundFXCompressor_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxcompressor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxcompressor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1001,7 +1001,7 @@ impl IDirectSoundFXDistortion_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxdistortion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxdistortion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1034,7 +1034,7 @@ impl IDirectSoundFXEcho_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxecho = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxecho, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1067,7 +1067,7 @@ impl IDirectSoundFXFlanger_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxflanger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxflanger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1100,7 +1100,7 @@ impl IDirectSoundFXGargle_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxgargle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxgargle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1137,7 +1137,7 @@ impl IDirectSoundFXI3DL2Reverb_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxi3dl2reverb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxi3dl2reverb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1153,7 +1153,7 @@ impl IDirectSoundFXI3DL2Reverb_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwpreset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwpreset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1169,7 +1169,7 @@ impl IDirectSoundFXI3DL2Reverb_Vtbl {
             let this = (*this).get_impl();
             match this.GetQuality() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plquality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plquality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1206,7 +1206,7 @@ impl IDirectSoundFXParamEq_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxparameq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxparameq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1239,7 +1239,7 @@ impl IDirectSoundFXWavesReverb_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdsfxwavesreverb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdsfxwavesreverb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
@@ -57,7 +57,7 @@ impl IAudioEndpointOffloadStreamMeter_Vtbl {
             let this = (*this).get_impl();
             match this.GetMeterChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pu32channelcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pu32channelcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -68,7 +68,7 @@ impl IAudioEndpointOffloadStreamMeter_Vtbl {
             let this = (*this).get_impl();
             match this.GetMeteringData(::core::mem::transmute_copy(&u32channelcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pf32peakvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pf32peakvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -101,7 +101,7 @@ impl IAudioEndpointOffloadStreamMute_Vtbl {
             let this = (*this).get_impl();
             match this.GetMute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmuted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmuted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl IAudioEndpointOffloadStreamVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetVolumeChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pu32channelcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pu32channelcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -149,7 +149,7 @@ impl IAudioEndpointOffloadStreamVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelVolumes(::core::mem::transmute_copy(&u32channelcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pf32volumes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pf32volumes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -207,7 +207,7 @@ impl IAudioEndpointVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnchannelcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnchannelcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -228,7 +228,7 @@ impl IAudioEndpointVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetMasterVolumeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfleveldb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfleveldb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -239,7 +239,7 @@ impl IAudioEndpointVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetMasterVolumeLevelScalar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -260,7 +260,7 @@ impl IAudioEndpointVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelVolumeLevel(::core::mem::transmute_copy(&nchannel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfleveldb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfleveldb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -271,7 +271,7 @@ impl IAudioEndpointVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelVolumeLevelScalar(::core::mem::transmute_copy(&nchannel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -287,7 +287,7 @@ impl IAudioEndpointVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetMute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -313,7 +313,7 @@ impl IAudioEndpointVolume_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHardwareSupport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhardwaresupportmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhardwaresupportmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -410,7 +410,7 @@ impl IAudioLfxControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalEffectsState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl IAudioMeterInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetPeakValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfpeak = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfpeak, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -451,7 +451,7 @@ impl IAudioMeterInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetMeteringChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnchannelcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnchannelcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -467,7 +467,7 @@ impl IAudioMeterInformation_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHardwareSupport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhardwaresupportmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhardwaresupportmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -503,7 +503,7 @@ impl IHardwareAudioEngineBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableOffloadConnectorCount(::core::mem::transmute(&_pwstrdeviceid), ::core::mem::transmute_copy(&_uconnectorid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *_pavailableconnectorinstancecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_pavailableconnectorinstancecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -529,7 +529,7 @@ impl IHardwareAudioEngineBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetGfxState(::core::mem::transmute(&pdevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *_pbenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_pbenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
@@ -21,7 +21,7 @@ impl IXAPO_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegistrationProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppregistrationproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppregistrationproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32,7 +32,7 @@ impl IXAPO_Vtbl {
             let this = (*this).get_impl();
             match this.IsInputFormatSupported(::core::mem::transmute_copy(&poutputformat), ::core::mem::transmute_copy(&prequestedinputformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsupportedinputformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsupportedinputformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -43,7 +43,7 @@ impl IXAPO_Vtbl {
             let this = (*this).get_impl();
             match this.IsOutputFormatSupported(::core::mem::transmute_copy(&pinputformat), ::core::mem::transmute_copy(&prequestedoutputformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsupportedoutputformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsupportedoutputformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IXAudio2MasteringVoice_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchannelmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchannelmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
@@ -59,7 +59,7 @@ impl IAudioAmbisonicsControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetHeadTracking() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenableheadtracking = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenableheadtracking, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -97,7 +97,7 @@ impl IAudioAutoGainControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -151,7 +151,7 @@ impl IAudioCaptureClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextPacketSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumframesinnextpacket = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumframesinnextpacket, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -185,7 +185,7 @@ impl IAudioChannelConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelConfig() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -231,7 +231,7 @@ impl IAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetBufferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumbufferframes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumbufferframes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -242,7 +242,7 @@ impl IAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phnslatency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phnslatency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -253,7 +253,7 @@ impl IAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPadding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumpaddingframes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumpaddingframes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -269,7 +269,7 @@ impl IAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetMixFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdeviceformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdeviceformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -341,7 +341,7 @@ impl IAudioClient2_Vtbl {
             let this = (*this).get_impl();
             match this.IsOffloadCapable(::core::mem::transmute_copy(&category)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pboffloadcapable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pboffloadcapable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -438,7 +438,7 @@ impl IAudioClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pu64frequency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pu64frequency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -454,7 +454,7 @@ impl IAudioClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharacteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcharacteristics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcharacteristics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -578,7 +578,7 @@ impl IAudioFormatEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -589,7 +589,7 @@ impl IAudioFormatEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -617,7 +617,7 @@ impl IAudioInputSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnidselected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnidselected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -653,7 +653,7 @@ impl IAudioLoudness_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -704,7 +704,7 @@ impl IAudioMute_Vtbl {
             let this = (*this).get_impl();
             match this.GetMute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmuted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmuted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -732,7 +732,7 @@ impl IAudioOutputSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnidselected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnidselected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -765,7 +765,7 @@ impl IAudioPeakMeter_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchannels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchannels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -776,7 +776,7 @@ impl IAudioPeakMeter_Vtbl {
             let this = (*this).get_impl();
             match this.GetLevel(::core::mem::transmute_copy(&nchannel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -804,7 +804,7 @@ impl IAudioRenderClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetBuffer(::core::mem::transmute_copy(&numframesrequested)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -844,7 +844,7 @@ impl IAudioSessionControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -855,7 +855,7 @@ impl IAudioSessionControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -871,7 +871,7 @@ impl IAudioSessionControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetIconPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -887,7 +887,7 @@ impl IAudioSessionControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroupingParam() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl IAudioSessionControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSessionIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl IAudioSessionControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSessionInstanceIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -965,7 +965,7 @@ impl IAudioSessionControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1006,7 +1006,7 @@ impl IAudioSessionEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sessioncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sessioncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1017,7 +1017,7 @@ impl IAudioSessionEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetSession(::core::mem::transmute_copy(&sessioncount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *session = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(session, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1110,7 +1110,7 @@ impl IAudioSessionManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioSessionControl(::core::mem::transmute_copy(&audiosessionguid), ::core::mem::transmute_copy(&streamflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sessioncontrol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sessioncontrol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1121,7 +1121,7 @@ impl IAudioSessionManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSimpleAudioVolume(::core::mem::transmute_copy(&audiosessionguid), ::core::mem::transmute_copy(&streamflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiovolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiovolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1152,7 +1152,7 @@ impl IAudioSessionManager2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSessionEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sessionenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sessionenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1221,7 +1221,7 @@ impl IAudioStateMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterCallback(::core::mem::transmute(&callback), ::core::mem::transmute_copy(&context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *registration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(registration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1263,7 +1263,7 @@ impl IAudioStreamVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1279,7 +1279,7 @@ impl IAudioStreamVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelVolume(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1348,7 +1348,7 @@ impl IAudioSystemEffectsPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.OpenDefaultPropertyStore(::core::mem::transmute_copy(&stgmaccess)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1359,7 +1359,7 @@ impl IAudioSystemEffectsPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.OpenUserPropertyStore(::core::mem::transmute_copy(&stgmaccess)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1370,7 +1370,7 @@ impl IAudioSystemEffectsPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.OpenVolatilePropertyStore(::core::mem::transmute_copy(&stgmaccess)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1473,7 +1473,7 @@ impl IChannelAudioVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1489,7 +1489,7 @@ impl IChannelAudioVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelVolume(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1539,7 +1539,7 @@ impl IConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1550,7 +1550,7 @@ impl IConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataFlow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1571,7 +1571,7 @@ impl IConnector_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1582,7 +1582,7 @@ impl IConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectedTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1593,7 +1593,7 @@ impl IConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectorIdConnectedTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwstrconnectorid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwstrconnectorid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1604,7 +1604,7 @@ impl IConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceIdConnectedTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwstrdeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwstrdeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1655,7 +1655,7 @@ impl IControlInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1666,7 +1666,7 @@ impl IControlInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetIID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1696,7 +1696,7 @@ impl IDeviceSpecificProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1749,7 +1749,7 @@ impl IDeviceTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1760,7 +1760,7 @@ impl IDeviceTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnector(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1771,7 +1771,7 @@ impl IDeviceTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubunitCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1782,7 +1782,7 @@ impl IDeviceTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubunit(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubunit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubunit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1793,7 +1793,7 @@ impl IDeviceTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartById(::core::mem::transmute_copy(&nid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1804,7 +1804,7 @@ impl IDeviceTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwstrdeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwstrdeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1815,7 +1815,7 @@ impl IDeviceTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignalPath(::core::mem::transmute(&pipartfrom), ::core::mem::transmute(&pipartto), ::core::mem::transmute_copy(&brejectmixedpaths)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1858,7 +1858,7 @@ impl IMMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.OpenPropertyStore(::core::mem::transmute_copy(&stgmaccess)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1869,7 +1869,7 @@ impl IMMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1880,7 +1880,7 @@ impl IMMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1930,7 +1930,7 @@ impl IMMDeviceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcdevices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcdevices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1941,7 +1941,7 @@ impl IMMDeviceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&ndevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1972,7 +1972,7 @@ impl IMMDeviceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAudioEndpoints(::core::mem::transmute_copy(&dataflow), ::core::mem::transmute_copy(&dwstatemask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1983,7 +1983,7 @@ impl IMMDeviceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultAudioEndpoint(::core::mem::transmute_copy(&dataflow), ::core::mem::transmute_copy(&role)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppendpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppendpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1994,7 +1994,7 @@ impl IMMDeviceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice(::core::mem::transmute(&pwstrid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2034,7 +2034,7 @@ impl IMMEndpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataFlow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdataflow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdataflow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2157,7 +2157,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2168,7 +2168,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2179,7 +2179,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlobalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwstrglobalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwstrglobalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2190,7 +2190,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2201,7 +2201,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psubtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psubtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2212,7 +2212,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlInterfaceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2223,7 +2223,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlInterface(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinterfacedesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinterfacedesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2234,7 +2234,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.EnumPartsIncoming() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2245,7 +2245,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.EnumPartsOutgoing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2256,7 +2256,7 @@ impl IPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetTopologyObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptopology = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptopology, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2310,7 +2310,7 @@ impl IPartsList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2321,7 +2321,7 @@ impl IPartsList_Vtbl {
             let this = (*this).get_impl();
             match this.GetPart(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2353,7 +2353,7 @@ impl IPerChannelDbLevel_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchannels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchannels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2369,7 +2369,7 @@ impl IPerChannelDbLevel_Vtbl {
             let this = (*this).get_impl();
             match this.GetLevel(::core::mem::transmute_copy(&nchannel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfleveldb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfleveldb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2426,7 +2426,7 @@ impl ISimpleAudioVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetMasterVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2442,7 +2442,7 @@ impl ISimpleAudioVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetMute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2486,7 +2486,7 @@ impl ISpatialAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetNativeStaticObjectTypeMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2497,7 +2497,7 @@ impl ISpatialAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxDynamicObjectCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2508,7 +2508,7 @@ impl ISpatialAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedAudioObjectFormatEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2519,7 +2519,7 @@ impl ISpatialAudioClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxFrameCount(::core::mem::transmute_copy(&objectformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *framecountperbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(framecountperbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2571,7 +2571,7 @@ impl ISpatialAudioClient2_Vtbl {
             let this = (*this).get_impl();
             match this.IsOffloadCapable(::core::mem::transmute_copy(&category)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isoffloadcapable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isoffloadcapable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2582,7 +2582,7 @@ impl ISpatialAudioClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxFrameCountForCategory(::core::mem::transmute_copy(&category), ::core::mem::transmute_copy(&offloadenabled), ::core::mem::transmute_copy(&objectformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *framecountperbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(framecountperbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2618,7 +2618,7 @@ impl ISpatialAudioMetadataClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpatialAudioMetadataItemsBufferLength(::core::mem::transmute_copy(&maxitemcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bufferlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bufferlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2629,7 +2629,7 @@ impl ISpatialAudioMetadataClient_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateSpatialAudioMetadataWriter(::core::mem::transmute_copy(&overflowmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *metadatawriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metadatawriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2640,7 +2640,7 @@ impl ISpatialAudioMetadataClient_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateSpatialAudioMetadataCopier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *metadatacopier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metadatacopier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2651,7 +2651,7 @@ impl ISpatialAudioMetadataClient_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateSpatialAudioMetadataReader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *metadatareader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metadatareader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2688,7 +2688,7 @@ impl ISpatialAudioMetadataCopier_Vtbl {
             let this = (*this).get_impl();
             match this.CopyMetadataForFrames(::core::mem::transmute_copy(&copyframecount), ::core::mem::transmute_copy(&copymode), ::core::mem::transmute(&dstmetadataitems)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemscopied = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemscopied, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2725,7 +2725,7 @@ impl ISpatialAudioMetadataItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *framecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(framecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2736,7 +2736,7 @@ impl ISpatialAudioMetadataItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2747,7 +2747,7 @@ impl ISpatialAudioMetadataItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxitemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxitemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2758,7 +2758,7 @@ impl ISpatialAudioMetadataItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxValueBufferLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxvaluebufferlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxvaluebufferlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2769,7 +2769,7 @@ impl ISpatialAudioMetadataItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2961,7 +2961,7 @@ impl ISpatialAudioObjectBase_Vtbl {
             let this = (*this).get_impl();
             match this.IsActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isactive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isactive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2972,7 +2972,7 @@ impl ISpatialAudioObjectBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioObjectType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioobjecttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioobjecttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3085,7 +3085,7 @@ impl ISpatialAudioObjectForMetadataItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpatialAudioMetadataItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *metadataitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metadataitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3111,7 +3111,7 @@ impl ISpatialAudioObjectRenderStream_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateSpatialAudioObject(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3143,7 +3143,7 @@ impl ISpatialAudioObjectRenderStreamBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableDynamicObjectCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3205,7 +3205,7 @@ impl ISpatialAudioObjectRenderStreamForHrtf_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateSpatialAudioObjectForHrtf(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3232,7 +3232,7 @@ impl ISpatialAudioObjectRenderStreamForMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateSpatialAudioObjectForMetadataCommands(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3243,7 +3243,7 @@ impl ISpatialAudioObjectRenderStreamForMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateSpatialAudioObjectForMetadataItems(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
@@ -56,7 +56,7 @@ impl IMDSPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -67,7 +67,7 @@ impl IMDSPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -88,7 +88,7 @@ impl IMDSPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -99,7 +99,7 @@ impl IMDSPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -110,7 +110,7 @@ impl IMDSPDevice_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStorage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -162,7 +162,7 @@ impl IMDSPDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorage(::core::mem::transmute(&pszstoragename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -213,7 +213,7 @@ impl IMDSPDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&pwszpropname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -229,7 +229,7 @@ impl IMDSPDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatCapability(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformatsupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformatsupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl IMDSPDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.FindStorage(::core::mem::transmute_copy(&findscope), ::core::mem::transmute(&pwszuniqueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -282,7 +282,7 @@ impl IMDSPDeviceControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDCStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -293,7 +293,7 @@ impl IMDSPDeviceControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcapabilitiesmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcapabilitiesmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -356,7 +356,7 @@ impl IMDSPDirectTransfer_Vtbl {
             let this = (*this).get_impl();
             match this.TransferToDevice(::core::mem::transmute(&pwszsourcefilepath), ::core::mem::transmute(&psourceoperation), ::core::mem::transmute_copy(&fuflags), ::core::mem::transmute(&pwszdestinationname), ::core::mem::transmute(&psourcemetadata), ::core::mem::transmute(&ptransferprogress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -387,7 +387,7 @@ impl IMDSPEnumDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Skip(::core::mem::transmute_copy(&celt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pceltfetched = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pceltfetched, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -403,7 +403,7 @@ impl IMDSPEnumDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl IMDSPEnumStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Skip(::core::mem::transmute_copy(&celt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pceltfetched = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pceltfetched, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -456,7 +456,7 @@ impl IMDSPEnumStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -587,7 +587,7 @@ impl IMDSPObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlayLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -603,7 +603,7 @@ impl IMDSPObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlayOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -619,7 +619,7 @@ impl IMDSPObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -630,7 +630,7 @@ impl IMDSPObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastPlayPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlastpos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlastpos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -641,7 +641,7 @@ impl IMDSPObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLongestPlayPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlongestpos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlongestpos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -704,7 +704,7 @@ impl IMDSPStorage_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorageGlobals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorageglobals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorageglobals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -725,7 +725,7 @@ impl IMDSPStorage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetimeutc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetimeutc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -746,7 +746,7 @@ impl IMDSPStorage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStorage(::core::mem::transmute_copy(&dwattributes), ::core::mem::transmute_copy(&pformat), ::core::mem::transmute(&pwszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -757,7 +757,7 @@ impl IMDSPStorage_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStorage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -803,7 +803,7 @@ impl IMDSPStorage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorage(::core::mem::transmute(&pszstoragename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -814,7 +814,7 @@ impl IMDSPStorage2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStorage2(::core::mem::transmute_copy(&dwattributes), ::core::mem::transmute_copy(&dwattributesex), ::core::mem::transmute_copy(&paudioformat), ::core::mem::transmute_copy(&pvideoformat), ::core::mem::transmute(&pwszname), ::core::mem::transmute_copy(&qwfilesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -901,7 +901,7 @@ impl IMDSPStorage4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStorageWithMetadata(::core::mem::transmute_copy(&dwattributes), ::core::mem::transmute(&pwszname), ::core::mem::transmute(&pmetadata), ::core::mem::transmute_copy(&qwfilesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -917,7 +917,7 @@ impl IMDSPStorage4_Vtbl {
             let this = (*this).get_impl();
             match this.FindStorage(::core::mem::transmute_copy(&findscope), ::core::mem::transmute(&pwszuniqueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -928,7 +928,7 @@ impl IMDSPStorage4_Vtbl {
             let this = (*this).get_impl();
             match this.GetParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -967,7 +967,7 @@ impl IMDSPStorageGlobals_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -998,7 +998,7 @@ impl IMDSPStorageGlobals_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1014,7 +1014,7 @@ impl IMDSPStorageGlobals_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1025,7 +1025,7 @@ impl IMDSPStorageGlobals_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootStorage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1060,7 +1060,7 @@ impl IMDServiceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1071,7 +1071,7 @@ impl IMDServiceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1132,7 +1132,7 @@ impl ISCPSecureAuthenticate_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecureQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecurequery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecurequery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1155,7 +1155,7 @@ impl ISCPSecureAuthenticate2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSCPSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscpsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscpsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1231,7 +1231,7 @@ impl ISCPSecureExchange3_Vtbl {
             let this = (*this).get_impl();
             match this.TransferContainerDataOnClearChannel(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&dwsize), ::core::mem::transmute(&pprogresscallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfureadyflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfureadyflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1406,7 +1406,7 @@ impl ISCPSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecureQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecurequery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecurequery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1454,7 +1454,7 @@ impl IWMDMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1465,7 +1465,7 @@ impl IWMDMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1486,7 +1486,7 @@ impl IWMDMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1497,7 +1497,7 @@ impl IWMDMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1508,7 +1508,7 @@ impl IWMDMDevice_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStorage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1560,7 +1560,7 @@ impl IWMDMDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorage(::core::mem::transmute(&pszstoragename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1611,7 +1611,7 @@ impl IWMDMDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&pwszpropname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1627,7 +1627,7 @@ impl IWMDMDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormatCapability(::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformatsupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformatsupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1643,7 +1643,7 @@ impl IWMDMDevice3_Vtbl {
             let this = (*this).get_impl();
             match this.FindStorage(::core::mem::transmute_copy(&findscope), ::core::mem::transmute(&pwszuniqueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1680,7 +1680,7 @@ impl IWMDMDeviceControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1691,7 +1691,7 @@ impl IWMDMDeviceControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcapabilitiesmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcapabilitiesmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1789,7 +1789,7 @@ impl IWMDMEnumDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Skip(::core::mem::transmute_copy(&celt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pceltfetched = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pceltfetched, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1805,7 +1805,7 @@ impl IWMDMEnumDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1842,7 +1842,7 @@ impl IWMDMEnumStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Skip(::core::mem::transmute_copy(&celt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pceltfetched = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pceltfetched, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1858,7 +1858,7 @@ impl IWMDMEnumStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1898,7 +1898,7 @@ impl IWMDMLogger_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1990,7 +1990,7 @@ impl IWMDMMetaData_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2042,7 +2042,7 @@ impl IWMDMObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlayLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2058,7 +2058,7 @@ impl IWMDMObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlayOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2074,7 +2074,7 @@ impl IWMDMObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2085,7 +2085,7 @@ impl IWMDMObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastPlayPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlastpos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlastpos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2096,7 +2096,7 @@ impl IWMDMObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLongestPlayPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlongestpos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlongestpos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2376,7 +2376,7 @@ impl IWMDMStorage_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorageGlobals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorageglobals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorageglobals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2397,7 +2397,7 @@ impl IWMDMStorage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatetimeutc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatetimeutc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2418,7 +2418,7 @@ impl IWMDMStorage_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStorage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penumstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penumstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2462,7 +2462,7 @@ impl IWMDMStorage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorage(::core::mem::transmute(&pszstoragename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2506,7 +2506,7 @@ impl IWMDMStorage3_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2522,7 +2522,7 @@ impl IWMDMStorage3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEmptyMetadataObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2579,7 +2579,7 @@ impl IWMDMStorage4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpecifiedMetadata(::core::mem::transmute_copy(&cproperties), ::core::mem::transmute_copy(&ppwszpropnames)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2590,7 +2590,7 @@ impl IWMDMStorage4_Vtbl {
             let this = (*this).get_impl();
             match this.FindStorage(::core::mem::transmute_copy(&findscope), ::core::mem::transmute(&pwszuniqueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2601,7 +2601,7 @@ impl IWMDMStorage4_Vtbl {
             let this = (*this).get_impl();
             match this.GetParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2636,7 +2636,7 @@ impl IWMDMStorageControl_Vtbl {
             let this = (*this).get_impl();
             match this.Insert(::core::mem::transmute_copy(&fumode), ::core::mem::transmute(&pwszfile), ::core::mem::transmute(&poperation), ::core::mem::transmute(&pprogress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2726,7 +2726,7 @@ impl IWMDMStorageGlobals_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2757,7 +2757,7 @@ impl IWMDMStorageGlobals_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2796,7 +2796,7 @@ impl IWMDeviceManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetRevision() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrevision = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrevision, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2807,7 +2807,7 @@ impl IWMDeviceManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2818,7 +2818,7 @@ impl IWMDeviceManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2848,7 +2848,7 @@ impl IWMDeviceManager2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceFromCanonicalName(::core::mem::transmute(&pwszcanonicalname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2859,7 +2859,7 @@ impl IWMDeviceManager2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDevices2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
@@ -17,7 +17,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableTVFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lanalogvideostandard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lanalogvideostandard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33,7 +33,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.TVFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *planalogvideostandard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planalogvideostandard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -44,7 +44,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontalLocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllocked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllocked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -60,7 +60,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.VCRHorizontalLocking() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvcrhorizontallocking = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvcrhorizontallocking, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -71,7 +71,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfLines() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnumberoflines = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnumberoflines, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -87,7 +87,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.OutputEnable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ploutputenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ploutputenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -127,7 +127,7 @@ impl IAMAnalogVideoEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableTVFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lanalogvideostandard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lanalogvideostandard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -143,7 +143,7 @@ impl IAMAnalogVideoEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.TVFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *planalogvideostandard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planalogvideostandard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -159,7 +159,7 @@ impl IAMAnalogVideoEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.CopyProtection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lvideocopyprotection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lvideocopyprotection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -175,7 +175,7 @@ impl IAMAnalogVideoEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.CCEnable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lccenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lccenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -211,7 +211,7 @@ impl IAMAsyncReaderTimestampScaling_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimestampMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfraw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfraw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -266,7 +266,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.Enable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -282,7 +282,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.Mono() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmono = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmono, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.MixLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.Pan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppan = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppan, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.Loudness() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfloudness = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfloudness, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -346,7 +346,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.Treble() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptreble = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptreble, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -357,7 +357,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.TrebleRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -373,7 +373,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.Bass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -384,7 +384,7 @@ impl IAMAudioInputMixer_Vtbl {
             let this = (*this).get_impl();
             match this.BassRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -448,7 +448,7 @@ impl IAMBufferNegotiation_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocatorProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -527,7 +527,7 @@ impl IAMCertifiedOutputProtection_Vtbl {
             let this = (*this).get_impl();
             match this.ProtectionStatus(::core::mem::transmute_copy(&pstatusinput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatusoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatusoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -637,7 +637,7 @@ impl IAMClockSlave_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorTolerance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtolerance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtolerance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl IAMCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl IAMCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&litem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -691,7 +691,7 @@ impl IAMCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -758,7 +758,7 @@ impl IAMCrossbar_Vtbl {
             let this = (*this).get_impl();
             match this.get_IsRoutedTo(::core::mem::transmute_copy(&outputpinindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inputpinindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inputpinindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -793,7 +793,7 @@ impl IAMDecoderCaps_Vtbl {
             let this = (*this).get_impl();
             match this.GetDecoderCaps(::core::mem::transmute_copy(&dwcapindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwcap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwcap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -876,7 +876,7 @@ impl IAMDevMemoryControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwdevid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwdevid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -948,7 +948,7 @@ impl IAMDirectSound_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectSoundInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -959,7 +959,7 @@ impl IAMDirectSound_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrimaryBufferInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpdsb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpdsb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -970,7 +970,7 @@ impl IAMDirectSound_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecondaryBufferInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpdsb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpdsb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1031,7 +1031,7 @@ impl IAMDroppedFrames_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumDropped() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldropped = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldropped, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1042,7 +1042,7 @@ impl IAMDroppedFrames_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumNotDropped() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnotdropped = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnotdropped, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1058,7 +1058,7 @@ impl IAMDroppedFrames_Vtbl {
             let this = (*this).get_impl();
             match this.GetAverageFrameSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plaveragesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plaveragesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1099,7 +1099,7 @@ impl IAMExtDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ExternalDeviceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1110,7 +1110,7 @@ impl IAMExtDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ExternalDeviceVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1126,7 +1126,7 @@ impl IAMExtDevice_Vtbl {
             let this = (*this).get_impl();
             match this.DevicePower() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppowermode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppowermode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1137,7 +1137,7 @@ impl IAMExtDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Calibrate(::core::mem::transmute_copy(&hevent), ::core::mem::transmute_copy(&mode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1153,7 +1153,7 @@ impl IAMExtDevice_Vtbl {
             let this = (*this).get_impl();
             match this.DevicePort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdeviceport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdeviceport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1223,7 +1223,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.MediaState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1239,7 +1239,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.LocalControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1250,7 +1250,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus(::core::mem::transmute_copy(&statusitem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1271,7 +1271,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportVideoParameters(::core::mem::transmute_copy(&param)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1287,7 +1287,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportAudioParameters(::core::mem::transmute_copy(&param)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1308,7 +1308,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.Mode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1324,7 +1324,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.Rate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdblrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdblrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1355,7 +1355,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.AntiClogControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1371,7 +1371,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.GetEditPropertySet(::core::mem::transmute_copy(&editid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1387,7 +1387,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.GetEditProperty(::core::mem::transmute_copy(&editid), ::core::mem::transmute_copy(&param)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1403,7 +1403,7 @@ impl IAMExtTransport_Vtbl {
             let this = (*this).get_impl();
             match this.EditStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1664,7 +1664,7 @@ impl IAMLatency_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtlatency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtlatency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2013,7 +2013,7 @@ impl IAMMediaTypeSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetPointer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2069,7 +2069,7 @@ impl IAMMediaTypeSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2153,7 +2153,7 @@ impl IAMMediaTypeStream_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSample(::core::mem::transmute_copy(&lsamplesize), ::core::mem::transmute_copy(&pbbuffer), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&punkouter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppammediatypesample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppammediatypesample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2164,7 +2164,7 @@ impl IAMMediaTypeStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamAllocatorRequirements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2213,7 +2213,7 @@ impl IAMMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterGraph() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgraphbuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgraphbuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2224,7 +2224,7 @@ impl IAMMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2235,7 +2235,7 @@ impl IAMMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.AddMediaStream(::core::mem::transmute(&pstreamobject), ::core::mem::transmute_copy(&purposeid), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2655,7 +2655,7 @@ impl IAMOverlayFX_Vtbl {
             let this = (*this).get_impl();
             match this.QueryOverlayFXCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwoverlayfxcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwoverlayfxcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2671,7 +2671,7 @@ impl IAMOverlayFX_Vtbl {
             let this = (*this).get_impl();
             match this.GetOverlayFX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwoverlayfx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwoverlayfx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2701,7 +2701,7 @@ impl IAMParse_Vtbl {
             let this = (*this).get_impl();
             match this.GetParseTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtcurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtcurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2760,7 +2760,7 @@ impl IAMPlayList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2771,7 +2771,7 @@ impl IAMPlayList_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2782,7 +2782,7 @@ impl IAMPlayList_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&dwitemindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2835,7 +2835,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2846,7 +2846,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2857,7 +2857,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceURL(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2868,7 +2868,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceStart(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2879,7 +2879,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceDuration(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2890,7 +2890,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceStartMarker(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmarker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmarker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2901,7 +2901,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceEndMarker(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmarker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmarker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2912,7 +2912,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceStartMarkerName(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstartmarker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstartmarker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2923,7 +2923,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceEndMarkerName(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrendmarker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrendmarker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2934,7 +2934,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2945,7 +2945,7 @@ impl IAMPlayListItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetScanDuration(::core::mem::transmute_copy(&dwsourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtscanduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtscanduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2990,7 +2990,7 @@ impl IAMPluginControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredClsid(::core::mem::transmute_copy(&subtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *clsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3016,7 +3016,7 @@ impl IAMPluginControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisabledByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *clsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3063,7 +3063,7 @@ impl IAMPushSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetPushSourceFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3084,7 +3084,7 @@ impl IAMPushSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3095,7 +3095,7 @@ impl IAMPushSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxStreamOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtmaxoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtmaxoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3178,7 +3178,7 @@ impl IAMStats_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3199,7 +3199,7 @@ impl IAMStats_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndex(::core::mem::transmute(&szname), ::core::mem::transmute_copy(&lcreate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3246,7 +3246,7 @@ impl IAMStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3300,7 +3300,7 @@ impl IAMStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3333,7 +3333,7 @@ impl IAMStreamSelect_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3376,7 +3376,7 @@ impl IAMTVAudio_Vtbl {
             let this = (*this).get_impl();
             match this.GetHardwareSupportedTVAudioModes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3387,7 +3387,7 @@ impl IAMTVAudio_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableTVAudioModes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3398,7 +3398,7 @@ impl IAMTVAudio_Vtbl {
             let this = (*this).get_impl();
             match this.TVAudioMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3474,7 +3474,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableTVFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lanalogvideostandard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lanalogvideostandard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3485,7 +3485,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.TVFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *planalogvideostandard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planalogvideostandard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3496,7 +3496,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.AutoTune(::core::mem::transmute_copy(&lchannel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfoundsignal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfoundsignal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.NumInputConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnuminputconnections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnuminputconnections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3528,7 +3528,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.get_InputType(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinputtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinputtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3544,7 +3544,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3555,7 +3555,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.VideoFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lfreq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lfreq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3566,7 +3566,7 @@ impl IAMTVTuner_Vtbl {
             let this = (*this).get_impl();
             match this.AudioFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lfreq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lfreq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3605,7 +3605,7 @@ impl IAMTimecodeDisplay_Vtbl {
             let this = (*this).get_impl();
             match this.GetTCDisplayEnable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3621,7 +3621,7 @@ impl IAMTimecodeDisplay_Vtbl {
             let this = (*this).get_impl();
             match this.GetTCDisplay(::core::mem::transmute_copy(&param)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3660,7 +3660,7 @@ impl IAMTimecodeGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetTCGMode(::core::mem::transmute_copy(&param)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3681,7 +3681,7 @@ impl IAMTimecodeGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.VITCLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3697,7 +3697,7 @@ impl IAMTimecodeGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimecode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimecodesample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimecodesample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3732,7 +3732,7 @@ impl IAMTimecodeReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetTCRMode(::core::mem::transmute_copy(&param)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3753,7 +3753,7 @@ impl IAMTimecodeReader_Vtbl {
             let this = (*this).get_impl();
             match this.VITCLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3764,7 +3764,7 @@ impl IAMTimecodeReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimecode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimecodesample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimecodesample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3831,7 +3831,7 @@ impl IAMTuner_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcountrycode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcountrycode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3847,7 +3847,7 @@ impl IAMTuner_Vtbl {
             let this = (*this).get_impl();
             match this.TuningSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltuningspace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltuningspace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3868,7 +3868,7 @@ impl IAMTuner_Vtbl {
             let this = (*this).get_impl();
             match this.SignalPresent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsignalstrength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsignalstrength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3884,7 +3884,7 @@ impl IAMTuner_Vtbl {
             let this = (*this).get_impl();
             match this.Mode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3895,7 +3895,7 @@ impl IAMTuner_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableModes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4195,7 +4195,7 @@ impl IAMVideoCompression_Vtbl {
             let this = (*this).get_impl();
             match this.KeyFrameRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkeyframerate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkeyframerate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4211,7 +4211,7 @@ impl IAMVideoCompression_Vtbl {
             let this = (*this).get_impl();
             match this.PFramesPerKeyFrame() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppframesperkeyframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppframesperkeyframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4227,7 +4227,7 @@ impl IAMVideoCompression_Vtbl {
             let this = (*this).get_impl();
             match this.Quality() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pquality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pquality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4243,7 +4243,7 @@ impl IAMVideoCompression_Vtbl {
             let this = (*this).get_impl();
             match this.WindowSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwindowsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwindowsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4302,7 +4302,7 @@ impl IAMVideoControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaps(::core::mem::transmute(&ppin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcapsflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcapsflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4318,7 +4318,7 @@ impl IAMVideoControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetMode(::core::mem::transmute(&ppin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4329,7 +4329,7 @@ impl IAMVideoControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentActualFrameRate(::core::mem::transmute(&ppin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *actualframerate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actualframerate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4340,7 +4340,7 @@ impl IAMVideoControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxAvailableFrameRate(::core::mem::transmute(&ppin), ::core::mem::transmute_copy(&iindex), ::core::mem::transmute(&dimensions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxavailableframerate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxavailableframerate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4377,7 +4377,7 @@ impl IAMVideoDecimationProperties_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDecimationUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpusage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpusage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4616,7 +4616,7 @@ impl IATSCChannelTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.MinorChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minorchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minorchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4652,7 +4652,7 @@ impl IATSCComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4690,7 +4690,7 @@ impl IATSCLocator_Vtbl {
             let this = (*this).get_impl();
             match this.PhysicalChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *physicalchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(physicalchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4706,7 +4706,7 @@ impl IATSCLocator_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4744,7 +4744,7 @@ impl IATSCLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.ProgramNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *programnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(programnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4786,7 +4786,7 @@ impl IATSCTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MinMinorChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minminorchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minminorchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4802,7 +4802,7 @@ impl IATSCTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MaxMinorChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxminorchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxminorchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4818,7 +4818,7 @@ impl IATSCTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MinPhysicalChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minphysicalchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minphysicalchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4834,7 +4834,7 @@ impl IATSCTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MaxPhysicalChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxphysicalchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxphysicalchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4889,7 +4889,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4900,7 +4900,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4911,7 +4911,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4922,7 +4922,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4933,7 +4933,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEventId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4944,7 +4944,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordStartTime(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdtval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdtval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4955,7 +4955,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEtmLocation(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4966,7 +4966,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDuration(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4982,7 +4982,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4993,7 +4993,7 @@ impl IATSC_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5045,7 +5045,7 @@ impl IATSC_ETT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5056,7 +5056,7 @@ impl IATSC_ETT_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5067,7 +5067,7 @@ impl IATSC_ETT_Vtbl {
             let this = (*this).get_impl();
             match this.GetEtmId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5119,7 +5119,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5130,7 +5130,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5141,7 +5141,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5152,7 +5152,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordType(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5163,7 +5163,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTypePid(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5174,7 +5174,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordVersionNumber(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5185,7 +5185,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5196,7 +5196,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5217,7 +5217,7 @@ impl IATSC_MGT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5272,7 +5272,7 @@ impl IATSC_STT_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5283,7 +5283,7 @@ impl IATSC_STT_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdtsystemtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdtsystemtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5294,7 +5294,7 @@ impl IATSC_STT_Vtbl {
             let this = (*this).get_impl();
             match this.GetGpsUtcOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5305,7 +5305,7 @@ impl IATSC_STT_Vtbl {
             let this = (*this).get_impl();
             match this.GetDaylightSavings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5316,7 +5316,7 @@ impl IATSC_STT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5327,7 +5327,7 @@ impl IATSC_STT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5398,7 +5398,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5409,7 +5409,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportStreamId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5420,7 +5420,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5431,7 +5431,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5442,7 +5442,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordName(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwsname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwsname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5453,7 +5453,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordMajorChannelNumber(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5464,7 +5464,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordMinorChannelNumber(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5475,7 +5475,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordModulationMode(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5486,7 +5486,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCarrierFrequency(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5497,7 +5497,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTransportStreamId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5508,7 +5508,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordProgramNumber(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5519,7 +5519,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEtmLocation(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5530,7 +5530,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordIsAccessControlledBitSet(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5541,7 +5541,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordIsHiddenBitSet(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5552,7 +5552,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordIsPathSelectBitSet(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5563,7 +5563,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordIsOutOfBandBitSet(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5574,7 +5574,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordIsHideGuideBitSet(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5585,7 +5585,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceType(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5596,7 +5596,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordSourceId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5607,7 +5607,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5618,7 +5618,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5639,7 +5639,7 @@ impl IATSC_VCT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5699,7 +5699,7 @@ impl IAnalogAudioComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.AnalogAudioMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5735,7 +5735,7 @@ impl IAnalogLocator_Vtbl {
             let this = (*this).get_impl();
             match this.VideoStandard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *avs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(avs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5775,7 +5775,7 @@ impl IAnalogRadioTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MinFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minfrequencyval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minfrequencyval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5791,7 +5791,7 @@ impl IAnalogRadioTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MaxFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxfrequencyval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxfrequencyval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5807,7 +5807,7 @@ impl IAnalogRadioTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.Step() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stepval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stepval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5847,7 +5847,7 @@ impl IAnalogRadioTuningSpace2_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *countrycodeval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(countrycodeval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5889,7 +5889,7 @@ impl IAnalogTVTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MinChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5905,7 +5905,7 @@ impl IAnalogTVTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MaxChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5921,7 +5921,7 @@ impl IAnalogTVTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.InputType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *inputtypeval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inputtypeval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5937,7 +5937,7 @@ impl IAnalogTVTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *countrycodeval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(countrycodeval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5982,7 +5982,7 @@ impl IAsyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.RequestAllocator(::core::mem::transmute(&ppreferred), ::core::mem::transmute_copy(&pprops)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppactual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppactual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6008,7 +6008,7 @@ impl IAsyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.SyncRead(::core::mem::transmute_copy(&llposition), ::core::mem::transmute_copy(&llength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6063,7 +6063,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6074,7 +6074,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6085,7 +6085,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRatingRegionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6096,7 +6096,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRatingRegion(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6107,7 +6107,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRatedDimensions(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6118,7 +6118,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRatingDimension(::core::mem::transmute_copy(&bindexouter), ::core::mem::transmute_copy(&bindexinner)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6129,7 +6129,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRatingValue(::core::mem::transmute_copy(&bindexouter), ::core::mem::transmute_copy(&bindexinner)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6185,7 +6185,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetPAT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6196,7 +6196,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAT(::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6207,7 +6207,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetPMT(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&pwprogramnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6218,7 +6218,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetTSDT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptsdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptsdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6229,7 +6229,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetMGT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmgt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmgt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6240,7 +6240,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetVCT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&fgetnexttable)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvct = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvct, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6251,7 +6251,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetEIT(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&pwsourceid), ::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6262,7 +6262,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetETT(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&wsourceid), ::core::mem::transmute_copy(&pweventid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppett = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppett, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6273,7 +6273,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetSTT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6284,7 +6284,7 @@ impl IAtscPsipParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetEAS(::core::mem::transmute_copy(&pid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6322,7 +6322,7 @@ impl IAttributeGet_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6381,7 +6381,7 @@ impl IAudioData_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwaveformatcurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwaveformatcurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6418,7 +6418,7 @@ impl IAudioMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwaveformatcurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwaveformatcurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6434,7 +6434,7 @@ impl IAudioMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSample(::core::mem::transmute(&paudiodata), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6465,7 +6465,7 @@ impl IAudioStreamSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaudio = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaudio, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6505,7 +6505,7 @@ impl IAuxInTuningSpace2_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *countrycodeval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(countrycodeval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6545,7 +6545,7 @@ impl IBDAComparable_Vtbl {
             let this = (*this).get_impl();
             match this.CompareExact(::core::mem::transmute(&compareto)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6556,7 +6556,7 @@ impl IBDAComparable_Vtbl {
             let this = (*this).get_impl();
             match this.CompareEquivalent(::core::mem::transmute(&compareto), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6567,7 +6567,7 @@ impl IBDAComparable_Vtbl {
             let this = (*this).get_impl();
             match this.HashExact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6578,7 +6578,7 @@ impl IBDAComparable_Vtbl {
             let this = (*this).get_impl();
             match this.HashExactIncremental(::core::mem::transmute_copy(&partialresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6589,7 +6589,7 @@ impl IBDAComparable_Vtbl {
             let this = (*this).get_impl();
             match this.HashEquivalent(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6600,7 +6600,7 @@ impl IBDAComparable_Vtbl {
             let this = (*this).get_impl();
             match this.HashEquivalentIncremental(::core::mem::transmute_copy(&partialresult), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6634,7 +6634,7 @@ impl IBDACreateTuneRequestEx_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTuneRequestEx(::core::mem::transmute_copy(&tunerequestiid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6658,7 +6658,7 @@ impl IBDA_AUX_Vtbl {
             let this = (*this).get_impl();
             match this.QueryCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumauxinputsbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumauxinputsbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6768,7 +6768,7 @@ impl IBDA_ConditionalAccess_Vtbl {
             let this = (*this).get_impl();
             match this.get_Entitlement(::core::mem::transmute_copy(&usvirtualchannel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pentitlement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pentitlement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6799,7 +6799,7 @@ impl IBDA_ConditionalAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetModuleUI(::core::mem::transmute_copy(&bydialognumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6846,7 +6846,7 @@ impl IBDA_ConditionalAccessEx_Vtbl {
             let this = (*this).get_impl();
             match this.CheckEntitlementToken(::core::mem::transmute_copy(&uldialogrequest), ::core::mem::transmute(&bstrlanguage), ::core::mem::transmute_copy(&requesttype), ::core::mem::transmute_copy(&ulcbentitlementtokenlen), ::core::mem::transmute_copy(&pbentitlementtoken)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puldescramblestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puldescramblestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6867,7 +6867,7 @@ impl IBDA_ConditionalAccessEx_Vtbl {
             let this = (*this).get_impl();
             match this.CloseMmiDialog(::core::mem::transmute_copy(&uldialogrequest), ::core::mem::transmute(&bstrlanguage), ::core::mem::transmute_copy(&uldialognumber), ::core::mem::transmute_copy(&reasoncode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulsessionresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulsessionresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6878,7 +6878,7 @@ impl IBDA_ConditionalAccessEx_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDialogRequestNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puldialogrequestnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puldialogrequestnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7513,7 +7513,7 @@ impl IBDA_EthernetFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetMulticastMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulmodemask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulmodemask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7579,7 +7579,7 @@ impl IBDA_FDC_Vtbl {
             let this = (*this).get_impl();
             match this.AddPid(::core::mem::transmute(&pidstoadd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *remainingfilterentries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remainingfilterentries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7595,7 +7595,7 @@ impl IBDA_FDC_Vtbl {
             let this = (*this).get_impl();
             match this.AddTid(::core::mem::transmute(&tidstoadd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *currenttidlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currenttidlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7742,7 +7742,7 @@ impl IBDA_GuideDataDeliveryService_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuideDataType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguiddatatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguiddatatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7763,7 +7763,7 @@ impl IBDA_GuideDataDeliveryService_Vtbl {
             let this = (*this).get_impl();
             match this.GetTuneXmlFromServiceIdx(::core::mem::transmute_copy(&ul64serviceidx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtunexml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtunexml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7779,7 +7779,7 @@ impl IBDA_GuideDataDeliveryService_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceInfoFromTuneXml(::core::mem::transmute(&bstrtunexml)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrservicedescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrservicedescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7847,7 +7847,7 @@ impl IBDA_IPSinkInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AdapterIPAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7858,7 +7858,7 @@ impl IBDA_IPSinkInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AdapterDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7910,7 +7910,7 @@ impl IBDA_IPV4Filter_Vtbl {
             let this = (*this).get_impl();
             match this.GetMulticastMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulmodemask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulmodemask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7964,7 +7964,7 @@ impl IBDA_IPV6Filter_Vtbl {
             let this = (*this).get_impl();
             match this.GetMulticastMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulmodemask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulmodemask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8098,7 +8098,7 @@ impl IBDA_NameValueService_Vtbl {
             let this = (*this).get_impl();
             match this.GetValueNameByIndex(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8109,7 +8109,7 @@ impl IBDA_NameValueService_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrlanguage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8522,7 +8522,7 @@ impl IBDA_TransportStreamInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PatTableTickCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattickcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattickcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8579,7 +8579,7 @@ impl IBDA_UserActivityService_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserActivityInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwactivityinterval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwactivityinterval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8727,7 +8727,7 @@ impl IBDA_WMDRMTuner_Vtbl {
             let this = (*this).get_impl();
             match this.GetPidProtection(::core::mem::transmute_copy(&pulpid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *uuidkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uuidkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8812,7 +8812,7 @@ impl IBaseFilter_Vtbl {
             let this = (*this).get_impl();
             match this.EnumPins() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8823,7 +8823,7 @@ impl IBaseFilter_Vtbl {
             let this = (*this).get_impl();
             match this.FindPin(::core::mem::transmute(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8834,7 +8834,7 @@ impl IBaseFilter_Vtbl {
             let this = (*this).get_impl();
             match this.QueryFilterInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8850,7 +8850,7 @@ impl IBaseFilter_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVendorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvendorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvendorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8891,7 +8891,7 @@ impl IBaseVideoMixer_Vtbl {
             let this = (*this).get_impl();
             match this.GetLeadPin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pipin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pipin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8902,7 +8902,7 @@ impl IBaseVideoMixer_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputPinCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pipincount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pipincount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8913,7 +8913,7 @@ impl IBaseVideoMixer_Vtbl {
             let this = (*this).get_impl();
             match this.IsUsingClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8929,7 +8929,7 @@ impl IBaseVideoMixer_Vtbl {
             let this = (*this).get_impl();
             match this.GetClockPeriod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8977,7 +8977,7 @@ impl IBasicAudio_Vtbl {
             let this = (*this).get_impl();
             match this.Volume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8993,7 +8993,7 @@ impl IBasicAudio_Vtbl {
             let this = (*this).get_impl();
             match this.Balance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbalance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbalance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9056,7 +9056,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.AvgTimePerFrame() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pavgtimeperframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pavgtimeperframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9067,7 +9067,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.BitRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbitrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbitrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9078,7 +9078,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.BitErrorRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbiterrorrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbiterrorrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9089,7 +9089,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.VideoWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvideowidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvideowidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9100,7 +9100,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.VideoHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvideoheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvideoheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9116,7 +9116,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.SourceLeft() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psourceleft = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psourceleft, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9132,7 +9132,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.SourceWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psourcewidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psourcewidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9148,7 +9148,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.SourceTop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psourcetop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psourcetop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9164,7 +9164,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.SourceHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psourceheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psourceheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9180,7 +9180,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationLeft() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdestinationleft = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdestinationleft, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9196,7 +9196,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdestinationwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdestinationwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9212,7 +9212,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationTop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdestinationtop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdestinationtop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9228,7 +9228,7 @@ impl IBasicVideo_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdestinationheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdestinationheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9437,7 +9437,7 @@ impl ICAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9448,7 +9448,7 @@ impl ICAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9459,7 +9459,7 @@ impl ICAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9480,7 +9480,7 @@ impl ICAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable(::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9525,7 +9525,7 @@ impl ICCSubStreamFiltering_Vtbl {
             let this = (*this).get_impl();
             match this.SubstreamTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9932,7 +9932,7 @@ impl ICaptionServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfServices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9948,7 +9948,7 @@ impl ICaptionServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaptionServiceNumber(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9959,7 +9959,7 @@ impl ICaptionServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCCType(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9970,7 +9970,7 @@ impl ICaptionServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetEasyReader(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9981,7 +9981,7 @@ impl ICaptionServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetWideAspectRatio(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10027,7 +10027,7 @@ impl ICaptureGraphBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFiltergraph() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10106,7 +10106,7 @@ impl ICaptureGraphBuilder2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFiltergraph() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10147,7 +10147,7 @@ impl ICaptureGraphBuilder2_Vtbl {
             let this = (*this).get_impl();
             match this.FindPin(::core::mem::transmute(&psource), ::core::mem::transmute_copy(&pindir), ::core::mem::transmute_copy(&pcategory), ::core::mem::transmute_copy(&ptype), ::core::mem::transmute_copy(&funconnected), ::core::mem::transmute_copy(&num)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10185,7 +10185,7 @@ impl IChannelIDTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ChannelID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *channelid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(channelid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10221,7 +10221,7 @@ impl IChannelTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Channel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *channel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(channel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10264,7 +10264,7 @@ impl IComponent_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ct = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ct, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10280,7 +10280,7 @@ impl IComponent_Vtbl {
             let this = (*this).get_impl();
             match this.DescLangID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *langid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(langid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10296,7 +10296,7 @@ impl IComponent_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10312,7 +10312,7 @@ impl IComponent_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10328,7 +10328,7 @@ impl IComponent_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10381,7 +10381,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.Category() {
                 ::core::result::Result::Ok(ok__) => {
-                    *category = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(category, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10397,7 +10397,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.MediaMajorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mediamajortype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mediamajortype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10413,7 +10413,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this._MediaMajorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mediamajortypeguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mediamajortypeguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10429,7 +10429,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.MediaSubType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mediasubtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mediasubtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10445,7 +10445,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this._MediaSubType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mediasubtypeguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mediasubtypeguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10461,7 +10461,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.MediaFormatType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mediaformattype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mediaformattype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10477,7 +10477,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this._MediaFormatType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mediaformattypeguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mediaformattypeguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10493,7 +10493,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10509,7 +10509,7 @@ impl IComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newct = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newct, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10561,7 +10561,7 @@ impl IComponentTypes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10572,7 +10572,7 @@ impl IComponentTypes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10583,7 +10583,7 @@ impl IComponentTypes_Vtbl {
             let this = (*this).get_impl();
             match this.EnumComponentTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10594,7 +10594,7 @@ impl IComponentTypes_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *componenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(componenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10610,7 +10610,7 @@ impl IComponentTypes_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&componenttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10626,7 +10626,7 @@ impl IComponentTypes_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10669,7 +10669,7 @@ impl IComponents_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10680,7 +10680,7 @@ impl IComponents_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10691,7 +10691,7 @@ impl IComponents_Vtbl {
             let this = (*this).get_impl();
             match this.EnumComponents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10702,7 +10702,7 @@ impl IComponents_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10713,7 +10713,7 @@ impl IComponents_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&component)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10729,7 +10729,7 @@ impl IComponents_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10776,7 +10776,7 @@ impl IComponentsOld_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10787,7 +10787,7 @@ impl IComponentsOld_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10798,7 +10798,7 @@ impl IComponentsOld_Vtbl {
             let this = (*this).get_impl();
             match this.EnumComponents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10809,7 +10809,7 @@ impl IComponentsOld_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10820,7 +10820,7 @@ impl IComponentsOld_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&component)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10836,7 +10836,7 @@ impl IComponentsOld_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10883,7 +10883,7 @@ impl IConfigAsfWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProfileId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwprofileid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwprofileid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10899,7 +10899,7 @@ impl IConfigAsfWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProfileGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprofileguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprofileguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10915,7 +10915,7 @@ impl IConfigAsfWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10931,7 +10931,7 @@ impl IConfigAsfWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbindexfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbindexfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10970,7 +10970,7 @@ impl IConfigAsfWriter2_Vtbl {
             let this = (*this).get_impl();
             match this.StreamNumFromPin(::core::mem::transmute(&ppin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwstreamnum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwstreamnum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11025,7 +11025,7 @@ impl IConfigAviMux_Vtbl {
             let this = (*this).get_impl();
             match this.GetMasterStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11041,7 +11041,7 @@ impl IConfigAviMux_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCompatibilityIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfoldindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfoldindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11078,7 +11078,7 @@ impl IConfigInterleaving_Vtbl {
             let this = (*this).get_impl();
             match this.Mode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11316,7 +11316,7 @@ impl IDTFilter_Vtbl {
             let this = (*this).get_impl();
             match this.EvalRatObjOK() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrcocreateretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrcocreateretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11332,7 +11332,7 @@ impl IDTFilter_Vtbl {
             let this = (*this).get_impl();
             match this.get_BlockedRatingAttributes(::core::mem::transmute_copy(&ensystem), ::core::mem::transmute_copy(&enlevel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbfenattr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbfenattr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11348,7 +11348,7 @@ impl IDTFilter_Vtbl {
             let this = (*this).get_impl();
             match this.BlockUnRated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfblockunratedshows = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfblockunratedshows, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11364,7 +11364,7 @@ impl IDTFilter_Vtbl {
             let this = (*this).get_impl();
             match this.BlockUnRatedDelay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmsecsdelaybeforeblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmsecsdelaybeforeblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11407,7 +11407,7 @@ impl IDTFilter2_Vtbl {
             let this = (*this).get_impl();
             match this.ChallengeUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrchallengeurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrchallengeurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11418,7 +11418,7 @@ impl IDTFilter2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrLicenseExpDate(::core::mem::transmute_copy(&prottype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11456,7 +11456,7 @@ impl IDTFilter3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtectionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotectiontype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotectiontype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11467,7 +11467,7 @@ impl IDTFilter3_Vtbl {
             let this = (*this).get_impl();
             match this.LicenseHasExpirationDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflicensehasexpirationdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflicensehasexpirationdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11500,7 +11500,7 @@ impl IDTFilterConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecureChannelObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdrmsecurechannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdrmsecurechannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11578,7 +11578,7 @@ impl IDVBSLocator_Vtbl {
             let this = (*this).get_impl();
             match this.SignalPolarisation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *polarisationval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(polarisationval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11594,7 +11594,7 @@ impl IDVBSLocator_Vtbl {
             let this = (*this).get_impl();
             match this.WestPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *westlongitude = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(westlongitude, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11610,7 +11610,7 @@ impl IDVBSLocator_Vtbl {
             let this = (*this).get_impl();
             match this.OrbitalPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *longitude = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(longitude, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11626,7 +11626,7 @@ impl IDVBSLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Azimuth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *azimuth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(azimuth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11642,7 +11642,7 @@ impl IDVBSLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Elevation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *elevation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(elevation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11698,7 +11698,7 @@ impl IDVBSLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.DiseqLNBSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *diseqlnbsourceval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(diseqlnbsourceval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11714,7 +11714,7 @@ impl IDVBSLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.LocalOscillatorOverrideLow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *localoscillatoroverridelowval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localoscillatoroverridelowval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11730,7 +11730,7 @@ impl IDVBSLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.LocalOscillatorOverrideHigh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *localoscillatoroverridehighval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localoscillatoroverridehighval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11746,7 +11746,7 @@ impl IDVBSLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.LocalLNBSwitchOverride() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locallnbswitchoverrideval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locallnbswitchoverrideval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11762,7 +11762,7 @@ impl IDVBSLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.LocalSpectralInversionOverride() {
                 ::core::result::Result::Ok(ok__) => {
-                    *localspectralinversionoverrideval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localspectralinversionoverrideval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11778,7 +11778,7 @@ impl IDVBSLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.SignalRollOff() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rolloffval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rolloffval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11794,7 +11794,7 @@ impl IDVBSLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.SignalPilot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pilotval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pilotval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11850,7 +11850,7 @@ impl IDVBSTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.LowOscillator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lowoscillator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lowoscillator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11866,7 +11866,7 @@ impl IDVBSTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.HighOscillator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *highoscillator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(highoscillator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11882,7 +11882,7 @@ impl IDVBSTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.LNBSwitch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lnbswitch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lnbswitch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11898,7 +11898,7 @@ impl IDVBSTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.InputRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *inputrange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inputrange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11914,7 +11914,7 @@ impl IDVBSTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.SpectralInversion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *spectralinversionval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(spectralinversionval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11970,7 +11970,7 @@ impl IDVBTLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Bandwidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bandwidthval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bandwidthval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11986,7 +11986,7 @@ impl IDVBTLocator_Vtbl {
             let this = (*this).get_impl();
             match this.LPInnerFEC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12002,7 +12002,7 @@ impl IDVBTLocator_Vtbl {
             let this = (*this).get_impl();
             match this.LPInnerFECRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12018,7 +12018,7 @@ impl IDVBTLocator_Vtbl {
             let this = (*this).get_impl();
             match this.HAlpha() {
                 ::core::result::Result::Ok(ok__) => {
-                    *alpha = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(alpha, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12034,7 +12034,7 @@ impl IDVBTLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Guard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *gi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12050,7 +12050,7 @@ impl IDVBTLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Mode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12066,7 +12066,7 @@ impl IDVBTLocator_Vtbl {
             let this = (*this).get_impl();
             match this.OtherFrequencyInUse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *otherfrequencyinuseval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(otherfrequencyinuseval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12114,7 +12114,7 @@ impl IDVBTLocator2_Vtbl {
             let this = (*this).get_impl();
             match this.PhysicalLayerPipeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *physicallayerpipeidval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(physicallayerpipeidval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12154,7 +12154,7 @@ impl IDVBTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ONID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *onid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(onid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12170,7 +12170,7 @@ impl IDVBTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12186,7 +12186,7 @@ impl IDVBTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.SID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12226,7 +12226,7 @@ impl IDVBTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.SystemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *systype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(systype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12262,7 +12262,7 @@ impl IDVBTuningSpace2_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *networkid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(networkid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12317,7 +12317,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12328,7 +12328,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetBouquetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12339,7 +12339,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12360,7 +12360,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12371,7 +12371,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTransportStreamId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12382,7 +12382,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordOriginalNetworkId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12393,7 +12393,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12404,7 +12404,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12425,7 +12425,7 @@ impl IDVB_BAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12485,7 +12485,7 @@ impl IDVB_DIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransitionFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12540,7 +12540,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12551,7 +12551,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12562,7 +12562,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportStreamId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12573,7 +12573,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12584,7 +12584,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetSegmentLastSectionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12595,7 +12595,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastTableId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12606,7 +12606,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12617,7 +12617,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEventId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12628,7 +12628,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordStartTime(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdtval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdtval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12639,7 +12639,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDuration(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12650,7 +12650,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRunningStatus(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12661,7 +12661,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordFreeCAMode(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12672,7 +12672,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12683,7 +12683,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12704,7 +12704,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12725,7 +12725,7 @@ impl IDVB_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12780,7 +12780,7 @@ impl IDVB_EIT2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordSection(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12831,7 +12831,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12842,7 +12842,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12853,7 +12853,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12864,7 +12864,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12880,7 +12880,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12891,7 +12891,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTransportStreamId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12902,7 +12902,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordOriginalNetworkId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12913,7 +12913,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12924,7 +12924,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12945,7 +12945,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12966,7 +12966,7 @@ impl IDVB_NIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13019,7 +13019,7 @@ impl IDVB_RST_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13030,7 +13030,7 @@ impl IDVB_RST_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTransportStreamId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13041,7 +13041,7 @@ impl IDVB_RST_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordOriginalNetworkId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13052,7 +13052,7 @@ impl IDVB_RST_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13063,7 +13063,7 @@ impl IDVB_RST_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEventId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13074,7 +13074,7 @@ impl IDVB_RST_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRunningStatus(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13131,7 +13131,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13142,7 +13142,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportStreamId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13153,7 +13153,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13164,7 +13164,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13175,7 +13175,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13186,7 +13186,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEITScheduleFlag(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13197,7 +13197,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEITPresentFollowingFlag(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13208,7 +13208,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRunningStatus(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13219,7 +13219,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordFreeCAMode(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13230,7 +13230,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13241,7 +13241,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13262,7 +13262,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13283,7 +13283,7 @@ impl IDVB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13348,7 +13348,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13359,7 +13359,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13370,7 +13370,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13386,7 +13386,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13397,7 +13397,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13408,7 +13408,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordRunningStatus(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13419,7 +13419,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13430,7 +13430,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13451,7 +13451,7 @@ impl IDVB_SIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable(::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13508,7 +13508,7 @@ impl IDVB_ST_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13519,7 +13519,7 @@ impl IDVB_ST_Vtbl {
             let this = (*this).get_impl();
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13553,7 +13553,7 @@ impl IDVB_TDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetUTCTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdtval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdtval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13589,7 +13589,7 @@ impl IDVB_TOT_Vtbl {
             let this = (*this).get_impl();
             match this.GetUTCTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdtval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdtval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13600,7 +13600,7 @@ impl IDVB_TOT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13611,7 +13611,7 @@ impl IDVB_TOT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13748,7 +13748,7 @@ impl IDeferredCommand_Vtbl {
             let this = (*this).get_impl();
             match this.Confidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconfidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconfidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13764,7 +13764,7 @@ impl IDeferredCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetHResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13812,7 +13812,7 @@ impl IDigitalCableTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.MajorChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmajorchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmajorchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13828,7 +13828,7 @@ impl IDigitalCableTuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.SourceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psourceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psourceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13872,7 +13872,7 @@ impl IDigitalCableTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MinMajorChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minmajorchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minmajorchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13888,7 +13888,7 @@ impl IDigitalCableTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MaxMajorChannel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxmajorchannelval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxmajorchannelval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13904,7 +13904,7 @@ impl IDigitalCableTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MinSourceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minsourceidval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minsourceidval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13920,7 +13920,7 @@ impl IDigitalCableTuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.MaxSourceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxsourceidval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxsourceidval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14004,7 +14004,7 @@ impl IDirectDrawMediaSampleAllocator_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectDraw() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdirectdraw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdirectdraw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14045,7 +14045,7 @@ impl IDirectDrawMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectDraw() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdirectdraw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdirectdraw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14061,7 +14061,7 @@ impl IDirectDrawMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSample(::core::mem::transmute(&psurface), ::core::mem::transmute_copy(&prect), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14072,7 +14072,7 @@ impl IDirectDrawMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimePerFrame() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pframetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pframetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14151,7 +14151,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSwitches() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pswitches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pswitches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14167,7 +14167,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14178,7 +14178,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmulatedCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14204,7 +14204,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectDraw() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdirectdraw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdirectdraw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14215,7 +14215,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurfaceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psurfacetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psurfacetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14236,7 +14236,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.CanUseScanLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usescanline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usescanline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14252,7 +14252,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.CanUseOverlayStretch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *useoverlaystretch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(useoverlaystretch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14268,7 +14268,7 @@ impl IDirectDrawVideo_Vtbl {
             let this = (*this).get_impl();
             match this.WillUseFullScreen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usewhenfullscreen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usewhenfullscreen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14400,7 +14400,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14411,7 +14411,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14422,7 +14422,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14433,7 +14433,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFECOuter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14444,7 +14444,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetModulation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14455,7 +14455,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14466,7 +14466,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFECInner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14507,7 +14507,7 @@ impl IDvbComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14518,7 +14518,7 @@ impl IDvbComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14529,7 +14529,7 @@ impl IDvbComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14540,7 +14540,7 @@ impl IDvbComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14551,7 +14551,7 @@ impl IDvbComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14567,7 +14567,7 @@ impl IDvbComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14603,7 +14603,7 @@ impl IDvbContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14614,7 +14614,7 @@ impl IDvbContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14625,7 +14625,7 @@ impl IDvbContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14668,7 +14668,7 @@ impl IDvbContentIdentifierDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14679,7 +14679,7 @@ impl IDvbContentIdentifierDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14690,7 +14690,7 @@ impl IDvbContentIdentifierDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14732,7 +14732,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14743,7 +14743,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14754,7 +14754,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataBroadcastID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14765,7 +14765,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14776,7 +14776,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectorLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14792,7 +14792,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLangID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14803,7 +14803,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14845,7 +14845,7 @@ impl IDvbDataBroadcastIDDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14856,7 +14856,7 @@ impl IDvbDataBroadcastIDDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14867,7 +14867,7 @@ impl IDvbDataBroadcastIDDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataBroadcastID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14903,7 +14903,7 @@ impl IDvbDefaultAuthorityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14914,7 +14914,7 @@ impl IDvbDefaultAuthorityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14960,7 +14960,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14971,7 +14971,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14982,7 +14982,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescriptorNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14993,7 +14993,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastDescriptorNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15009,7 +15009,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15030,7 +15030,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15041,7 +15041,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetConcatenatedTextW(::core::mem::transmute(&followingdescriptor), ::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15086,7 +15086,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15097,7 +15097,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15108,7 +15108,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodingType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15119,7 +15119,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15130,7 +15130,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCentreFrequency(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15177,7 +15177,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15188,7 +15188,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15199,7 +15199,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTSId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15210,7 +15210,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetONId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15221,7 +15221,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15232,7 +15232,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15243,7 +15243,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrivateDataLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15291,7 +15291,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfLists() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15302,7 +15302,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetListId(::core::mem::transmute_copy(&blistindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15313,7 +15313,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetListNameW(::core::mem::transmute_copy(&blistindex), ::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15329,7 +15329,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetListCountOfRecords(::core::mem::transmute_copy(&bchannellistindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15340,7 +15340,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetListRecordServiceId(::core::mem::transmute_copy(&blistindex), ::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15351,7 +15351,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetListRecordLogicalChannelNumber(::core::mem::transmute_copy(&blistindex), ::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15362,7 +15362,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetListRecordLogicalChannelAndVisibility(::core::mem::transmute_copy(&blistindex), ::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15399,7 +15399,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15410,7 +15410,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15421,7 +15421,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15432,7 +15432,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15443,7 +15443,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordLogicalChannelNumber(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15473,7 +15473,7 @@ impl IDvbLogicalChannelDescriptor2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordLogicalChannelAndVisibility(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15507,7 +15507,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15518,7 +15518,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15529,7 +15529,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15540,7 +15540,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordLangId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ulval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ulval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15551,7 +15551,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceProviderNameW(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15562,7 +15562,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceNameW(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15599,7 +15599,7 @@ impl IDvbNetworkNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15610,7 +15610,7 @@ impl IDvbNetworkNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15621,7 +15621,7 @@ impl IDvbNetworkNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15632,7 +15632,7 @@ impl IDvbNetworkNameDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkNameW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15664,7 +15664,7 @@ impl IDvbParentalRatingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15675,7 +15675,7 @@ impl IDvbParentalRatingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15686,7 +15686,7 @@ impl IDvbParentalRatingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15722,7 +15722,7 @@ impl IDvbPrivateDataSpecifierDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15733,7 +15733,7 @@ impl IDvbPrivateDataSpecifierDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15744,7 +15744,7 @@ impl IDvbPrivateDataSpecifierDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrivateDataSpecifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15780,7 +15780,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15791,7 +15791,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15802,7 +15802,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15813,7 +15813,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetOrbitalPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15824,7 +15824,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetWestEastFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15835,7 +15835,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolarization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15846,7 +15846,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetModulation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15857,7 +15857,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15868,7 +15868,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFECInner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15910,7 +15910,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15921,7 +15921,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15932,7 +15932,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15943,7 +15943,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15954,7 +15954,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordNumericSelectionFlag(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15965,7 +15965,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordVisibleServiceFlag(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16006,7 +16006,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16017,7 +16017,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16028,7 +16028,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16039,7 +16039,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16050,7 +16050,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceProviderNameW() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16061,7 +16061,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16072,7 +16072,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessedServiceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16083,7 +16083,7 @@ impl IDvbServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceNameEmphasized() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16120,7 +16120,7 @@ impl IDvbServiceDescriptor2_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceProviderNameW2(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16131,7 +16131,7 @@ impl IDvbServiceDescriptor2_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceNameW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16162,7 +16162,7 @@ impl IDvbServiceListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16173,7 +16173,7 @@ impl IDvbServiceListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16184,7 +16184,7 @@ impl IDvbServiceListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16195,7 +16195,7 @@ impl IDvbServiceListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16206,7 +16206,7 @@ impl IDvbServiceListDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceType(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16243,7 +16243,7 @@ impl IDvbShortEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16254,7 +16254,7 @@ impl IDvbShortEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16270,7 +16270,7 @@ impl IDvbShortEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventNameW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16281,7 +16281,7 @@ impl IDvbShortEventDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16330,7 +16330,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetPAT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16341,7 +16341,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAT(::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16352,7 +16352,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetPMT(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&pwprogramnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16363,7 +16363,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetTSDT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptsdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptsdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16374,7 +16374,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetNIT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pwnetworkid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16385,7 +16385,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetSDT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pwtransportstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16396,7 +16396,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetEIT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pwserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16407,7 +16407,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetBAT(::core::mem::transmute_copy(&pwbouquetid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16418,7 +16418,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetRST(::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprst = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprst, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16429,7 +16429,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetST(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppst = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppst, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16440,7 +16440,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetTDT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16451,7 +16451,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetTOT() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16462,7 +16462,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetDIT(::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16473,7 +16473,7 @@ impl IDvbSiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetSIT(::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16513,7 +16513,7 @@ impl IDvbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEIT2(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pwserviceid), ::core::mem::transmute_copy(&pbsegment)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16542,7 +16542,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16553,7 +16553,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16564,7 +16564,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16575,7 +16575,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordLangId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16586,7 +16586,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordSubtitlingType(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16597,7 +16597,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCompositionPageID(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16608,7 +16608,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordAncillaryPageID(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16646,7 +16646,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16657,7 +16657,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16668,7 +16668,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16679,7 +16679,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordLangId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16690,7 +16690,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTeletextType(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16701,7 +16701,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordMagazineNumber(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16712,7 +16712,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordPageNumber(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16756,7 +16756,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16767,7 +16767,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16778,7 +16778,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTagExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16789,7 +16789,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCentreFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16800,7 +16800,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetPLPId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16811,7 +16811,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetT2SystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16822,7 +16822,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetMultipleInputMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16833,7 +16833,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetBandwidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16844,7 +16844,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuardInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16855,7 +16855,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransmissionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16866,7 +16866,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16877,7 +16877,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherFrequencyFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16888,7 +16888,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTFSFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16936,7 +16936,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16947,7 +16947,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16958,7 +16958,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCentreFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16969,7 +16969,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetBandwidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16980,7 +16980,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetConstellation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16991,7 +16991,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetHierarchyInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17002,7 +17002,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeRateHPStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17013,7 +17013,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeRateLPStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17024,7 +17024,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuardInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17035,7 +17035,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransmissionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17046,7 +17046,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherFrequencyFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17412,7 +17412,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayTitle(::core::mem::transmute_copy(&ultitle), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17423,7 +17423,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayChapterInTitle(::core::mem::transmute_copy(&ultitle), ::core::mem::transmute_copy(&ulchapter), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17444,7 +17444,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.ReturnFromSubmenu(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17460,7 +17460,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayChapter(::core::mem::transmute_copy(&ulchapter), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17471,7 +17471,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayPrevChapter(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17482,7 +17482,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.ReplayChapter(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17493,7 +17493,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayNextChapter(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17504,7 +17504,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayForwards(::core::mem::transmute_copy(&dspeed), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17515,7 +17515,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayBackwards(::core::mem::transmute_copy(&dspeed), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17526,7 +17526,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.ShowMenu(::core::mem::transmute_copy(&menuid), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17537,7 +17537,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.Resume(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17578,7 +17578,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.SelectAudioStream(::core::mem::transmute_copy(&ulaudio), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17589,7 +17589,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.SelectSubpictureStream(::core::mem::transmute_copy(&ulsubpicture), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17600,7 +17600,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.SetSubpictureState(::core::mem::transmute_copy(&bstate), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17611,7 +17611,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.SelectAngle(::core::mem::transmute_copy(&ulangle), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17657,7 +17657,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.PlayChaptersAutoStop(::core::mem::transmute_copy(&ultitle), ::core::mem::transmute_copy(&ulchapter), ::core::mem::transmute_copy(&ulchapterstoplay), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17678,7 +17678,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.SetState(::core::mem::transmute(&pstate), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17694,7 +17694,7 @@ impl IDvdControl2_Vtbl {
             let this = (*this).get_impl();
             match this.SetGPRM(::core::mem::transmute_copy(&ulindex), ::core::mem::transmute_copy(&wvalue), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17779,7 +17779,7 @@ impl IDvdGraphBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFiltergraph() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17795,7 +17795,7 @@ impl IDvdGraphBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.RenderDvdVideoVolume(::core::mem::transmute(&lpcwszpathname), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17853,7 +17853,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17864,7 +17864,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalTitleTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pultotaltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pultotaltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17895,7 +17895,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentUOPS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17906,7 +17906,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllSPRMs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pregisterarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pregisterarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17917,7 +17917,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllGPRMs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pregisterarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pregisterarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17928,7 +17928,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioLanguage(::core::mem::transmute_copy(&ulstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *planguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17939,7 +17939,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubpictureLanguage(::core::mem::transmute_copy(&ulstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *planguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17950,7 +17950,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitleAttributes(::core::mem::transmute_copy(&ultitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17961,7 +17961,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetVMGAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17972,7 +17972,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentVideoAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17983,7 +17983,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentAudioAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17994,7 +17994,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSubpictureAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18020,7 +18020,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfChapters(::core::mem::transmute_copy(&ultitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulnumberofchapters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulnumberofchapters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18031,7 +18031,7 @@ impl IDvdInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitleParentalLevels(::core::mem::transmute_copy(&ultitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulparentallevels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulparentallevels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18125,7 +18125,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentDomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdomain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdomain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18136,7 +18136,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18172,7 +18172,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentUOPS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puluops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puluops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18183,7 +18183,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllSPRMs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pregisterarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pregisterarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18194,7 +18194,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllGPRMs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pregisterarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pregisterarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18205,7 +18205,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioLanguage(::core::mem::transmute_copy(&ulstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *planguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18216,7 +18216,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubpictureLanguage(::core::mem::transmute_copy(&ulstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *planguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18232,7 +18232,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetVMGAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18243,7 +18243,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentVideoAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18254,7 +18254,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioAttributes(::core::mem::transmute_copy(&ulstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18265,7 +18265,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetKaraokeAttributes(::core::mem::transmute_copy(&ulstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18276,7 +18276,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubpictureAttributes(::core::mem::transmute_copy(&ulstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *patr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18292,7 +18292,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDVDTextNumberOfLanguages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulnumoflangs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulnumoflangs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18323,7 +18323,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfChapters(::core::mem::transmute_copy(&ultitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulnumofchapters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulnumofchapters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18334,7 +18334,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitleParentalLevels(::core::mem::transmute_copy(&ultitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulparentallevels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulparentallevels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18350,7 +18350,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.IsAudioStreamEnabled(::core::mem::transmute_copy(&ulstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18361,7 +18361,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDiscID(::core::mem::transmute(&pszwpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulldiscid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulldiscid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18372,7 +18372,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatedata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatedata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18388,7 +18388,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetButtonAtPosition(::core::mem::transmute(&point)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulbuttonindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulbuttonindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18399,7 +18399,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCmdFromEvent(::core::mem::transmute_copy(&lparam1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmdobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmdobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18410,7 +18410,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultMenuLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *planguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(planguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18431,7 +18431,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDecoderCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18442,7 +18442,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetButtonRect(::core::mem::transmute_copy(&ulbutton)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18453,7 +18453,7 @@ impl IDvdInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.IsSubpictureStreamEnabled(::core::mem::transmute_copy(&ulstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18518,7 +18518,7 @@ impl IDvdState_Vtbl {
             let this = (*this).get_impl();
             match this.GetDiscID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulluniqueid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulluniqueid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18529,7 +18529,7 @@ impl IDvdState_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentalLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulparentallevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulparentallevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18559,7 +18559,7 @@ impl IESCloseMmiEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDialogNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdialognumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdialognumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18589,7 +18589,7 @@ impl IESEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdweventid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdweventid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18600,7 +18600,7 @@ impl IESEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguideventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguideventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18616,7 +18616,7 @@ impl IESEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18627,7 +18627,7 @@ impl IESEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18660,7 +18660,7 @@ impl IESEventFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateESEvent(::core::mem::transmute(&pserviceprovider), ::core::mem::transmute_copy(&dweventid), ::core::mem::transmute(&guideventtype), ::core::mem::transmute_copy(&dweventdatalength), ::core::mem::transmute_copy(&peventdata), ::core::mem::transmute(&bstrbaseurl), ::core::mem::transmute(&pinitcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppesevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppesevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18780,7 +18780,7 @@ impl IESFileExpiryDateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetTunerId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidtunerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidtunerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18791,7 +18791,7 @@ impl IESFileExpiryDateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpiryDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwexpirydate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwexpirydate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18802,7 +18802,7 @@ impl IESFileExpiryDateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetFinalExpiryDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwexpirydate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwexpirydate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18813,7 +18813,7 @@ impl IESFileExpiryDateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxRenewalCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwmaxrenewalcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwmaxrenewalcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18824,7 +18824,7 @@ impl IESFileExpiryDateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.IsEntitlementTokenPresent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenttokenpresent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenttokenpresent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18835,7 +18835,7 @@ impl IESFileExpiryDateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.DoesExpireAfterFirstUse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfexpireafterfirstuse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfexpireafterfirstuse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18872,7 +18872,7 @@ impl IESIsdbCasResponseEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18883,7 +18883,7 @@ impl IESIsdbCasResponseEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18894,7 +18894,7 @@ impl IESIsdbCasResponseEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18905,7 +18905,7 @@ impl IESIsdbCasResponseEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetResponseData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18947,7 +18947,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetCallersId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcallersid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcallersid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18958,7 +18958,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18969,7 +18969,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.IsRenewalSuccessful() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrenewalsuccessful = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrenewalsuccessful, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18980,7 +18980,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.IsCheckEntitlementCallRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcheckenttokencallneeded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcheckenttokencallneeded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18991,7 +18991,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescrambledStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdescrambledstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdescrambledstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19002,7 +19002,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenewalResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrenewalresultcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrenewalresultcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19013,7 +19013,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetCASFailureCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcasfailurecode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcasfailurecode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19024,7 +19024,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenewalHResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19035,7 +19035,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntitlementTokenLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19046,7 +19046,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntitlementToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19057,7 +19057,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpiryDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwexpirydate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwexpirydate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19104,7 +19104,7 @@ impl IESOpenMmiEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDialogType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guiddialogtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guiddialogtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19115,7 +19115,7 @@ impl IESOpenMmiEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDialogData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19155,7 +19155,7 @@ impl IESRequestTunerEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbypriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbypriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19166,7 +19166,7 @@ impl IESRequestTunerEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetReason() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbyreason = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbyreason, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19177,7 +19177,7 @@ impl IESRequestTunerEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetConsequences() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbyconsequences = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbyconsequences, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19188,7 +19188,7 @@ impl IESRequestTunerEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEstimatedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwestimatedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwestimatedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19220,7 +19220,7 @@ impl IESValueUpdatedEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetValueNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19250,7 +19250,7 @@ impl IETFilter_Vtbl {
             let this = (*this).get_impl();
             match this.EvalRatObjOK() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrcocreateretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrcocreateretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19266,7 +19266,7 @@ impl IETFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrLicenseExpDate(::core::mem::transmute_copy(&prottype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19312,7 +19312,7 @@ impl IETFilterConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecureChannelObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdrmsecurechannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdrmsecurechannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19381,7 +19381,7 @@ impl IEncoderAPI_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultValue(::core::mem::transmute_copy(&api)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19392,7 +19392,7 @@ impl IEncoderAPI_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&api)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19450,7 +19450,7 @@ impl IEnumComponentTypes_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19500,7 +19500,7 @@ impl IEnumComponents_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19550,7 +19550,7 @@ impl IEnumFilters_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19597,7 +19597,7 @@ impl IEnumGuideDataProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19647,7 +19647,7 @@ impl IEnumMSVidGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19697,7 +19697,7 @@ impl IEnumMediaTypes_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19744,7 +19744,7 @@ impl IEnumPIDMap_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumpidmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumpidmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19791,7 +19791,7 @@ impl IEnumPins_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19838,7 +19838,7 @@ impl IEnumRegFilters_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19885,7 +19885,7 @@ impl IEnumStreamBufferRecordingAttrib_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumstreambufferattrib = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumstreambufferattrib, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19932,7 +19932,7 @@ impl IEnumStreamIdMap_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumstreamidmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumstreamidmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19982,7 +19982,7 @@ impl IEnumTuneRequests_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20032,7 +20032,7 @@ impl IEnumTuningSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20069,7 +20069,7 @@ impl IEvalRat_Vtbl {
             let this = (*this).get_impl();
             match this.get_BlockedRatingAttributes(::core::mem::transmute_copy(&ensystem), ::core::mem::transmute_copy(&enlevel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbfattrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbfattrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20085,7 +20085,7 @@ impl IEvalRat_Vtbl {
             let this = (*this).get_impl();
             match this.BlockUnRated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfblockunratedshows = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfblockunratedshows, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20170,7 +20170,7 @@ impl IFileSinkFilter2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20291,7 +20291,7 @@ impl IFilterGraph_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFilters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20302,7 +20302,7 @@ impl IFilterGraph_Vtbl {
             let this = (*this).get_impl();
             match this.FindFilterByName(::core::mem::transmute(&pname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20360,7 +20360,7 @@ impl IFilterGraph2_Vtbl {
             let this = (*this).get_impl();
             match this.AddSourceFilterForMoniker(::core::mem::transmute(&pmoniker), ::core::mem::transmute(&pctx), ::core::mem::transmute(&lpcwstrfiltername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20428,7 +20428,7 @@ impl IFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.FindPin(::core::mem::transmute(&strpinid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20439,7 +20439,7 @@ impl IFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20450,7 +20450,7 @@ impl IFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.VendorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strvendorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strvendorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20461,7 +20461,7 @@ impl IFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Filter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20472,7 +20472,7 @@ impl IFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Pins() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20483,7 +20483,7 @@ impl IFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsFileSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbissource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbissource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20494,7 +20494,7 @@ impl IFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Filename() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20547,7 +20547,7 @@ impl IFilterMapper_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterFilterInstance(::core::mem::transmute(&clsid), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20674,7 +20674,7 @@ impl IFilterMapper3_Vtbl {
             let this = (*this).get_impl();
             match this.GetICreateDevEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20712,7 +20712,7 @@ impl IFrequencyMap_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcountrycode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcountrycode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20777,7 +20777,7 @@ impl IFullScreenVideo_Vtbl {
             let this = (*this).get_impl();
             match this.CountModes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20793,7 +20793,7 @@ impl IFullScreenVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20819,7 +20819,7 @@ impl IFullScreenVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipFactor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclipfactor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclipfactor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20840,7 +20840,7 @@ impl IFullScreenVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessageDrain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20856,7 +20856,7 @@ impl IFullScreenVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMonitor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *monitor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(monitor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20882,7 +20882,7 @@ impl IFullScreenVideo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrcaption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrcaption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20950,7 +20950,7 @@ impl IFullScreenVideoEx_Vtbl {
             let this = (*this).get_impl();
             match this.IsKeepPixelAspectRatio() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkeepaspect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkeepaspect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20987,7 +20987,7 @@ impl IGenericDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20998,7 +20998,7 @@ impl IGenericDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21009,7 +21009,7 @@ impl IGenericDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetBody() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21044,7 +21044,7 @@ impl IGenericDescriptor2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21074,7 +21074,7 @@ impl IGetCapabilitiesKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilitiesKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21100,7 +21100,7 @@ impl IGpnvsCommonBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetValueUpdateName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21147,7 +21147,7 @@ impl IGraphBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.AddSourceFilter(::core::mem::transmute(&lpcwstrfilename), ::core::mem::transmute(&lpcwstrfiltername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21221,7 +21221,7 @@ impl IGraphConfig_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCacheFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21303,7 +21303,7 @@ impl IGraphVersion_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21334,7 +21334,7 @@ impl IGuideData_Vtbl {
             let this = (*this).get_impl();
             match this.GetServices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumtunerequests = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumtunerequests, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21345,7 +21345,7 @@ impl IGuideData_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceProperties(::core::mem::transmute(&ptunerequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21356,7 +21356,7 @@ impl IGuideData_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuideProgramIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penumprograms = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penumprograms, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21367,7 +21367,7 @@ impl IGuideData_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgramProperties(::core::mem::transmute(&varprogramdescriptionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21378,7 +21378,7 @@ impl IGuideData_Vtbl {
             let this = (*this).get_impl();
             match this.GetScheduleEntryIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penumscheduleentries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penumscheduleentries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21389,7 +21389,7 @@ impl IGuideData_Vtbl {
             let this = (*this).get_impl();
             match this.GetScheduleEntryProperties(::core::mem::transmute(&varscheduleentrydescriptionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21517,7 +21517,7 @@ impl IGuideDataProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21528,7 +21528,7 @@ impl IGuideDataProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *idlang = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(idlang, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21539,7 +21539,7 @@ impl IGuideDataProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21568,7 +21568,7 @@ impl IIPDVDec_Vtbl {
             let this = (*this).get_impl();
             match this.IPDisplay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displaypix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displaypix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21630,7 +21630,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21641,7 +21641,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21652,7 +21652,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetBroadcastViewPropriety() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21663,7 +21663,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21674,7 +21674,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21690,7 +21690,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21701,7 +21701,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordBroadcasterId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21712,7 +21712,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21723,7 +21723,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21739,7 +21739,7 @@ impl IISDB_BIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21793,7 +21793,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21804,7 +21804,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetDownloadDataId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21815,7 +21815,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetSectionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21826,7 +21826,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21837,7 +21837,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21848,7 +21848,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21859,7 +21859,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21875,7 +21875,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetSizeOfDataModule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21886,7 +21886,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataModule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21897,7 +21897,7 @@ impl IISDB_CDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21945,7 +21945,7 @@ impl IISDB_EMM_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21956,7 +21956,7 @@ impl IISDB_EMM_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableIdExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21982,7 +21982,7 @@ impl IISDB_EMM_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22029,7 +22029,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22040,7 +22040,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22051,7 +22051,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportStreamId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22062,7 +22062,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22073,7 +22073,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22084,7 +22084,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptionId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22095,7 +22095,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22106,7 +22106,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22122,7 +22122,7 @@ impl IISDB_LDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22177,7 +22177,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22188,7 +22188,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22199,7 +22199,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22210,7 +22210,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordInformationId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22221,7 +22221,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordInformationType(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22232,7 +22232,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptionBodyLocation(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22243,7 +22243,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordMessageSectionNumber(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22254,7 +22254,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordUserDefined(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22265,7 +22265,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordNumberOfKeys(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22276,7 +22276,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordKeys(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22287,7 +22287,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22298,7 +22298,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22314,7 +22314,7 @@ impl IISDB_NBIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22357,7 +22357,7 @@ impl IISDB_SDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEITUserDefinedFlags(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22404,7 +22404,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22415,7 +22415,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableIdExt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22426,7 +22426,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportStreamId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22437,7 +22437,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22448,7 +22448,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22459,7 +22459,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22470,7 +22470,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordGroup(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22481,7 +22481,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTargetVersion(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22492,7 +22492,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordNewVersion(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22503,7 +22503,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDownloadLevel(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22514,7 +22514,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordVersionIndicator(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22525,7 +22525,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordScheduleTimeShiftInformation(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22536,7 +22536,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfSchedules(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22547,7 +22547,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordStartTimeByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdtval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdtval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22558,7 +22558,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDurationByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22569,7 +22569,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22580,7 +22580,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22596,7 +22596,7 @@ impl IISDB_SDTT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversionhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversionhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22657,7 +22657,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22668,7 +22668,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22679,7 +22679,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22690,7 +22690,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22701,7 +22701,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22712,7 +22712,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22723,7 +22723,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSimulcastGroupTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22734,7 +22734,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetESMultiLingualFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22745,7 +22745,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetMainComponentFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22756,7 +22756,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetQualityIndicator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22767,7 +22767,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSamplingRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22788,7 +22788,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22838,7 +22838,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22849,7 +22849,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22860,7 +22860,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCASystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22871,7 +22871,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAUnitId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22882,7 +22882,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22893,7 +22893,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordComponentTag(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22904,7 +22904,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetContractVerificationInfoLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22915,7 +22915,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetContractVerificationInfo(::core::mem::transmute_copy(&bbuflength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbbuf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbbuf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22926,7 +22926,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeeNameW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22965,7 +22965,7 @@ impl IIsdbCADescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22976,7 +22976,7 @@ impl IIsdbCADescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22987,7 +22987,7 @@ impl IIsdbCADescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCASystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22998,7 +22998,7 @@ impl IIsdbCADescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetReservedBits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23009,7 +23009,7 @@ impl IIsdbCADescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAPID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23050,7 +23050,7 @@ impl IIsdbCAServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23061,7 +23061,7 @@ impl IIsdbCAServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23072,7 +23072,7 @@ impl IIsdbCAServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCASystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23083,7 +23083,7 @@ impl IIsdbCAServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCABroadcasterGroupId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23094,7 +23094,7 @@ impl IIsdbCAServiceDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessageControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23143,7 +23143,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23154,7 +23154,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23165,7 +23165,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentGroupType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23176,7 +23176,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23187,7 +23187,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordGroupId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23198,7 +23198,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordNumberOfCAUnit(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23209,7 +23209,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCAUnitCAUnitId(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&bcaunitindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23220,7 +23220,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCAUnitNumberOfComponents(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&bcaunitindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23231,7 +23231,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCAUnitComponentTag(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&bcaunitindex), ::core::mem::transmute_copy(&bcomponentindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23242,7 +23242,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTotalBitRate(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23253,7 +23253,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTextW(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23301,7 +23301,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23312,7 +23312,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23323,7 +23323,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataComponentId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23334,7 +23334,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntryComponent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23345,7 +23345,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectorLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23356,7 +23356,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectorBytes(::core::mem::transmute_copy(&bbuflength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbbuf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbbuf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23367,7 +23367,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23378,7 +23378,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordComponentRef(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23394,7 +23394,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23433,7 +23433,7 @@ impl IIsdbDigitalCopyControlDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23444,7 +23444,7 @@ impl IIsdbDigitalCopyControlDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23460,7 +23460,7 @@ impl IIsdbDigitalCopyControlDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23514,7 +23514,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23525,7 +23525,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23541,7 +23541,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23552,7 +23552,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetDownloadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23563,7 +23563,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeOutValueDII() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23574,7 +23574,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLeakRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23585,7 +23585,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23596,7 +23596,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompatiblityDescriptorLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23607,7 +23607,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompatiblityDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23618,7 +23618,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23629,7 +23629,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordModuleId(::core::mem::transmute_copy(&wrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23640,7 +23640,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordModuleSize(::core::mem::transmute_copy(&wrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23651,7 +23651,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordModuleInfoLength(::core::mem::transmute_copy(&wrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23662,7 +23662,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordModuleInfo(::core::mem::transmute_copy(&wrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23678,7 +23678,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23726,7 +23726,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23737,7 +23737,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23748,7 +23748,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23759,7 +23759,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23770,7 +23770,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStartEndFlag(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23781,7 +23781,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignalLevel(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23824,7 +23824,7 @@ impl IIsdbEventGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23835,7 +23835,7 @@ impl IIsdbEventGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23846,7 +23846,7 @@ impl IIsdbEventGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroupType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23857,7 +23857,7 @@ impl IIsdbEventGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23873,7 +23873,7 @@ impl IIsdbEventGroupDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRefRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23915,7 +23915,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23926,7 +23926,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23937,7 +23937,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFutureUse1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23948,7 +23948,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetQualityLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23959,7 +23959,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFutureUse2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23970,7 +23970,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetReferencePid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24010,7 +24010,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24021,7 +24021,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24032,7 +24032,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogoTransmissionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24043,7 +24043,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogoId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24054,7 +24054,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogoVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24065,7 +24065,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetDownloadDataId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24076,7 +24076,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogoCharW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrchar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrchar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24115,7 +24115,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24126,7 +24126,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24137,7 +24137,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameterVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24148,7 +24148,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24159,7 +24159,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordNumberOfTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24170,7 +24170,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableId(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24181,7 +24181,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptionLength(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24230,7 +24230,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24241,7 +24241,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24252,7 +24252,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSeriesId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24263,7 +24263,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRepeatLabel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24274,7 +24274,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgramPattern() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24290,7 +24290,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetEpisodeNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24301,7 +24301,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastEpisodeNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24312,7 +24312,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSeriesNameW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24352,7 +24352,7 @@ impl IIsdbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSDT2(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pwtransportstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24363,7 +24363,7 @@ impl IIsdbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBIT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pworiginalnetworkid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24374,7 +24374,7 @@ impl IIsdbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNBIT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pworiginalnetworkid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnbit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnbit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24385,7 +24385,7 @@ impl IIsdbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLDT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pworiginalserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppldt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppldt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24396,7 +24396,7 @@ impl IIsdbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSDTT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&pwtableidext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdtt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdtt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24407,7 +24407,7 @@ impl IIsdbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCDT(::core::mem::transmute_copy(&tableid), ::core::mem::transmute_copy(&bsectionnumber), ::core::mem::transmute_copy(&pwdownloaddataid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24418,7 +24418,7 @@ impl IIsdbSiParser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEMM(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&wtableidext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppemm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppemm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24460,7 +24460,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24471,7 +24471,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24482,7 +24482,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRemoteControlKeyId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24493,7 +24493,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTSNameW(::core::mem::transmute_copy(&convmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24504,7 +24504,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24515,7 +24515,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordTransmissionTypeInfo(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24526,7 +24526,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordNumberOfServices(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24537,7 +24537,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordServiceIdByIndex(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&bserviceindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24576,7 +24576,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24587,7 +24587,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24598,7 +24598,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetAreaCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24609,7 +24609,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuardInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24620,7 +24620,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransmissionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24631,7 +24631,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24642,7 +24642,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordFrequency(::core::mem::transmute_copy(&brecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24711,7 +24711,7 @@ impl IKsTopologyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.NumCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumcategories = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumcategories, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24722,7 +24722,7 @@ impl IKsTopologyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_Category(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcategory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcategory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24733,7 +24733,7 @@ impl IKsTopologyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.NumConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumconnections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumconnections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24744,7 +24744,7 @@ impl IKsTopologyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_ConnectionInfo(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconnectioninfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconnectioninfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24760,7 +24760,7 @@ impl IKsTopologyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.NumNodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumnodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumnodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24771,7 +24771,7 @@ impl IKsTopologyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_NodeType(::core::mem::transmute_copy(&dwnodeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnodetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnodetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24813,7 +24813,7 @@ impl ILanguageComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.LangID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *langid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(langid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24862,7 +24862,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.CarrierFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *frequency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(frequency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24878,7 +24878,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.InnerFEC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24894,7 +24894,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.InnerFECRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24910,7 +24910,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.OuterFEC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24926,7 +24926,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.OuterFECRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24942,7 +24942,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.Modulation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modulation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modulation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24958,7 +24958,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.SymbolRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24974,7 +24974,7 @@ impl ILocator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newlocator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newlocator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25022,7 +25022,7 @@ impl IMPEG2Component_Vtbl {
             let this = (*this).get_impl();
             match this.PID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25038,7 +25038,7 @@ impl IMPEG2Component_Vtbl {
             let this = (*this).get_impl();
             match this.PCRPID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrpid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrpid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25054,7 +25054,7 @@ impl IMPEG2Component_Vtbl {
             let this = (*this).get_impl();
             match this.ProgramNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *programnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(programnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25094,7 +25094,7 @@ impl IMPEG2ComponentType_Vtbl {
             let this = (*this).get_impl();
             match this.StreamType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mp2streamtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mp2streamtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25138,7 +25138,7 @@ impl IMPEG2PIDMap_Vtbl {
             let this = (*this).get_impl();
             match this.EnumPIDMap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pienumpidmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pienumpidmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25178,7 +25178,7 @@ impl IMPEG2StreamIdMap_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStreamIdMap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumstreamidmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumstreamidmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25212,7 +25212,7 @@ impl IMPEG2TuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.TSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25228,7 +25228,7 @@ impl IMPEG2TuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ProgNo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *progno = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(progno, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25265,7 +25265,7 @@ impl IMPEG2TuneRequestFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTuneRequest(::core::mem::transmute(&tuningspace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25326,7 +25326,7 @@ impl IMPEG2_TIF_CONTROL_Vtbl {
             let this = (*this).get_impl();
             match this.GetPIDCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcpids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcpids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25366,7 +25366,7 @@ impl IMSEventBinder_Vtbl {
             let this = (*this).get_impl();
             match this.Bind(::core::mem::transmute(&peventobject), ::core::mem::transmute(&eventname), ::core::mem::transmute(&eventhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cancelid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cancelid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25409,7 +25409,7 @@ impl IMSVidAnalogTuner_Vtbl {
             let this = (*this).get_impl();
             match this.Channel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *channel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(channel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25425,7 +25425,7 @@ impl IMSVidAnalogTuner_Vtbl {
             let this = (*this).get_impl();
             match this.VideoFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25436,7 +25436,7 @@ impl IMSVidAnalogTuner_Vtbl {
             let this = (*this).get_impl();
             match this.AudioFrequency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25447,7 +25447,7 @@ impl IMSVidAnalogTuner_Vtbl {
             let this = (*this).get_impl();
             match this.CountryCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25463,7 +25463,7 @@ impl IMSVidAnalogTuner_Vtbl {
             let this = (*this).get_impl();
             match this.SAP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsapon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsapon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25512,7 +25512,7 @@ impl IMSVidAnalogTuner2_Vtbl {
             let this = (*this).get_impl();
             match this.TVFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25523,7 +25523,7 @@ impl IMSVidAnalogTuner2_Vtbl {
             let this = (*this).get_impl();
             match this.TunerModes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25534,7 +25534,7 @@ impl IMSVidAnalogTuner2_Vtbl {
             let this = (*this).get_impl();
             match this.NumAuxInputs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *inputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25586,7 +25586,7 @@ impl IMSVidAudioRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.Volume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lvol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lvol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25602,7 +25602,7 @@ impl IMSVidAudioRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.Balance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lbal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lbal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25638,7 +25638,7 @@ impl IMSVidAudioRendererDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25649,7 +25649,7 @@ impl IMSVidAudioRendererDevices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25660,7 +25660,7 @@ impl IMSVidAudioRendererDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&v)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25789,7 +25789,7 @@ impl IMSVidClosedCaptioning_Vtbl {
             let this = (*this).get_impl();
             match this.Enable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *on = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(on, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25825,7 +25825,7 @@ impl IMSVidClosedCaptioning2_Vtbl {
             let this = (*this).get_impl();
             match this.Service() {
                 ::core::result::Result::Ok(ok__) => {
-                    *on = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(on, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25860,7 +25860,7 @@ impl IMSVidClosedCaptioning3_Vtbl {
             let this = (*this).get_impl();
             match this.TeleTextFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punkttfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punkttfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25893,7 +25893,7 @@ impl IMSVidCompositionSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Up() {
                 ::core::result::Result::Ok(ok__) => {
-                    *upstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(upstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25904,7 +25904,7 @@ impl IMSVidCompositionSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Down() {
                 ::core::result::Result::Ok(ok__) => {
-                    *downstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(downstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25977,7 +25977,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.AutoSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25993,7 +25993,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.BackColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *backcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(backcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26009,7 +26009,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26025,7 +26025,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.TabStop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26041,7 +26041,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.Window() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26057,7 +26057,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.DisplaySize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26073,7 +26073,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.MaintainAspectRatio() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26089,7 +26089,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.ColorKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26105,7 +26105,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.get_InputsAvailable(::core::mem::transmute(&categoryguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26116,7 +26116,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.get_OutputsAvailable(::core::mem::transmute(&categoryguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26127,7 +26127,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.get__InputsAvailable(::core::mem::transmute_copy(&categoryguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26138,7 +26138,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.get__OutputsAvailable(::core::mem::transmute_copy(&categoryguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26149,7 +26149,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.VideoRenderersAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26160,7 +26160,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.AudioRenderersAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26171,7 +26171,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.FeaturesAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26182,7 +26182,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.InputActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26198,7 +26198,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.OutputsActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26214,7 +26214,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.VideoRendererActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26230,7 +26230,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.AudioRendererActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26246,7 +26246,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.FeaturesActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26262,7 +26262,7 @@ impl IMSVidCtl_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26412,7 +26412,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26423,7 +26423,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26439,7 +26439,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Power() {
                 ::core::result::Result::Ok(ok__) => {
-                    *power = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(power, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26450,7 +26450,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Category() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26461,7 +26461,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this.ClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26472,7 +26472,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this._Category() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26483,7 +26483,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this._ClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26494,7 +26494,7 @@ impl IMSVidDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqualDevice(::core::mem::transmute(&device)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26531,7 +26531,7 @@ impl IMSVidDevice2_Vtbl {
             let this = (*this).get_impl();
             match this.DevicePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *devpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26580,7 +26580,7 @@ impl IMSVidEVR_Vtbl {
             let this = (*this).get_impl();
             match this.Presenter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppallocpresent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppallocpresent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26601,7 +26601,7 @@ impl IMSVidEVR_Vtbl {
             let this = (*this).get_impl();
             match this.SuppressEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bsuppress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bsuppress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26654,7 +26654,7 @@ impl IMSVidEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.VideoEncoderInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppencint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppencint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26665,7 +26665,7 @@ impl IMSVidEncoder_Vtbl {
             let this = (*this).get_impl();
             match this.AudioEncoderInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppencint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppencint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26725,7 +26725,7 @@ impl IMSVidFeatures_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26736,7 +26736,7 @@ impl IMSVidFeatures_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26747,7 +26747,7 @@ impl IMSVidFeatures_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&v)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26791,7 +26791,7 @@ impl IMSVidFilePlayback_Vtbl {
             let this = (*this).get_impl();
             match this.FileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26876,7 +26876,7 @@ impl IMSVidGenericSink_Vtbl {
             let this = (*this).get_impl();
             match this.SinkStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26956,7 +26956,7 @@ impl IMSVidGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Init() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26972,7 +26972,7 @@ impl IMSVidGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFilters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26983,7 +26983,7 @@ impl IMSVidGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Container() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppctl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppctl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26999,7 +26999,7 @@ impl IMSVidGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27010,7 +27010,7 @@ impl IMSVidGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Category() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27103,7 +27103,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Graph() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgraph = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgraph, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27114,7 +27114,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Input() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27125,7 +27125,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Outputs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27136,7 +27136,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.VideoRenderer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27147,7 +27147,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.AudioRenderer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27158,7 +27158,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Features() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfeatures = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfeatures, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27169,7 +27169,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Composites() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomposites = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomposites, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27180,7 +27180,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.ParentContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontainer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontainer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27304,7 +27304,7 @@ impl IMSVidInputDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IsViewable(::core::mem::transmute_copy(&v)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfviewable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfviewable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27356,7 +27356,7 @@ impl IMSVidInputDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27367,7 +27367,7 @@ impl IMSVidInputDevices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27378,7 +27378,7 @@ impl IMSVidInputDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&v)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27451,7 +27451,7 @@ impl IMSVidOutputDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27462,7 +27462,7 @@ impl IMSVidOutputDevices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27473,7 +27473,7 @@ impl IMSVidOutputDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&v)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27529,7 +27529,7 @@ impl IMSVidPlayback_Vtbl {
             let this = (*this).get_impl();
             match this.EnableResetOnStop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27560,7 +27560,7 @@ impl IMSVidPlayback_Vtbl {
             let this = (*this).get_impl();
             match this.get_CanStep(::core::mem::transmute_copy(&fbackwards)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcan = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcan, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27581,7 +27581,7 @@ impl IMSVidPlayback_Vtbl {
             let this = (*this).get_impl();
             match this.Rate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27597,7 +27597,7 @@ impl IMSVidPlayback_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27613,7 +27613,7 @@ impl IMSVidPlayback_Vtbl {
             let this = (*this).get_impl();
             match this.PositionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpositionmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpositionmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27624,7 +27624,7 @@ impl IMSVidPlayback_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *llength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(llength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27696,7 +27696,7 @@ impl IMSVidRect_Vtbl {
             let this = (*this).get_impl();
             match this.Top() {
                 ::core::result::Result::Ok(ok__) => {
-                    *topval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(topval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27712,7 +27712,7 @@ impl IMSVidRect_Vtbl {
             let this = (*this).get_impl();
             match this.Left() {
                 ::core::result::Result::Ok(ok__) => {
-                    *leftval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(leftval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27728,7 +27728,7 @@ impl IMSVidRect_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *widthval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(widthval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27744,7 +27744,7 @@ impl IMSVidRect_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *heightval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(heightval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27760,7 +27760,7 @@ impl IMSVidRect_Vtbl {
             let this = (*this).get_impl();
             match this.HWnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hwndval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hwndval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27816,7 +27816,7 @@ impl IMSVidStreamBufferRecordingControl_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rtstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rtstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27832,7 +27832,7 @@ impl IMSVidStreamBufferRecordingControl_Vtbl {
             let this = (*this).get_impl();
             match this.StopTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rtstop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rtstop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27848,7 +27848,7 @@ impl IMSVidStreamBufferRecordingControl_Vtbl {
             let this = (*this).get_impl();
             match this.RecordingStopped() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27859,7 +27859,7 @@ impl IMSVidStreamBufferRecordingControl_Vtbl {
             let this = (*this).get_impl();
             match this.RecordingStarted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27870,7 +27870,7 @@ impl IMSVidStreamBufferRecordingControl_Vtbl {
             let this = (*this).get_impl();
             match this.RecordingType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27881,7 +27881,7 @@ impl IMSVidStreamBufferRecordingControl_Vtbl {
             let this = (*this).get_impl();
             match this.RecordingAttribute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *precordingattribute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precordingattribute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27922,7 +27922,7 @@ impl IMSVidStreamBufferSink_Vtbl {
             let this = (*this).get_impl();
             match this.get_ContentRecorder(::core::mem::transmute(&pszfilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *precordingiunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precordingiunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27933,7 +27933,7 @@ impl IMSVidStreamBufferSink_Vtbl {
             let this = (*this).get_impl();
             match this.get_ReferenceRecorder(::core::mem::transmute(&pszfilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *precordingiunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precordingiunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27944,7 +27944,7 @@ impl IMSVidStreamBufferSink_Vtbl {
             let this = (*this).get_impl();
             match this.SinkName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27965,7 +27965,7 @@ impl IMSVidStreamBufferSink_Vtbl {
             let this = (*this).get_impl();
             match this.SBESink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sbeconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sbeconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28036,7 +28036,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.SetMinSeek() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28047,7 +28047,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.AudioCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28058,7 +28058,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.VideoCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28069,7 +28069,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.CCCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28080,7 +28080,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.WSTCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28096,7 +28096,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.AudioAnalysisFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28112,7 +28112,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this._AudioAnalysisFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28128,7 +28128,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.VideoAnalysisFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28144,7 +28144,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this._VideoAnalysisFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28160,7 +28160,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.DataAnalysisFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28176,7 +28176,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this._DataAnalysisFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28187,7 +28187,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
             let this = (*this).get_impl();
             match this.LicenseErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hres = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hres, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28346,7 +28346,7 @@ impl IMSVidStreamBufferSource_Vtbl {
             let this = (*this).get_impl();
             match this.Start() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28357,7 +28357,7 @@ impl IMSVidStreamBufferSource_Vtbl {
             let this = (*this).get_impl();
             match this.RecordingAttribute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *precordingattribute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precordingattribute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28388,7 +28388,7 @@ impl IMSVidStreamBufferSource_Vtbl {
             let this = (*this).get_impl();
             match this.SBESource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sbefilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sbefilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28432,7 +28432,7 @@ impl IMSVidStreamBufferSource2_Vtbl {
             let this = (*this).get_impl();
             match this.AudioCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28443,7 +28443,7 @@ impl IMSVidStreamBufferSource2_Vtbl {
             let this = (*this).get_impl();
             match this.VideoCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28454,7 +28454,7 @@ impl IMSVidStreamBufferSource2_Vtbl {
             let this = (*this).get_impl();
             match this.CCCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28465,7 +28465,7 @@ impl IMSVidStreamBufferSource2_Vtbl {
             let this = (*this).get_impl();
             match this.WSTCounter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28730,7 +28730,7 @@ impl IMSVidTuner_Vtbl {
             let this = (*this).get_impl();
             match this.Tune() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28746,7 +28746,7 @@ impl IMSVidTuner_Vtbl {
             let this = (*this).get_impl();
             match this.TuningSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28807,7 +28807,7 @@ impl IMSVidVMR9_Vtbl {
             let this = (*this).get_impl();
             match this.Allocator_ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28828,7 +28828,7 @@ impl IMSVidVMR9_Vtbl {
             let this = (*this).get_impl();
             match this.SuppressEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bsuppress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bsuppress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28839,7 +28839,7 @@ impl IMSVidVMR9_Vtbl {
             let this = (*this).get_impl();
             match this.Allocator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allocpresent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allocpresent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28902,7 +28902,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Owner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *window = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(window, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28913,7 +28913,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.UseOverlay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *useoverlayval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(useoverlayval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28929,7 +28929,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28945,7 +28945,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.ColorKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28961,7 +28961,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Source() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28977,7 +28977,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.Destination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28998,7 +28998,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.BorderColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *color = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(color, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29014,7 +29014,7 @@ impl IMSVidVRGraphSegment_Vtbl {
             let this = (*this).get_impl();
             match this.MaintainAspectRatio() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fmaintain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fmaintain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29125,7 +29125,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.CustomCompositorClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *compositorclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(compositorclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29141,7 +29141,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this._CustomCompositorClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *compositorclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(compositorclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29157,7 +29157,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this._CustomCompositor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *compositor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(compositor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29173,7 +29173,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.MixerBitmap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mixerpicturedisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mixerpicturedisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29184,7 +29184,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this._MixerBitmap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mixerpicture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mixerpicture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29205,7 +29205,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.MixerBitmapPositionRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rdest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rdest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29221,7 +29221,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.MixerBitmapOpacity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *opacity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(opacity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29242,7 +29242,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.SourceSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29258,7 +29258,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.OverScan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpercent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpercent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29274,7 +29274,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableSourceRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29285,7 +29285,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.MaxVidRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvidrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvidrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29296,7 +29296,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.MinVidRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvidrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvidrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29307,7 +29307,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.ClippedSourceRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29323,7 +29323,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.UsingOverlay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *useoverlayval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(useoverlayval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29339,7 +29339,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.Capture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentimage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentimage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29350,7 +29350,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.FramesPerSecond() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29361,7 +29361,7 @@ impl IMSVidVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.DecimateInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdeci = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdeci, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29430,7 +29430,7 @@ impl IMSVidVideoRenderer2_Vtbl {
             let this = (*this).get_impl();
             match this.Allocator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allocpresent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allocpresent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29441,7 +29441,7 @@ impl IMSVidVideoRenderer2_Vtbl {
             let this = (*this).get_impl();
             match this._Allocator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allocpresent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allocpresent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29452,7 +29452,7 @@ impl IMSVidVideoRenderer2_Vtbl {
             let this = (*this).get_impl();
             match this.Allocator_ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29478,7 +29478,7 @@ impl IMSVidVideoRenderer2_Vtbl {
             let this = (*this).get_impl();
             match this.SuppressEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bsuppress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bsuppress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29517,7 +29517,7 @@ impl IMSVidVideoRendererDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29528,7 +29528,7 @@ impl IMSVidVideoRendererDevices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29539,7 +29539,7 @@ impl IMSVidVideoRendererDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&v)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29776,7 +29776,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_AudioLanguage(::core::mem::transmute_copy(&lstream), ::core::mem::transmute_copy(&fformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *straudiolang = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(straudiolang, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29802,7 +29802,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.ButtonsAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29813,7 +29813,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentButton() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29864,7 +29864,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_ButtonAtPosition(::core::mem::transmute_copy(&xpos), ::core::mem::transmute_copy(&ypos)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbutton = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbutton, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29875,7 +29875,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_NumberOfChapters(::core::mem::transmute_copy(&ltitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29886,7 +29886,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.TotalTitleTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29897,7 +29897,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.TitlesAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29908,7 +29908,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.VolumesAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29919,7 +29919,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29930,7 +29930,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDiscSide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29941,7 +29941,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29952,7 +29952,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentChapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29963,7 +29963,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentTitle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29974,7 +29974,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29985,7 +29985,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DVDTimeCode2bstr(::core::mem::transmute_copy(&timecode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimestr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimestr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29996,7 +29996,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DVDDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30012,7 +30012,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.IsSubpictureStreamEnabled(::core::mem::transmute_copy(&lstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30023,7 +30023,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.IsAudioStreamEnabled(::core::mem::transmute_copy(&lstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30034,7 +30034,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentSubpictureStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30050,7 +30050,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_SubpictureLanguage(::core::mem::transmute_copy(&lstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strlanguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strlanguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30061,7 +30061,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAudioStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30077,7 +30077,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.AudioStreamsAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30088,7 +30088,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.AnglesAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30099,7 +30099,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAngle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30115,7 +30115,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.SubpictureStreamsAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30126,7 +30126,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.SubpictureOn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30142,7 +30142,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DVDUniqueID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30173,7 +30173,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_TitleParentalLevels(::core::mem::transmute_copy(&ltitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plparentallevels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plparentallevels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30184,7 +30184,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.PlayerParentalCountry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcountrycode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcountrycode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30195,7 +30195,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.PlayerParentalLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plparentallevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plparentallevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30211,7 +30211,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.UOPValid(::core::mem::transmute_copy(&luop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30222,7 +30222,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_SPRM(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pssprm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pssprm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30233,7 +30233,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_GPRM(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pssprm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pssprm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30249,7 +30249,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_DVDTextStringType(::core::mem::transmute_copy(&llangindex), ::core::mem::transmute_copy(&lstringindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30260,7 +30260,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_DVDTextString(::core::mem::transmute_copy(&llangindex), ::core::mem::transmute_copy(&lstringindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30271,7 +30271,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_DVDTextNumberOfStrings(::core::mem::transmute_copy(&llangindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnumofstrings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnumofstrings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30282,7 +30282,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DVDTextNumberOfLanguages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnumoflangs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnumoflangs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30293,7 +30293,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_DVDTextLanguageLCID(::core::mem::transmute_copy(&llangindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30309,7 +30309,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DVDAdm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30345,7 +30345,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredSubpictureStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30356,7 +30356,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultMenuLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lang = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lang, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30372,7 +30372,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultSubpictureLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lang = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lang, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30383,7 +30383,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultAudioLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lang = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lang, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30394,7 +30394,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultSubpictureLanguageExt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30405,7 +30405,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultAudioLanguageExt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30416,7 +30416,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_LanguageFromLCID(::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lang = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lang, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30427,7 +30427,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.KaraokeAudioPresentationMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30443,7 +30443,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_KaraokeChannelContent(::core::mem::transmute_copy(&lstream), ::core::mem::transmute_copy(&lchan)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30454,7 +30454,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_KaraokeChannelAssignment(::core::mem::transmute_copy(&lstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lchannelassignment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lchannelassignment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30470,7 +30470,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.get_ButtonRect(::core::mem::transmute_copy(&lbutton)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30481,7 +30481,7 @@ impl IMSVidWebDVD_Vtbl {
             let this = (*this).get_impl();
             match this.DVDScreenInMouseCoordinates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30667,7 +30667,7 @@ impl IMSVidWebDVDAdm_Vtbl {
             let this = (*this).get_impl();
             match this.ConfirmPassword(::core::mem::transmute(&strusername), ::core::mem::transmute(&strpassword)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30678,7 +30678,7 @@ impl IMSVidWebDVDAdm_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentalLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *llevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(llevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30689,7 +30689,7 @@ impl IMSVidWebDVDAdm_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentalCountry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcountry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcountry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30700,7 +30700,7 @@ impl IMSVidWebDVDAdm_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultAudioLCID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30716,7 +30716,7 @@ impl IMSVidWebDVDAdm_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultSubpictureLCID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30732,7 +30732,7 @@ impl IMSVidWebDVDAdm_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultMenuLCID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30748,7 +30748,7 @@ impl IMSVidWebDVDAdm_Vtbl {
             let this = (*this).get_impl();
             match this.BookmarkOnStop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30972,7 +30972,7 @@ impl IMSVidXDS_Vtbl {
             let this = (*this).get_impl();
             match this.ChannelChangeInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punkcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punkcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31058,7 +31058,7 @@ impl IMediaControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetState(::core::mem::transmute_copy(&mstimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31074,7 +31074,7 @@ impl IMediaControl_Vtbl {
             let this = (*this).get_impl();
             match this.AddSourceFilter(::core::mem::transmute(&strfilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31085,7 +31085,7 @@ impl IMediaControl_Vtbl {
             let this = (*this).get_impl();
             match this.FilterCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31096,7 +31096,7 @@ impl IMediaControl_Vtbl {
             let this = (*this).get_impl();
             match this.RegFilterCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31143,7 +31143,7 @@ impl IMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31159,7 +31159,7 @@ impl IMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForCompletion(::core::mem::transmute_copy(&mstimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31220,7 +31220,7 @@ impl IMediaEventEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplnonotifyflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplnonotifyflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31288,7 +31288,7 @@ impl IMediaFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetState(::core::mem::transmute_copy(&dwmillisecstimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31304,7 +31304,7 @@ impl IMediaFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31340,7 +31340,7 @@ impl IMediaParamInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetParamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31351,7 +31351,7 @@ impl IMediaParamInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetParamInfo(::core::mem::transmute_copy(&dwparamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31362,7 +31362,7 @@ impl IMediaParamInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetParamText(::core::mem::transmute_copy(&dwparamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwchtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwchtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31373,7 +31373,7 @@ impl IMediaParamInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumTimeFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumtimeformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumtimeformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31384,7 +31384,7 @@ impl IMediaParamInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedTimeFormat(::core::mem::transmute_copy(&dwformatindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidtimeformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidtimeformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31424,7 +31424,7 @@ impl IMediaParams_Vtbl {
             let this = (*this).get_impl();
             match this.GetParam(::core::mem::transmute_copy(&dwparamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31487,7 +31487,7 @@ impl IMediaPosition_Vtbl {
             let this = (*this).get_impl();
             match this.Duration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31503,7 +31503,7 @@ impl IMediaPosition_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31514,7 +31514,7 @@ impl IMediaPosition_Vtbl {
             let this = (*this).get_impl();
             match this.StopTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31530,7 +31530,7 @@ impl IMediaPosition_Vtbl {
             let this = (*this).get_impl();
             match this.PrerollTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31551,7 +31551,7 @@ impl IMediaPosition_Vtbl {
             let this = (*this).get_impl();
             match this.Rate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31562,7 +31562,7 @@ impl IMediaPosition_Vtbl {
             let this = (*this).get_impl();
             match this.CanSeekForward() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcanseekforward = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcanseekforward, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31573,7 +31573,7 @@ impl IMediaPosition_Vtbl {
             let this = (*this).get_impl();
             match this.CanSeekBackward() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcanseekbackward = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcanseekbackward, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31650,7 +31650,7 @@ impl IMediaSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetPointer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31706,7 +31706,7 @@ impl IMediaSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31776,7 +31776,7 @@ impl IMediaSample2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties(::core::mem::transmute_copy(&cbproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31808,7 +31808,7 @@ impl IMediaSample2Config_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdirect3dsurface9 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdirect3dsurface9, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31847,7 +31847,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31868,7 +31868,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.QueryPreferredFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31879,7 +31879,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31900,7 +31900,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31911,7 +31911,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.GetStopPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31922,7 +31922,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31958,7 +31958,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.GetRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31969,7 +31969,7 @@ impl IMediaSeeking_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreroll() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllpreroll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllpreroll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32016,7 +32016,7 @@ impl IMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetMultiMediaStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmultimediastream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmultimediastream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32037,7 +32037,7 @@ impl IMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateSample(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32048,7 +32048,7 @@ impl IMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSharedSample(::core::mem::transmute(&pexistingsample), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewsample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewsample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32100,7 +32100,7 @@ impl IMediaStreamFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaStream(::core::mem::transmute_copy(&idpurpose)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediastream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediastream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32111,7 +32111,7 @@ impl IMediaStreamFilter_Vtbl {
             let this = (*this).get_impl();
             match this.EnumMediaStreams(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediastream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediastream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32127,7 +32127,7 @@ impl IMediaStreamFilter_Vtbl {
             let this = (*this).get_impl();
             match this.ReferenceTimeToStreamTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32138,7 +32138,7 @@ impl IMediaStreamFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentStreamTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcurrentstreamtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcurrentstreamtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32191,7 +32191,7 @@ impl IMediaTypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32202,7 +32202,7 @@ impl IMediaTypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Subtype() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32234,7 +32234,7 @@ impl IMemAllocator_Vtbl {
             let this = (*this).get_impl();
             match this.SetProperties(::core::mem::transmute_copy(&prequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pactual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pactual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32245,7 +32245,7 @@ impl IMemAllocator_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32302,7 +32302,7 @@ impl IMemAllocatorCallbackTemp_Vtbl {
             let this = (*this).get_impl();
             match this.GetFreeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbuffersfree = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbuffersfree, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32354,7 +32354,7 @@ impl IMemInputPin_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppallocator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppallocator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32370,7 +32370,7 @@ impl IMemInputPin_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocatorRequirements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32386,7 +32386,7 @@ impl IMemInputPin_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveMultiple(::core::mem::transmute_copy(&psamples), ::core::mem::transmute_copy(&nsamples)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nsamplesprocessed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nsamplesprocessed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32481,7 +32481,7 @@ impl IMixerOCX_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32706,7 +32706,7 @@ impl IMpeg2Data_Vtbl {
             let this = (*this).get_impl();
             match this.GetSection(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&tid), ::core::mem::transmute_copy(&pfilter), ::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsectionlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsectionlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32717,7 +32717,7 @@ impl IMpeg2Data_Vtbl {
             let this = (*this).get_impl();
             match this.GetTable(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&tid), ::core::mem::transmute_copy(&pfilter), ::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsectionlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsectionlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32728,7 +32728,7 @@ impl IMpeg2Data_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamOfSections(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&tid), ::core::mem::transmute_copy(&pfilter), ::core::mem::transmute_copy(&hdatareadyevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmpegstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmpegstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32893,7 +32893,7 @@ impl IMpegAudioDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.FrequencyDivider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdivider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdivider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32909,7 +32909,7 @@ impl IMpegAudioDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.DecoderAccuracy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paccuracy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paccuracy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32925,7 +32925,7 @@ impl IMpegAudioDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.Stereo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstereo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstereo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32941,7 +32941,7 @@ impl IMpegAudioDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.DecoderWordSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwordsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwordsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32957,7 +32957,7 @@ impl IMpegAudioDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.IntegerDecode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pintdecode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pintdecode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32983,7 +32983,7 @@ impl IMpegAudioDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.AudioFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpfmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpfmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33037,7 +33037,7 @@ impl IMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaStream(::core::mem::transmute_copy(&idpurpose)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediastream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediastream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33048,7 +33048,7 @@ impl IMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.EnumMediaStreams(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediastream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediastream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33059,7 +33059,7 @@ impl IMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcurrentstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcurrentstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33075,7 +33075,7 @@ impl IMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcurrenttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcurrenttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33086,7 +33086,7 @@ impl IMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33102,7 +33102,7 @@ impl IMultiMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndOfStreamEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pheos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pheos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33158,7 +33158,7 @@ impl IOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultColorKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolorkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolorkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33169,7 +33169,7 @@ impl IOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.GetColorKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolorkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolorkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33185,7 +33185,7 @@ impl IOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindowHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33322,7 +33322,7 @@ impl IPAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportStreamId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33333,7 +33333,7 @@ impl IPAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33344,7 +33344,7 @@ impl IPAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33355,7 +33355,7 @@ impl IPAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordProgramNumber(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33366,7 +33366,7 @@ impl IPAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordProgramMapPid(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33377,7 +33377,7 @@ impl IPAT_Vtbl {
             let this = (*this).get_impl();
             match this.FindRecordProgramMapPid(::core::mem::transmute_copy(&wprogramnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33393,7 +33393,7 @@ impl IPAT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33441,7 +33441,7 @@ impl IPBDAAttributesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33452,7 +33452,7 @@ impl IPBDAAttributesDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33487,7 +33487,7 @@ impl IPBDAEntitlementDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33498,7 +33498,7 @@ impl IPBDAEntitlementDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33538,7 +33538,7 @@ impl IPBDASiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetEIT(::core::mem::transmute_copy(&dwsize), ::core::mem::transmute_copy(&pbuffer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33549,7 +33549,7 @@ impl IPBDASiParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetServices(::core::mem::transmute_copy(&dwsize), ::core::mem::transmute_copy(&pbuffer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33592,7 +33592,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33603,7 +33603,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33614,7 +33614,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceIdx() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33625,7 +33625,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33636,7 +33636,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordEventId(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33647,7 +33647,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordStartTime(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdtval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdtval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33658,7 +33658,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDuration(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33669,7 +33669,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33680,7 +33680,7 @@ impl IPBDA_EIT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33728,7 +33728,7 @@ impl IPBDA_Services_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33739,7 +33739,7 @@ impl IPBDA_Services_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordByIndex(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pul64serviceidx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pul64serviceidx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33793,7 +33793,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgramNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33804,7 +33804,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33815,7 +33815,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetPcrPid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33826,7 +33826,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33837,7 +33837,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33853,7 +33853,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33864,7 +33864,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordStreamType(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33875,7 +33875,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordElementaryPid(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33886,7 +33886,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCountOfDescriptors(::core::mem::transmute_copy(&dwrecordindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33897,7 +33897,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordDescriptorByIndex(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&dwdescindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33928,7 +33928,7 @@ impl IPMT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33982,7 +33982,7 @@ impl IPSITables_Vtbl {
             let this = (*this).get_impl();
             match this.GetTable(::core::mem::transmute_copy(&dwtsid), ::core::mem::transmute_copy(&dwtid_pid), ::core::mem::transmute_copy(&dwhashedver), ::core::mem::transmute_copy(&dwpara4)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34087,7 +34087,7 @@ impl IPersistTuneXml_Vtbl {
             let this = (*this).get_impl();
             match this.Save() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarfragment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarfragment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34118,7 +34118,7 @@ impl IPersistTuneXmlUtility_Vtbl {
             let this = (*this).get_impl();
             match this.Deserialize(::core::mem::transmute(&varvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34144,7 +34144,7 @@ impl IPersistTuneXmlUtility2_Vtbl {
             let this = (*this).get_impl();
             match this.Serialize(::core::mem::transmute(&pitunerequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34199,7 +34199,7 @@ impl IPin_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectedTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34210,7 +34210,7 @@ impl IPin_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34221,7 +34221,7 @@ impl IPin_Vtbl {
             let this = (*this).get_impl();
             match this.QueryPinInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34232,7 +34232,7 @@ impl IPin_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDirection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppindir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppindir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34243,7 +34243,7 @@ impl IPin_Vtbl {
             let this = (*this).get_impl();
             match this.QueryId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34259,7 +34259,7 @@ impl IPin_Vtbl {
             let this = (*this).get_impl();
             match this.EnumMediaTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34403,7 +34403,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Pin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34414,7 +34414,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectedTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34425,7 +34425,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34436,7 +34436,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.FilterInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34447,7 +34447,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34458,7 +34458,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Direction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdirection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdirection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34469,7 +34469,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PinID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strpinid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strpinid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34480,7 +34480,7 @@ impl IPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MediaTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34548,7 +34548,7 @@ impl IQualProp_Vtbl {
             let this = (*this).get_impl();
             match this.FramesDroppedInRenderer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcframes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcframes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34559,7 +34559,7 @@ impl IQualProp_Vtbl {
             let this = (*this).get_impl();
             match this.FramesDrawn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcframesdrawn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcframesdrawn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34570,7 +34570,7 @@ impl IQualProp_Vtbl {
             let this = (*this).get_impl();
             match this.AvgFrameRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piavgframerate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piavgframerate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34581,7 +34581,7 @@ impl IQualProp_Vtbl {
             let this = (*this).get_impl();
             match this.Jitter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ijitter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ijitter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34592,7 +34592,7 @@ impl IQualProp_Vtbl {
             let this = (*this).get_impl();
             match this.AvgSyncOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piavg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piavg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34603,7 +34603,7 @@ impl IQualProp_Vtbl {
             let this = (*this).get_impl();
             match this.DevSyncOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pidev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pidev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34698,7 +34698,7 @@ impl IRegFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34709,7 +34709,7 @@ impl IRegFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Filter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34817,7 +34817,7 @@ impl IResourceManager_Vtbl {
             let this = (*this).get_impl();
             match this.Register(::core::mem::transmute(&pname), ::core::mem::transmute_copy(&cresource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34828,7 +34828,7 @@ impl IResourceManager_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterGroup(::core::mem::transmute(&pname), ::core::mem::transmute_copy(&cresource), ::core::mem::transmute_copy(&paltokens)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34899,7 +34899,7 @@ impl ISBE2Crossbar_Vtbl {
             let this = (*this).get_impl();
             match this.GetInitialProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34915,7 +34915,7 @@ impl ISBE2Crossbar_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -34962,7 +34962,7 @@ impl ISBE2EnumStream_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35054,7 +35054,7 @@ impl ISBE2MediaTypeProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35065,7 +35065,7 @@ impl ISBE2MediaTypeProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35133,7 +35133,7 @@ impl ISBE2StreamMap_Vtbl {
             let this = (*this).get_impl();
             match this.EnumMappedStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35197,7 +35197,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35208,7 +35208,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetSequencyNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35219,7 +35219,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35230,7 +35230,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetEASEventID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35241,7 +35241,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginatorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35252,7 +35252,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetEASEventCodeLen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35263,7 +35263,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetEASEventCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35274,7 +35274,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawNatureOfActivationTextLen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35285,7 +35285,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawNatureOfActivationText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35296,7 +35296,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetNatureOfActivationText(::core::mem::transmute(&bstris0639code)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35307,7 +35307,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeRemaining() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35318,7 +35318,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetStartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35329,7 +35329,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35340,7 +35340,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlertPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35351,7 +35351,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsOOBSourceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35362,7 +35362,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsMajor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35373,7 +35373,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsMinor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35384,7 +35384,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsAudioOOBSourceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35395,7 +35395,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlertText(::core::mem::transmute(&bstris0639code)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35406,7 +35406,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawAlertTextLen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35417,7 +35417,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawAlertText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35428,7 +35428,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocationCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35444,7 +35444,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetExceptionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35460,7 +35460,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35471,7 +35471,7 @@ impl ISCTE_EAS_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35545,7 +35545,7 @@ impl ISIInbandEPG_Vtbl {
             let this = (*this).get_impl();
             match this.IsSIEPGScanRunning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *brunning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(brunning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35661,7 +35661,7 @@ impl IScanningTunerEx_Vtbl {
             let this = (*this).get_impl();
             match this.TerminateCurrentScan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcurrentfreq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcurrentfreq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35743,7 +35743,7 @@ impl ISectionList_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfSections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35812,7 +35812,7 @@ impl ISelector_Vtbl {
             let this = (*this).get_impl();
             match this.NumSources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumsources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumsources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35823,7 +35823,7 @@ impl ISelector_Vtbl {
             let this = (*this).get_impl();
             match this.SourceNodeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwpinid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwpinid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35860,7 +35860,7 @@ impl IServiceLocationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetPCR_PID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35871,7 +35871,7 @@ impl IServiceLocationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfElements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35882,7 +35882,7 @@ impl IServiceLocationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetElementStreamType(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35893,7 +35893,7 @@ impl IServiceLocationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetElementPID(::core::mem::transmute_copy(&bindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35931,7 +35931,7 @@ impl ISpecifyParticularPages_Vtbl {
             let this = (*this).get_impl();
             match this.GetPages(::core::mem::transmute_copy(&guidwhatpages)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35964,7 +35964,7 @@ impl IStreamBufferConfigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdirectoryname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdirectoryname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35990,7 +35990,7 @@ impl IStreamBufferConfigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackingFileDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36029,7 +36029,7 @@ impl IStreamBufferConfigure2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMultiplexedPacketSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbbytesperpacket = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbbytesperpacket, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36079,7 +36079,7 @@ impl IStreamBufferConfigure3_Vtbl {
             let this = (*this).get_impl();
             match this.GetStartRecConfig() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfstartstopscur = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfstartstopscur, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36095,7 +36095,7 @@ impl IStreamBufferConfigure3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsznamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsznamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36125,7 +36125,7 @@ impl IStreamBufferDataCounters_Vtbl {
             let this = (*this).get_impl();
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppindata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppindata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36234,7 +36234,7 @@ impl IStreamBufferRecComp_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36321,7 +36321,7 @@ impl IStreamBufferRecordingAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeCount(::core::mem::transmute_copy(&ulreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36342,7 +36342,7 @@ impl IStreamBufferRecordingAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumstreambufferattrib = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumstreambufferattrib, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36379,7 +36379,7 @@ impl IStreamBufferSink_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRecorder(::core::mem::transmute(&pszfilename), ::core::mem::transmute_copy(&dwrecordtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *precordingiunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precordingiunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36557,7 +36557,7 @@ impl ITSDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36568,7 +36568,7 @@ impl ITSDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetCountOfTableDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36579,7 +36579,7 @@ impl ITSDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetTableDescriptorByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36600,7 +36600,7 @@ impl ITSDT_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptsdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptsdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36651,7 +36651,7 @@ impl ITuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.TuningSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tuningspace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tuningspace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36662,7 +36662,7 @@ impl ITuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Components() {
                 ::core::result::Result::Ok(ok__) => {
-                    *components = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(components, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36673,7 +36673,7 @@ impl ITuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newtunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newtunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36684,7 +36684,7 @@ impl ITuneRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Locator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36743,7 +36743,7 @@ impl ITuneRequestInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextProgram(::core::mem::transmute(&currentrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36754,7 +36754,7 @@ impl ITuneRequestInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousProgram(::core::mem::transmute(&currentrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36765,7 +36765,7 @@ impl ITuneRequestInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextLocator(::core::mem::transmute(&currentrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36776,7 +36776,7 @@ impl ITuneRequestInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousLocator(::core::mem::transmute(&currentrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36811,7 +36811,7 @@ impl ITuneRequestInfoEx_Vtbl {
             let this = (*this).get_impl();
             match this.CreateComponentListEx(::core::mem::transmute(&currentrequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcurpmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcurpmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36846,7 +36846,7 @@ impl ITuner_Vtbl {
             let this = (*this).get_impl();
             match this.TuningSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tuningspace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tuningspace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36862,7 +36862,7 @@ impl ITuner_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTuningSpaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36873,7 +36873,7 @@ impl ITuner_Vtbl {
             let this = (*this).get_impl();
             match this.TuneRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36894,7 +36894,7 @@ impl ITuner_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredComponentTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *componenttypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(componenttypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36910,7 +36910,7 @@ impl ITuner_Vtbl {
             let this = (*this).get_impl();
             match this.SignalStrength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36984,7 +36984,7 @@ impl ITunerCapEx_Vtbl {
             let this = (*this).get_impl();
             match this.Has608_708Caption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbhascaption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbhascaption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37028,7 +37028,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.UniqueName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37044,7 +37044,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37060,7 +37060,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.CLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *spaceclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(spaceclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37071,7 +37071,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *networktypeguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(networktypeguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37087,7 +37087,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this._NetworkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *networktypeguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(networktypeguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37103,7 +37103,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTuneRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tunerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tunerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37114,7 +37114,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCategoryGUIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37125,7 +37125,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDeviceMonikers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37136,7 +37136,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultPreferredComponentTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *componenttypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(componenttypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37152,7 +37152,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.FrequencyMapping() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmapping = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmapping, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37168,7 +37168,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultLocator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locatorval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locatorval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37184,7 +37184,7 @@ impl ITuningSpace_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37243,7 +37243,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37254,7 +37254,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37265,7 +37265,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tuningspace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tuningspace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37281,7 +37281,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.TuningSpacesForCLSID(::core::mem::transmute(&spaceclsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcoll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcoll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37292,7 +37292,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this._TuningSpacesForCLSID2(::core::mem::transmute_copy(&spaceclsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcoll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcoll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37303,7 +37303,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.TuningSpacesForName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcoll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcoll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37314,7 +37314,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.FindID(::core::mem::transmute(&tuningspace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37325,7 +37325,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&tuningspace)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37336,7 +37336,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTuningSpaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37352,7 +37352,7 @@ impl ITuningSpaceContainer_Vtbl {
             let this = (*this).get_impl();
             match this.MaxCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37401,7 +37401,7 @@ impl ITuningSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37412,7 +37412,7 @@ impl ITuningSpaces_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37423,7 +37423,7 @@ impl ITuningSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tuningspace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tuningspace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37434,7 +37434,7 @@ impl ITuningSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTuningSpaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37491,7 +37491,7 @@ impl IVMRAspectRatioControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetAspectRatioMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwarmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwarmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37599,7 +37599,7 @@ impl IVMRDeinterlaceControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeinterlaceModeCaps(::core::mem::transmute_copy(&lpdeinterlacemode), ::core::mem::transmute_copy(&lpvideodescription)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdeinterlacecaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdeinterlacecaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37610,7 +37610,7 @@ impl IVMRDeinterlaceControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeinterlaceMode(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdeinterlacemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdeinterlacemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37626,7 +37626,7 @@ impl IVMRDeinterlaceControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeinterlacePrefs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwdeinterlaceprefs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwdeinterlaceprefs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37642,7 +37642,7 @@ impl IVMRDeinterlaceControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualDeinterlaceMode(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdeinterlacemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdeinterlacemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37752,7 +37752,7 @@ impl IVMRFilterConfig9_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37768,7 +37768,7 @@ impl IVMRFilterConfig9_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderingPrefs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrenderflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrenderflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37784,7 +37784,7 @@ impl IVMRFilterConfig9_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38011,7 +38011,7 @@ impl IVMRImagePresenterConfig9_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderingPrefs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwrenderflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwrenderflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38120,7 +38120,7 @@ impl IVMRMixerBitmap9_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlphaBitmapParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmpparms = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmpparms, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38248,7 +38248,7 @@ impl IVMRMixerControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlpha(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *palpha = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(palpha, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38264,7 +38264,7 @@ impl IVMRMixerControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetZOrder(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38280,7 +38280,7 @@ impl IVMRMixerControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputRect(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38306,7 +38306,7 @@ impl IVMRMixerControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetMixingPrefs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmixerprefs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmixerprefs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38422,7 +38422,7 @@ impl IVMRMonitorConfig9_Vtbl {
             let this = (*this).get_impl();
             match this.GetMonitor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pudev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pudev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38438,7 +38438,7 @@ impl IVMRMonitorConfig9_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultMonitor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pudev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pudev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38494,7 +38494,7 @@ impl IVMRSurface_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38534,7 +38534,7 @@ impl IVMRSurface9_Vtbl {
             let this = (*this).get_impl();
             match this.LockSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38550,7 +38550,7 @@ impl IVMRSurface9_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38639,7 +38639,7 @@ impl IVMRSurfaceAllocator9_Vtbl {
             let this = (*this).get_impl();
             match this.GetSurface(::core::mem::transmute_copy(&dwuserid), ::core::mem::transmute_copy(&surfaceindex), ::core::mem::transmute_copy(&surfaceflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpsurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpsurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38855,7 +38855,7 @@ impl IVMRVideoStreamControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamActiveState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpfactive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpfactive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39043,7 +39043,7 @@ impl IVMRWindowlessControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetAspectRatioMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpaspectratiomode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpaspectratiomode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39074,7 +39074,7 @@ impl IVMRWindowlessControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentImage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdib = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdib, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39090,7 +39090,7 @@ impl IVMRWindowlessControl9_Vtbl {
             let this = (*this).get_impl();
             match this.GetBorderColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpclr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpclr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39183,7 +39183,7 @@ impl IVPBaseConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetOverlaySurface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppddoverlaysurface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppddoverlaysurface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39774,7 +39774,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Caption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strcaption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strcaption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39790,7 +39790,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.WindowStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *windowstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(windowstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39806,7 +39806,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.WindowStyleEx() {
                 ::core::result::Result::Ok(ok__) => {
-                    *windowstyleex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(windowstyleex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39822,7 +39822,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.AutoShow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *autoshow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(autoshow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39838,7 +39838,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.WindowState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *windowstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(windowstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39854,7 +39854,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.BackgroundPalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbackgroundpalette = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbackgroundpalette, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39870,7 +39870,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvisible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvisible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39886,7 +39886,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Left() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pleft = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pleft, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39902,7 +39902,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39918,7 +39918,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Top() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39934,7 +39934,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39950,7 +39950,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Owner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39966,7 +39966,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.MessageDrain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *drain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(drain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39977,7 +39977,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.BorderColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *color = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(color, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39993,7 +39993,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.FullScreenMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fullscreenmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fullscreenmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40049,7 +40049,7 @@ impl IVideoWindow_Vtbl {
             let this = (*this).get_impl();
             match this.IsCursorHidden() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cursorhidden = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cursorhidden, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40122,7 +40122,7 @@ impl IXDSCodec_Vtbl {
             let this = (*this).get_impl();
             match this.XDSToRatObjOK() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrcocreateretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrcocreateretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40138,7 +40138,7 @@ impl IXDSCodec_Vtbl {
             let this = (*this).get_impl();
             match this.CCSubstreamService() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psubstreammask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psubstreammask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40159,7 +40159,7 @@ impl IXDSCodec_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrLicenseExpDate(::core::mem::transmute_copy(&prottype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40197,7 +40197,7 @@ impl IXDSCodecConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecureChannelObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdrmsecurechannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdrmsecurechannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
@@ -21,7 +21,7 @@ impl IDMOQualityControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -52,7 +52,7 @@ impl IDMOVideoOutputOptimizations_Vtbl {
             let this = (*this).get_impl();
             match this.QueryOperationModePreferences(::core::mem::transmute_copy(&uloutputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrequestedcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrequestedcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -68,7 +68,7 @@ impl IDMOVideoOutputOptimizations_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentOperationMode(::core::mem::transmute_copy(&uloutputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwenabledfeatures = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwenabledfeatures, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -79,7 +79,7 @@ impl IDMOVideoOutputOptimizations_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSampleRequirements(::core::mem::transmute_copy(&uloutputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrequestedfeatures = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrequestedfeatures, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -126,7 +126,7 @@ impl IEnumDMO_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -162,7 +162,7 @@ impl IMediaBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbmaxlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbmaxlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -223,7 +223,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStreamInfo(::core::mem::transmute_copy(&dwinputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamInfo(::core::mem::transmute_copy(&dwoutputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputType(::core::mem::transmute_copy(&dwinputstreamindex), ::core::mem::transmute_copy(&dwtypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -256,7 +256,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputType(::core::mem::transmute_copy(&dwoutputstreamindex), ::core::mem::transmute_copy(&dwtypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -277,7 +277,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCurrentType(::core::mem::transmute_copy(&dwinputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -288,7 +288,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCurrentType(::core::mem::transmute_copy(&dwoutputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -309,7 +309,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputMaxLatency(::core::mem::transmute_copy(&dwinputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtmaxlatency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtmaxlatency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -345,7 +345,7 @@ impl IMediaObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStatus(::core::mem::transmute_copy(&dwinputstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -413,7 +413,7 @@ impl IMediaObjectInPlace_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -424,7 +424,7 @@ impl IMediaObjectInPlace_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *platencytime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(platencytime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
@@ -79,7 +79,7 @@ impl IKsFormatSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevicePreferredFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppksformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppksformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -106,7 +106,7 @@ impl IKsJackContainerId_Vtbl {
             let this = (*this).get_impl();
             match this.GetJackContainerId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pjackcontainerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pjackcontainerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl IKsJackDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetJackCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcjacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcjacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -144,7 +144,7 @@ impl IKsJackDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetJackDescription(::core::mem::transmute_copy(&njack)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -172,7 +172,7 @@ impl IKsJackDescription2_Vtbl {
             let this = (*this).get_impl();
             match this.GetJackCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcjacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcjacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -183,7 +183,7 @@ impl IKsJackDescription2_Vtbl {
             let this = (*this).get_impl();
             match this.GetJackDescription2(::core::mem::transmute_copy(&njack)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdescription2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdescription2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -213,7 +213,7 @@ impl IKsJackSinkInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetJackSinkInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pjacksinkinformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pjacksinkinformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -248,7 +248,7 @@ impl IKsPropertySet_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySupported(::core::mem::transmute_copy(&propset), ::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typesupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typesupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/impl.rs
@@ -15,7 +15,7 @@ impl IWindowsMediaLibrarySharingDevice_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26,7 +26,7 @@ impl IWindowsMediaLibrarySharingDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Authorization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *authorization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(authorization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IWindowsMediaLibrarySharingDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deviceproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deviceproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -76,7 +76,7 @@ impl IWindowsMediaLibrarySharingDeviceProperties_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *property = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(property, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -87,7 +87,7 @@ impl IWindowsMediaLibrarySharingDeviceProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl IWindowsMediaLibrarySharingDeviceProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *property = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(property, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -130,7 +130,7 @@ impl IWindowsMediaLibrarySharingDeviceProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -141,7 +141,7 @@ impl IWindowsMediaLibrarySharingDeviceProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -173,7 +173,7 @@ impl IWindowsMediaLibrarySharingDevices_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *device = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(device, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -184,7 +184,7 @@ impl IWindowsMediaLibrarySharingDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -195,7 +195,7 @@ impl IWindowsMediaLibrarySharingDevices_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice(::core::mem::transmute(&deviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *device = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(device, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -249,7 +249,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.userHomeMediaSharingState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sharingenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sharingenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.userHomeMediaSharingLibraryName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *libraryname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(libraryname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -281,7 +281,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.computerHomeMediaSharingAllowedState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sharingallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sharingallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -297,7 +297,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.userInternetMediaSharingState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sharingenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sharingenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -313,7 +313,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.computerInternetMediaSharingAllowedState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sharingallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sharingallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -329,7 +329,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.internetMediaSharingSecurityGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *securitygroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(securitygroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -345,7 +345,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.allowSharingToAllDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sharingenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sharingenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -371,7 +371,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.getAllDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *devices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -382,7 +382,7 @@ impl IWindowsMediaLibrarySharingServices_Vtbl {
             let this = (*this).get_impl();
             match this.customSettingsApplied() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customsettingsapplied = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customsettingsapplied, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
@@ -9,7 +9,7 @@ impl IAdvancedMediaCapture_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdvancedMediaCaptureSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -52,7 +52,7 @@ impl IAdvancedMediaCaptureSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectxDeviceManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl IClusterDetector_Vtbl {
             let this = (*this).get_impl();
             match this.Detect(::core::mem::transmute_copy(&dwmaxnumclusters), ::core::mem::transmute_copy(&fminclusterduration), ::core::mem::transmute_copy(&fmaxclusterduration), ::core::mem::transmute(&psrctoc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdsttoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdsttoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -162,7 +162,7 @@ impl ICodecAPI_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultValue(::core::mem::transmute_copy(&api)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -173,7 +173,7 @@ impl ICodecAPI_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&api)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1331,7 +1331,7 @@ impl IDXVAHD_Device_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorDeviceCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1362,7 +1362,7 @@ impl IDXVAHD_Device_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorFilterRange(::core::mem::transmute_copy(&filter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1373,7 +1373,7 @@ impl IDXVAHD_Device_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoProcessor(::core::mem::transmute_copy(&pvpguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvideoprocessor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvideoprocessor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1658,7 +1658,7 @@ impl IDirect3DDeviceManager9_Vtbl {
             let this = (*this).get_impl();
             match this.OpenDeviceHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1744,7 +1744,7 @@ impl IDirectXVideoDecoder_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoDecoderService() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1827,7 +1827,7 @@ impl IDirectXVideoDecoderService_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoDecoder(::core::mem::transmute_copy(&guid), ::core::mem::transmute_copy(&pvideodesc), ::core::mem::transmute_copy(&pconfig), ::core::mem::transmute_copy(&ppdecoderrendertargets), ::core::mem::transmute_copy(&numrendertargets)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdecode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdecode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1857,7 +1857,7 @@ impl IDirectXVideoMemoryConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableSurfaceTypeByIndex(::core::mem::transmute_copy(&dwtypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1897,7 +1897,7 @@ impl IDirectXVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorService() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1913,7 +1913,7 @@ impl IDirectXVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1924,7 +1924,7 @@ impl IDirectXVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcAmpRange(::core::mem::transmute_copy(&procampcap)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1935,7 +1935,7 @@ impl IDirectXVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterPropertyRange(::core::mem::transmute_copy(&filtersetting)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2001,7 +2001,7 @@ impl IDirectXVideoProcessorService_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorCaps(::core::mem::transmute_copy(&videoprocdeviceguid), ::core::mem::transmute_copy(&pvideodesc), ::core::mem::transmute_copy(&rendertargetformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2012,7 +2012,7 @@ impl IDirectXVideoProcessorService_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcAmpRange(::core::mem::transmute_copy(&videoprocdeviceguid), ::core::mem::transmute_copy(&pvideodesc), ::core::mem::transmute_copy(&rendertargetformat), ::core::mem::transmute_copy(&procampcap)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2023,7 +2023,7 @@ impl IDirectXVideoProcessorService_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterPropertyRange(::core::mem::transmute_copy(&videoprocdeviceguid), ::core::mem::transmute_copy(&pvideodesc), ::core::mem::transmute_copy(&rendertargetformat), ::core::mem::transmute_copy(&filtersetting)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2034,7 +2034,7 @@ impl IDirectXVideoProcessorService_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVideoProcessor(::core::mem::transmute_copy(&videoprocdeviceguid), ::core::mem::transmute_copy(&pvideodesc), ::core::mem::transmute_copy(&rendertargetformat), ::core::mem::transmute_copy(&maxnumsubstreams)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvidprocess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvidprocess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2073,7 +2073,7 @@ impl IEVRFilterConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2106,7 +2106,7 @@ impl IEVRFilterConfigEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfigPrefs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconfigflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconfigflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2139,7 +2139,7 @@ impl IEVRTrustedVideoPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.IsInTrustedVideoMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pyes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pyes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2150,7 +2150,7 @@ impl IEVRTrustedVideoPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.CanConstrict() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pyes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pyes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2198,7 +2198,7 @@ impl IEVRVideoStreamControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamActiveState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpfactive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpfactive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2369,7 +2369,7 @@ impl IMF2DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.IsContiguousFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfiscontiguous = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfiscontiguous, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2380,7 +2380,7 @@ impl IMF2DBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetContiguousLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcblength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcblength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2461,7 +2461,7 @@ impl IMFASFContentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetHeaderSize(::core::mem::transmute(&pistartofcontent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cbheadersize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cbheadersize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2477,7 +2477,7 @@ impl IMFASFContentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateHeader(::core::mem::transmute(&piheader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbheader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbheader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2488,7 +2488,7 @@ impl IMFASFContentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2504,7 +2504,7 @@ impl IMFASFContentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GeneratePresentationDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipresentationdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipresentationdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2515,7 +2515,7 @@ impl IMFASFContentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetEncodingConfigurationPropertyStore(::core::mem::transmute_copy(&wstreamnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2567,7 +2567,7 @@ impl IMFASFIndexer_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2583,7 +2583,7 @@ impl IMFASFIndexer_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexPosition(::core::mem::transmute(&picontentinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbindexoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbindexoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2599,7 +2599,7 @@ impl IMFASFIndexer_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexByteStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbytestreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbytestreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2635,7 +2635,7 @@ impl IMFASFIndexer_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexWriteSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbindexwritespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbindexwritespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2696,7 +2696,7 @@ impl IMFASFMultiplexer_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2727,7 +2727,7 @@ impl IMFASFMultiplexer_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatistics(::core::mem::transmute_copy(&wstreamnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmuxstats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmuxstats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2774,7 +2774,7 @@ impl IMFASFMutualExclusion_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2790,7 +2790,7 @@ impl IMFASFMutualExclusion_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrecordcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrecordcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2821,7 +2821,7 @@ impl IMFASFMutualExclusion_Vtbl {
             let this = (*this).get_impl();
             match this.AddRecord() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrecordnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrecordnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2832,7 +2832,7 @@ impl IMFASFMutualExclusion_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimutex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimutex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2884,7 +2884,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2900,7 +2900,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamByNumber(::core::mem::transmute_copy(&wstreamnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2921,7 +2921,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStream(::core::mem::transmute(&pimediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2932,7 +2932,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetMutualExclusionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmutexs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmutexs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2943,7 +2943,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetMutualExclusion(::core::mem::transmute_copy(&dwmutexindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimutex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimutex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2964,7 +2964,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMutualExclusion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimutex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimutex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2975,7 +2975,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamPrioritization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistreamprioritization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistreamprioritization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2996,7 +2996,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStreamPrioritization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistreamprioritization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistreamprioritization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3007,7 +3007,7 @@ impl IMFASFProfile_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3066,7 +3066,7 @@ impl IMFASFSplitter_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3102,7 +3102,7 @@ impl IMFASFSplitter_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastSendTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlastsendtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlastsendtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3148,7 +3148,7 @@ impl IMFASFStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidstreamtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidstreamtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3169,7 +3169,7 @@ impl IMFASFStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3185,7 +3185,7 @@ impl IMFASFStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetPayloadExtensionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcpayloadextensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcpayloadextensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3211,7 +3211,7 @@ impl IMFASFStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistreamconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistreamconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3250,7 +3250,7 @@ impl IMFASFStreamPrioritization_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3276,7 +3276,7 @@ impl IMFASFStreamPrioritization_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistreamprioritization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistreamprioritization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3319,7 +3319,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3330,7 +3330,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcoutputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcoutputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3341,7 +3341,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamCount(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3352,7 +3352,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamNumbers(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rgwstreamnumbers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rgwstreamnumbers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3363,7 +3363,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputFromStream(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3374,7 +3374,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputOverride(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pselection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pselection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3390,7 +3390,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMutexCount(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmutexes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmutexes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3401,7 +3401,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMutex(::core::mem::transmute_copy(&dwoutputnum), ::core::mem::transmute_copy(&dwmutexnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmutex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmutex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3417,7 +3417,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetBandwidthStepCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstepcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstepcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3433,7 +3433,7 @@ impl IMFASFStreamSelector_Vtbl {
             let this = (*this).get_impl();
             match this.BitrateToStepNumber(::core::mem::transmute_copy(&dwbitrate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstepnum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstepnum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3572,7 +3572,7 @@ impl IMFAsyncResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3593,7 +3593,7 @@ impl IMFAsyncResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3665,7 +3665,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemType(::core::mem::transmute_copy(&guidkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3676,7 +3676,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.CompareItem(::core::mem::transmute_copy(&guidkey), ::core::mem::transmute_copy(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3687,7 +3687,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute(&ptheirs), ::core::mem::transmute_copy(&matchtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3698,7 +3698,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetUINT32(::core::mem::transmute_copy(&guidkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *punvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3709,7 +3709,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetUINT64(::core::mem::transmute_copy(&guidkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *punvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3720,7 +3720,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetDouble(::core::mem::transmute_copy(&guidkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3731,7 +3731,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUID(::core::mem::transmute_copy(&guidkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3742,7 +3742,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringLength(::core::mem::transmute_copy(&guidkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3763,7 +3763,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlobSize(::core::mem::transmute_copy(&guidkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbblobsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbblobsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3849,7 +3849,7 @@ impl IMFAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3944,7 +3944,7 @@ impl IMFAudioPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroupingParam() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3960,7 +3960,7 @@ impl IMFAudioPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3976,7 +3976,7 @@ impl IMFAudioPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetIconPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4011,7 +4011,7 @@ impl IMFAudioStreamVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4027,7 +4027,7 @@ impl IMFAudioStreamVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetChannelVolume(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4111,7 +4111,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4122,7 +4122,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4138,7 +4138,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4154,7 +4154,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.IsEndOfStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfendofstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfendofstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4175,7 +4175,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.EndRead(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4186,7 +4186,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.Write(::core::mem::transmute_copy(&pb), ::core::mem::transmute_copy(&cb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4202,7 +4202,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.EndWrite(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4213,7 +4213,7 @@ impl IMFByteStream_Vtbl {
             let this = (*this).get_impl();
             match this.Seek(::core::mem::transmute_copy(&seekorigin), ::core::mem::transmute_copy(&llseekoffset), ::core::mem::transmute_copy(&dwseekflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwcurrentposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwcurrentposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4332,7 +4332,7 @@ impl IMFByteStreamCacheControl2_Vtbl {
             let this = (*this).get_impl();
             match this.IsBackgroundTransferActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfactive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfactive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4381,7 +4381,7 @@ impl IMFByteStreamHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxNumberOfBytesRequiredForResolution() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwbytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwbytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4432,7 +4432,7 @@ impl IMFByteStreamTimeSeek_Vtbl {
             let this = (*this).get_impl();
             match this.IsTimeSeekSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftimeseekissupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftimeseekissupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4504,7 +4504,7 @@ impl IMFCameraOcclusionStateReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetOcclusionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *occlusionstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(occlusionstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4611,7 +4611,7 @@ impl IMFCaptureEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetSink(::core::mem::transmute_copy(&mfcaptureenginesinktype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4622,7 +4622,7 @@ impl IMFCaptureEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4738,7 +4738,7 @@ impl IMFCapturePhotoConfirmation_Vtbl {
             let this = (*this).get_impl();
             match this.GetPixelFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *subtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4831,7 +4831,7 @@ impl IMFCapturePreviewSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetMirrorState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmirrorstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmirrorstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4847,7 +4847,7 @@ impl IMFCapturePreviewSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetRotation(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrotationvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrotationvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4916,7 +4916,7 @@ impl IMFCaptureRecordSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetRotation(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrotationvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrotationvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4956,7 +4956,7 @@ impl IMFCaptureSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMediaType(::core::mem::transmute_copy(&dwsinkstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4967,7 +4967,7 @@ impl IMFCaptureSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetService(::core::mem::transmute_copy(&dwsinkstreamindex), ::core::mem::transmute_copy(&rguidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4978,7 +4978,7 @@ impl IMFCaptureSink_Vtbl {
             let this = (*this).get_impl();
             match this.AddStream(::core::mem::transmute_copy(&dwsourcestreamindex), ::core::mem::transmute(&pmediatype), ::core::mem::transmute(&pattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsinkstreamindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsinkstreamindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5051,7 +5051,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaptureDeviceSource(::core::mem::transmute_copy(&mfcaptureenginedevicetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediasource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediasource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5062,7 +5062,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaptureDeviceActivate(::core::mem::transmute_copy(&mfcaptureenginedevicetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppactivate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppactivate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5073,7 +5073,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetService(::core::mem::transmute_copy(&rguidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5099,7 +5099,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableDeviceMediaType(::core::mem::transmute_copy(&dwsourcestreamindex), ::core::mem::transmute_copy(&dwmediatypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5115,7 +5115,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentDeviceMediaType(::core::mem::transmute_copy(&dwsourcestreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5126,7 +5126,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5137,7 +5137,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceStreamCategory(::core::mem::transmute_copy(&dwsourcestreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstreamcategory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstreamcategory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5148,7 +5148,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetMirrorState(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmirrorstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmirrorstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5164,7 +5164,7 @@ impl IMFCaptureSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamIndexFromFriendlyName(::core::mem::transmute_copy(&uifriendlyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwactualstreamindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwactualstreamindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5230,7 +5230,7 @@ impl IMFClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetClockCharacteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcharacteristics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcharacteristics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5246,7 +5246,7 @@ impl IMFClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetContinuityKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcontinuitykey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcontinuitykey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5257,7 +5257,7 @@ impl IMFClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetState(::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *peclockstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peclockstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5268,7 +5268,7 @@ impl IMFClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclockproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclockproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5304,7 +5304,7 @@ impl IMFClockConsumer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresentationClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppresentationclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppresentationclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5384,7 +5384,7 @@ impl IMFCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetElementCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcelements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcelements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5395,7 +5395,7 @@ impl IMFCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetElement(::core::mem::transmute_copy(&dwelementindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5411,7 +5411,7 @@ impl IMFCollection_Vtbl {
             let this = (*this).get_impl();
             match this.RemoveElement(::core::mem::transmute_copy(&dwelementindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5463,7 +5463,7 @@ impl IMFContentDecryptionModule_Vtbl {
             let this = (*this).get_impl();
             match this.GetSuspendNotify() {
                 ::core::result::Result::Ok(ok__) => {
-                    *notify = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(notify, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5479,7 +5479,7 @@ impl IMFContentDecryptionModule_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession(::core::mem::transmute_copy(&sessiontype), ::core::mem::transmute(&callbacks)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *session = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(session, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5495,7 +5495,7 @@ impl IMFContentDecryptionModule_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTrustedInput(::core::mem::transmute_copy(&contentinitdata), ::core::mem::transmute_copy(&contentinitdatasize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *trustedinput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(trustedinput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5537,7 +5537,7 @@ impl IMFContentDecryptionModuleAccess_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContentDecryptionModule(::core::mem::transmute(&contentdecryptionmoduleproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentdecryptionmodule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentdecryptionmodule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5548,7 +5548,7 @@ impl IMFContentDecryptionModuleAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfiguration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *configuration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(configuration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5559,7 +5559,7 @@ impl IMFContentDecryptionModuleAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeySystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keysystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keysystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5596,7 +5596,7 @@ impl IMFContentDecryptionModuleFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContentDecryptionModuleAccess(::core::mem::transmute(&keysystem), ::core::mem::transmute_copy(&configurations), ::core::mem::transmute_copy(&numconfigurations)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentdecryptionmoduleaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentdecryptionmoduleaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5633,7 +5633,7 @@ impl IMFContentDecryptionModuleSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetSessionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sessionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sessionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5644,7 +5644,7 @@ impl IMFContentDecryptionModuleSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpiration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *expiration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expiration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5660,7 +5660,7 @@ impl IMFContentDecryptionModuleSession_Vtbl {
             let this = (*this).get_impl();
             match this.Load(::core::mem::transmute(&sessionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *loaded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(loaded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5740,7 +5740,7 @@ impl IMFContentDecryptorContext_Vtbl {
             let this = (*this).get_impl();
             match this.InitializeHardwareKey(::core::mem::transmute_copy(&inputprivatedatabytecount), ::core::mem::transmute_copy(&inputprivatedata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *outputprivatedata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(outputprivatedata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5772,7 +5772,7 @@ impl IMFContentEnabler_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5793,7 +5793,7 @@ impl IMFContentEnabler_Vtbl {
             let this = (*this).get_impl();
             match this.IsAutomaticSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfautomatic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfautomatic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6026,7 +6026,7 @@ impl IMFDXGIBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubresourceIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pusubresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pusubresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6089,7 +6089,7 @@ impl IMFDXGIDeviceManager_Vtbl {
             let this = (*this).get_impl();
             match this.OpenDeviceHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6136,7 +6136,7 @@ impl IMFDXGIDeviceManagerSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6248,7 +6248,7 @@ impl IMFExtendedCameraController_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtendedCameraControl(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute_copy(&ulpropertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontrol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontrol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6273,7 +6273,7 @@ impl IMFExtendedCameraIntrinsicModel_Vtbl {
             let this = (*this).get_impl();
             match this.GetModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pintrinsicmodel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pintrinsicmodel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6289,7 +6289,7 @@ impl IMFExtendedCameraIntrinsicModel_Vtbl {
             let this = (*this).get_impl();
             match this.GetDistortionModelType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdistortionmodeltype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdistortionmodeltype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6327,7 +6327,7 @@ impl IMFExtendedCameraIntrinsics_Vtbl {
             let this = (*this).get_impl();
             match this.GetBufferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwbuffersize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwbuffersize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6343,7 +6343,7 @@ impl IMFExtendedCameraIntrinsics_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntrinsicModelCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6354,7 +6354,7 @@ impl IMFExtendedCameraIntrinsics_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntrinsicModelByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppintrinsicmodel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppintrinsicmodel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6391,7 +6391,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModel6KT_Vtbl {
             let this = (*this).get_impl();
             match this.GetDistortionModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdistortionmodel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdistortionmodel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6424,7 +6424,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModelArcTan_Vtbl {
             let this = (*this).get_impl();
             match this.GetDistortionModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdistortionmodel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdistortionmodel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6459,7 +6459,7 @@ impl IMFExtendedDRMTypeSupport_Vtbl {
             let this = (*this).get_impl();
             match this.IsTypeSupportedEx(::core::mem::transmute(&r#type), ::core::mem::transmute(&keysystem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *panswer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(panswer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6622,7 +6622,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHeader(::core::mem::transmute(&szheadername), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszheadervalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszheadervalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6633,7 +6633,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6644,7 +6644,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             let this = (*this).get_impl();
             match this.HasNullSourceOrigin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfnullsourceorigin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfnullsourceorigin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6660,7 +6660,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetHttpStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhttpstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhttpstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6671,7 +6671,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetAtEndOfPayload() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfatendofpayload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfatendofpayload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6682,7 +6682,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwtotallength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwtotallength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6693,7 +6693,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetRangeEndOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqwrangeend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqwrangeend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6749,7 +6749,7 @@ impl IMFHttpDownloadSession_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRequest(::core::mem::transmute(&szobjectname), ::core::mem::transmute_copy(&fbypassproxycache), ::core::mem::transmute_copy(&fsecure), ::core::mem::transmute(&szverb), ::core::mem::transmute(&szreferrer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6782,7 +6782,7 @@ impl IMFHttpDownloadSessionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateHttpDownloadSession(::core::mem::transmute(&wszscheme)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdownloadsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdownloadsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6815,7 +6815,7 @@ impl IMFImageSharingEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6851,7 +6851,7 @@ impl IMFImageSharingEngineClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstanceFromUDN(::core::mem::transmute(&puniquedevicename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppengine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppengine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6884,7 +6884,7 @@ impl IMFInputTrustAuthority_Vtbl {
             let this = (*this).get_impl();
             match this.RequestAccess(::core::mem::transmute_copy(&action)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontentenableractivate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontentenableractivate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6895,7 +6895,7 @@ impl IMFInputTrustAuthority_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicy(::core::mem::transmute_copy(&action)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6972,7 +6972,7 @@ impl IMFMediaBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbcurrentlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbcurrentlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6988,7 +6988,7 @@ impl IMFMediaBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbmaxlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbmaxlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7062,7 +7062,7 @@ impl IMFMediaEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7088,7 +7088,7 @@ impl IMFMediaEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7114,7 +7114,7 @@ impl IMFMediaEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetBuffered() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffered = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffered, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7130,7 +7130,7 @@ impl IMFMediaEngine_Vtbl {
             let this = (*this).get_impl();
             match this.CanPlayType(::core::mem::transmute(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *panswer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(panswer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7196,7 +7196,7 @@ impl IMFMediaEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlayed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplayed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplayed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7207,7 +7207,7 @@ impl IMFMediaEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetSeekable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppseekable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppseekable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7303,7 +7303,7 @@ impl IMFMediaEngine_Vtbl {
             let this = (*this).get_impl();
             match this.OnVideoStreamTick() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7376,7 +7376,7 @@ impl IMFMediaEngineAudioEndpointId_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioEndpointId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszendpointid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszendpointid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7405,7 +7405,7 @@ impl IMFMediaEngineClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pattr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplayer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplayer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7416,7 +7416,7 @@ impl IMFMediaEngineClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTimeRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptimerange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptimerange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7427,7 +7427,7 @@ impl IMFMediaEngineClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7458,7 +7458,7 @@ impl IMFMediaEngineClassFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaKeys2(::core::mem::transmute(&keysystem), ::core::mem::transmute(&defaultcdmstorepath), ::core::mem::transmute(&inprivatecdmstorepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7484,7 +7484,7 @@ impl IMFMediaEngineClassFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaKeySystemAccess(::core::mem::transmute(&keysystem), ::core::mem::transmute_copy(&ppsupportedconfigurationsarray), ::core::mem::transmute_copy(&usize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeyaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeyaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7535,7 +7535,7 @@ impl IMFMediaEngineClassFactoryEx_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaSourceExtension(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pattr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7546,7 +7546,7 @@ impl IMFMediaEngineClassFactoryEx_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaKeys(::core::mem::transmute(&keysystem), ::core::mem::transmute(&cdmstorepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7557,7 +7557,7 @@ impl IMFMediaEngineClassFactoryEx_Vtbl {
             let this = (*this).get_impl();
             match this.IsTypeSupported(::core::mem::transmute(&r#type), ::core::mem::transmute(&keysystem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *issupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7586,7 +7586,7 @@ impl IMFMediaEngineEME_Vtbl {
             let this = (*this).get_impl();
             match this.Keys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7692,7 +7692,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatistics(::core::mem::transmute_copy(&statisticid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatistic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatistic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7728,7 +7728,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceCharacteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcharacteristics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcharacteristics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7739,7 +7739,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresentationAttribute(::core::mem::transmute_copy(&guidmfattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7750,7 +7750,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7761,7 +7761,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamAttribute(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute_copy(&guidmfattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7772,7 +7772,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSelection(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7793,7 +7793,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.IsProtected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7824,7 +7824,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimelineMarkerTimer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimetofire = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimetofire, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7845,7 +7845,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetStereo3DFramePackingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7861,7 +7861,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetStereo3DRenderMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *outputtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(outputtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7882,7 +7882,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoSwapchainHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phswapchain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phswapchain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7898,7 +7898,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioStreamCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcategory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcategory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7914,7 +7914,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioEndpointRole() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7930,7 +7930,7 @@ impl IMFMediaEngineEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetRealTimeMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8013,7 +8013,7 @@ impl IMFMediaEngineExtension_Vtbl {
             let this = (*this).get_impl();
             match this.CanPlayType(::core::mem::transmute_copy(&audioonly), ::core::mem::transmute(&mimetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *panswer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(panswer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8034,7 +8034,7 @@ impl IMFMediaEngineExtension_Vtbl {
             let this = (*this).get_impl();
             match this.EndCreateObject(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8130,7 +8130,7 @@ impl IMFMediaEngineProtectedContent_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequiredProtections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pframeprotectionflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pframeprotectionflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8146,7 +8146,7 @@ impl IMFMediaEngineProtectedContent_Vtbl {
             let this = (*this).get_impl();
             match this.TransferVideoFrame(::core::mem::transmute(&pdstsurf), ::core::mem::transmute_copy(&psrc), ::core::mem::transmute_copy(&pdst), ::core::mem::transmute_copy(&pborderclr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pframeprotectionflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pframeprotectionflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8200,7 +8200,7 @@ impl IMFMediaEngineSrcElements_Vtbl {
             let this = (*this).get_impl();
             match this.GetURL(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *purl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(purl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8211,7 +8211,7 @@ impl IMFMediaEngineSrcElements_Vtbl {
             let this = (*this).get_impl();
             match this.GetType(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8222,7 +8222,7 @@ impl IMFMediaEngineSrcElements_Vtbl {
             let this = (*this).get_impl();
             match this.GetMedia(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmedia = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmedia, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8272,7 +8272,7 @@ impl IMFMediaEngineSrcElementsEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeySystem(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8304,7 +8304,7 @@ impl IMFMediaEngineSupportsSourceTransfer_Vtbl {
             let this = (*this).get_impl();
             match this.ShouldTransferSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfshouldtransfer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfshouldtransfer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8372,7 +8372,7 @@ impl IMFMediaEngineWebSupport_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectWebAudio(::core::mem::transmute_copy(&dwsamplerate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsourceprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsourceprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8452,7 +8452,7 @@ impl IMFMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8463,7 +8463,7 @@ impl IMFMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtendedType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidextendedtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidextendedtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8474,7 +8474,7 @@ impl IMFMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8485,7 +8485,7 @@ impl IMFMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8520,7 +8520,7 @@ impl IMFMediaEventGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetEvent(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8536,7 +8536,7 @@ impl IMFMediaEventGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.EndGetEvent(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8579,7 +8579,7 @@ impl IMFMediaEventQueue_Vtbl {
             let this = (*this).get_impl();
             match this.GetEvent(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8595,7 +8595,7 @@ impl IMFMediaEventQueue_Vtbl {
             let this = (*this).get_impl();
             match this.EndGetEvent(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8659,7 +8659,7 @@ impl IMFMediaKeySession_Vtbl {
             let this = (*this).get_impl();
             match this.KeySystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keysystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keysystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8670,7 +8670,7 @@ impl IMFMediaKeySession_Vtbl {
             let this = (*this).get_impl();
             match this.SessionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sessionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sessionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8723,7 +8723,7 @@ impl IMFMediaKeySession2_Vtbl {
             let this = (*this).get_impl();
             match this.Load(::core::mem::transmute(&bstrsessionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfloaded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfloaded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8739,7 +8739,7 @@ impl IMFMediaKeySession2_Vtbl {
             let this = (*this).get_impl();
             match this.Expiration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dblexpiration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dblexpiration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8852,7 +8852,7 @@ impl IMFMediaKeySystemAccess_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaKeys(::core::mem::transmute(&pcdmcustomconfig)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8863,7 +8863,7 @@ impl IMFMediaKeySystemAccess_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedConfiguration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsupportedconfiguration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsupportedconfiguration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8874,7 +8874,7 @@ impl IMFMediaKeySystemAccess_Vtbl {
             let this = (*this).get_impl();
             match this.KeySystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkeysystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkeysystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8908,7 +8908,7 @@ impl IMFMediaKeys_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession(::core::mem::transmute(&mimetype), ::core::mem::transmute_copy(&initdata), ::core::mem::transmute_copy(&cb), ::core::mem::transmute_copy(&customdata), ::core::mem::transmute_copy(&cbcustomdata), ::core::mem::transmute(&notify)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8919,7 +8919,7 @@ impl IMFMediaKeys_Vtbl {
             let this = (*this).get_impl();
             match this.KeySystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keysystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keysystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8935,7 +8935,7 @@ impl IMFMediaKeys_Vtbl {
             let this = (*this).get_impl();
             match this.GetSuspendNotify() {
                 ::core::result::Result::Ok(ok__) => {
-                    *notify = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(notify, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8969,7 +8969,7 @@ impl IMFMediaKeys2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession2(::core::mem::transmute_copy(&esessiontype), ::core::mem::transmute(&pmfmediakeysessionnotify2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8985,7 +8985,7 @@ impl IMFMediaKeys2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDOMException(::core::mem::transmute_copy(&systemcode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9060,7 +9060,7 @@ impl IMFMediaSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9071,7 +9071,7 @@ impl IMFMediaSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetSessionCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9082,7 +9082,7 @@ impl IMFMediaSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullTopology(::core::mem::transmute_copy(&dwgetfulltopologyflags), ::core::mem::transmute_copy(&topoid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfulltopology = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfulltopology, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9120,7 +9120,7 @@ impl IMFMediaSharingEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9143,7 +9143,7 @@ impl IMFMediaSharingEngineClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pattr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppengine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppengine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9174,7 +9174,7 @@ impl IMFMediaSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharacteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcharacteristics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcharacteristics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9185,7 +9185,7 @@ impl IMFMediaSink_Vtbl {
             let this = (*this).get_impl();
             match this.AddStreamSink(::core::mem::transmute_copy(&dwstreamsinkidentifier), ::core::mem::transmute(&pmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreamsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreamsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9201,7 +9201,7 @@ impl IMFMediaSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSinkCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstreamsinkcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstreamsinkcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9212,7 +9212,7 @@ impl IMFMediaSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSinkByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreamsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreamsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9223,7 +9223,7 @@ impl IMFMediaSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSinkById(::core::mem::transmute_copy(&dwstreamsinkidentifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreamsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreamsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9239,7 +9239,7 @@ impl IMFMediaSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresentationClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppresentationclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppresentationclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9303,7 +9303,7 @@ impl IMFMediaSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharacteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcharacteristics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcharacteristics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9314,7 +9314,7 @@ impl IMFMediaSource_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePresentationDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppresentationdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppresentationdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9390,7 +9390,7 @@ impl IMFMediaSourceEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9401,7 +9401,7 @@ impl IMFMediaSourceEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamAttributes(::core::mem::transmute_copy(&dwstreamidentifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9471,7 +9471,7 @@ impl IMFMediaSourceExtension_Vtbl {
             let this = (*this).get_impl();
             match this.AddSourceBuffer(::core::mem::transmute(&r#type), ::core::mem::transmute(&pnotify)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsourcebuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsourcebuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9604,7 +9604,7 @@ impl IMFMediaSourceTopologyProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaSourceTopology(::core::mem::transmute(&ppresentationdescriptor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptopology = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptopology, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9632,7 +9632,7 @@ impl IMFMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediasource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediasource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9643,7 +9643,7 @@ impl IMFMediaStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreamdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreamdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9685,7 +9685,7 @@ impl IMFMediaStream2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9742,7 +9742,7 @@ impl IMFMediaTimeRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetStart(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9753,7 +9753,7 @@ impl IMFMediaTimeRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnd(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9806,7 +9806,7 @@ impl IMFMediaType_Vtbl {
             let this = (*this).get_impl();
             match this.GetMajorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidmajortype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidmajortype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9817,7 +9817,7 @@ impl IMFMediaType_Vtbl {
             let this = (*this).get_impl();
             match this.IsCompressedFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcompressed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcompressed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9828,7 +9828,7 @@ impl IMFMediaType_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&pimediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9873,7 +9873,7 @@ impl IMFMediaTypeHandler_Vtbl {
             let this = (*this).get_impl();
             match this.IsMediaTypeSupported(::core::mem::transmute(&pmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9884,7 +9884,7 @@ impl IMFMediaTypeHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaTypeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtypecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtypecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9895,7 +9895,7 @@ impl IMFMediaTypeHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaTypeByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9911,7 +9911,7 @@ impl IMFMediaTypeHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9922,7 +9922,7 @@ impl IMFMediaTypeHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetMajorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidmajortype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidmajortype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9967,7 +9967,7 @@ impl IMFMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszrfc1766 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszrfc1766, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9978,7 +9978,7 @@ impl IMFMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllLanguages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvlanguages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvlanguages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9994,7 +9994,7 @@ impl IMFMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&pwszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10010,7 +10010,7 @@ impl IMFMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllPropertyNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvnames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvnames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10042,7 +10042,7 @@ impl IMFMetadataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetMFMetadata(::core::mem::transmute(&ppresentationdescriptor), ::core::mem::transmute_copy(&dwstreamidentifier), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmfmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmfmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10066,7 +10066,7 @@ impl IMFMuxStreamAttributesManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmuxstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmuxstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10077,7 +10077,7 @@ impl IMFMuxStreamAttributesManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributes(::core::mem::transmute_copy(&dwmuxstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreamattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreamattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10109,7 +10109,7 @@ impl IMFMuxStreamMediaTypeManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmuxstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmuxstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10120,7 +10120,7 @@ impl IMFMuxStreamMediaTypeManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaType(::core::mem::transmute_copy(&dwmuxstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10131,7 +10131,7 @@ impl IMFMuxStreamMediaTypeManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamConfigurationCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10152,7 +10152,7 @@ impl IMFMuxStreamMediaTypeManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamConfiguration(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullstreammask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullstreammask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10185,7 +10185,7 @@ impl IMFMuxStreamSampleManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmuxstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmuxstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10196,7 +10196,7 @@ impl IMFMuxStreamSampleManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSample(::core::mem::transmute_copy(&dwmuxstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10256,7 +10256,7 @@ impl IMFNetCredential_Vtbl {
             let this = (*this).get_impl();
             match this.LoggedOnUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfloggedonuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfloggedonuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10333,7 +10333,7 @@ impl IMFNetCredentialManager_Vtbl {
             let this = (*this).get_impl();
             match this.EndGetCredentials(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcred = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcred, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10371,7 +10371,7 @@ impl IMFNetCrossOriginSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetCrossOriginPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10382,7 +10382,7 @@ impl IMFNetCrossOriginSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceOrigin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wszsourceorigin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wszsourceorigin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10393,7 +10393,7 @@ impl IMFNetCrossOriginSupport_Vtbl {
             let this = (*this).get_impl();
             match this.IsSameOrigin(::core::mem::transmute(&wszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfissameorigin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfissameorigin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10448,7 +10448,7 @@ impl IMFNetProxyLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproxylocator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproxylocator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10478,7 +10478,7 @@ impl IMFNetProxyLocatorFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProxyLocator(::core::mem::transmute(&pszprotocol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproxylocator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproxylocator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10502,7 +10502,7 @@ impl IMFNetResourceFilter_Vtbl {
             let this = (*this).get_impl();
             match this.OnRedirect(::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbcancel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbcancel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10536,7 +10536,7 @@ impl IMFNetSchemeHandlerConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfSupportedProtocols() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcprotocols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcprotocols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10547,7 +10547,7 @@ impl IMFNetSchemeHandlerConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedProtocolType(::core::mem::transmute_copy(&nprotocolindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnprotocoltype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnprotocoltype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10612,7 +10612,7 @@ impl IMFOutputPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateRequiredSchemas(::core::mem::transmute_copy(&dwattributes), ::core::mem::transmute(&guidoutputsubtype), ::core::mem::transmute_copy(&rgguidprotectionschemassupported), ::core::mem::transmute_copy(&cprotectionschemassupported)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprequiredprotectionschemas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprequiredprotectionschemas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10623,7 +10623,7 @@ impl IMFOutputPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginatorID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidoriginatorid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidoriginatorid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10634,7 +10634,7 @@ impl IMFOutputPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinimumGRLVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwminimumgrlversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwminimumgrlversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10667,7 +10667,7 @@ impl IMFOutputSchema_Vtbl {
             let this = (*this).get_impl();
             match this.GetSchemaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidschematype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidschematype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10678,7 +10678,7 @@ impl IMFOutputSchema_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfigurationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10689,7 +10689,7 @@ impl IMFOutputSchema_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginatorID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidoriginatorid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidoriginatorid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10718,7 +10718,7 @@ impl IMFOutputTrustAuthority_Vtbl {
             let this = (*this).get_impl();
             match this.GetAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10913,7 +10913,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaPlayer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaplayer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaplayer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10924,7 +10924,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10935,7 +10935,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10946,7 +10946,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwuserdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwuserdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10982,7 +10982,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsProtected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprotected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprotected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10993,7 +10993,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration(::core::mem::transmute_copy(&guidpositiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvdurationvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvdurationvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11004,7 +11004,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11015,7 +11015,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSelection(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11031,7 +11031,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamAttribute(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute_copy(&guidmfattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11042,7 +11042,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresentationAttribute(::core::mem::transmute_copy(&guidmfattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11053,7 +11053,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharacteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcharacteristics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcharacteristics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11069,7 +11069,7 @@ impl IMFPMediaItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadatastore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadatastore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11176,7 +11176,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPosition(::core::mem::transmute_copy(&guidpositiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvpositionvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvpositionvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11187,7 +11187,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration(::core::mem::transmute_copy(&guidpositiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvdurationvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvdurationvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11203,7 +11203,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11219,7 +11219,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pestate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pestate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11230,7 +11230,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaItemFromURL(::core::mem::transmute(&pwszurl), ::core::mem::transmute_copy(&fsync), ::core::mem::transmute_copy(&dwuserdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11241,7 +11241,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaItemFromObject(::core::mem::transmute(&piunknownobj), ::core::mem::transmute_copy(&fsync), ::core::mem::transmute_copy(&dwuserdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11262,7 +11262,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimfpmediaitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimfpmediaitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11273,7 +11273,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11289,7 +11289,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetBalance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflbalance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflbalance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11305,7 +11305,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11336,7 +11336,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoSourceRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnrcsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnrcsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11352,7 +11352,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAspectRatioMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwaspectratiomode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwaspectratiomode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11363,7 +11363,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndvideo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndvideo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11384,7 +11384,7 @@ impl IMFPMediaPlayer_Vtbl {
             let this = (*this).get_impl();
             match this.GetBorderColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11493,7 +11493,7 @@ impl IMFPluginControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredClsid(::core::mem::transmute_copy(&plugintype), ::core::mem::transmute(&selector)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *clsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11519,7 +11519,7 @@ impl IMFPluginControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisabledByIndex(::core::mem::transmute_copy(&plugintype), ::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *clsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11587,7 +11587,7 @@ impl IMFPresentationClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptimesource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptimesource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11598,7 +11598,7 @@ impl IMFPresentationClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phnsclocktime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phnsclocktime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11663,7 +11663,7 @@ impl IMFPresentationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamDescriptorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwdescriptorcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwdescriptorcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11689,7 +11689,7 @@ impl IMFPresentationDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppresentationdescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppresentationdescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11719,7 +11719,7 @@ impl IMFPresentationTimeSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnderlyingClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11743,7 +11743,7 @@ impl IMFProtectedEnvironmentAccess_Vtbl {
             let this = (*this).get_impl();
             match this.Call(::core::mem::transmute_copy(&inputlength), ::core::mem::transmute_copy(&input), ::core::mem::transmute_copy(&outputlength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *output = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(output, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11789,7 +11789,7 @@ impl IMFQualityAdvise_Vtbl {
             let this = (*this).get_impl();
             match this.GetDropMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pedropmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pedropmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11800,7 +11800,7 @@ impl IMFQualityAdvise_Vtbl {
             let this = (*this).get_impl();
             match this.GetQualityLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pequalitylevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pequalitylevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11835,7 +11835,7 @@ impl IMFQualityAdvise2_Vtbl {
             let this = (*this).get_impl();
             match this.NotifyQualityEvent(::core::mem::transmute(&pevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11859,7 +11859,7 @@ impl IMFQualityAdviseLimits_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumDropMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pedropmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pedropmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11870,7 +11870,7 @@ impl IMFQualityAdviseLimits_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinimumQualityLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pequalitylevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pequalitylevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11987,7 +11987,7 @@ impl IMFRateSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetSlowestRate(::core::mem::transmute_copy(&edirection), ::core::mem::transmute_copy(&fthin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11998,7 +11998,7 @@ impl IMFRateSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetFastestRate(::core::mem::transmute_copy(&edirection), ::core::mem::transmute_copy(&fthin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12126,7 +12126,7 @@ impl IMFRelativePanelReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelativePanel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *panel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(panel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12156,7 +12156,7 @@ impl IMFRelativePanelWatcher_Vtbl {
             let this = (*this).get_impl();
             match this.EndGetReport(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprelativepanelreport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprelativepanelreport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12167,7 +12167,7 @@ impl IMFRelativePanelWatcher_Vtbl {
             let this = (*this).get_impl();
             match this.GetReport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprelativepanelreport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprelativepanelreport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12262,7 +12262,7 @@ impl IMFSAMIStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetStyleCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12273,7 +12273,7 @@ impl IMFSAMIStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetStyles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvarstylearray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvarstylearray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12289,7 +12289,7 @@ impl IMFSAMIStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12345,7 +12345,7 @@ impl IMFSSLCertificateManager_Vtbl {
             let this = (*this).get_impl();
             match this.OnServerCertificate(::core::mem::transmute(&pszurl), ::core::mem::transmute_copy(&pbdata), ::core::mem::transmute_copy(&cbdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisgood = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisgood, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12391,7 +12391,7 @@ impl IMFSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetSampleFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsampleflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsampleflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12407,7 +12407,7 @@ impl IMFSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetSampleTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phnssampletime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phnssampletime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12423,7 +12423,7 @@ impl IMFSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetSampleDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phnssampleduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phnssampleduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12439,7 +12439,7 @@ impl IMFSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetBufferCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwbuffercount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwbuffercount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12450,7 +12450,7 @@ impl IMFSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetBufferByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12461,7 +12461,7 @@ impl IMFSample_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertToContiguousBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12487,7 +12487,7 @@ impl IMFSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbtotallength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbtotallength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12647,7 +12647,7 @@ impl IMFSampleProtection_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputProtectionVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12658,7 +12658,7 @@ impl IMFSampleProtection_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputProtectionVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12721,7 +12721,7 @@ impl IMFSaveJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwpercentcomplete = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwpercentcomplete, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12787,7 +12787,7 @@ impl IMFSecureBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguididentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguididentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12859,7 +12859,7 @@ impl IMFSensorActivitiesReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12870,7 +12870,7 @@ impl IMFSensorActivitiesReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivityReport(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sensoractivityreport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sensoractivityreport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12881,7 +12881,7 @@ impl IMFSensorActivitiesReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivityReportByDeviceName(::core::mem::transmute(&symbolicname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sensoractivityreport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sensoractivityreport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12962,7 +12962,7 @@ impl IMFSensorActivityReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12973,7 +12973,7 @@ impl IMFSensorActivityReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessActivity(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprocessactivity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprocessactivity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13010,7 +13010,7 @@ impl IMFSensorDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13021,7 +13021,7 @@ impl IMFSensorDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13032,7 +13032,7 @@ impl IMFSensorDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13048,7 +13048,7 @@ impl IMFSensorDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13059,7 +13059,7 @@ impl IMFSensorDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamAttributesCount(::core::mem::transmute_copy(&etype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13070,7 +13070,7 @@ impl IMFSensorDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamAttributes(::core::mem::transmute_copy(&etype), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13086,7 +13086,7 @@ impl IMFSensorDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorDeviceMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13132,7 +13132,7 @@ impl IMFSensorGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13143,7 +13143,7 @@ impl IMFSensorGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorGroupAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13154,7 +13154,7 @@ impl IMFSensorGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorDeviceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13165,7 +13165,7 @@ impl IMFSensorGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetSensorDevice(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13181,7 +13181,7 @@ impl IMFSensorGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultSensorDeviceIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13192,7 +13192,7 @@ impl IMFSensorGroup_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMediaSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13231,7 +13231,7 @@ impl IMFSensorProcessActivity_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13242,7 +13242,7 @@ impl IMFSensorProcessActivity_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamingState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfstreaming = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfstreaming, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13253,7 +13253,7 @@ impl IMFSensorProcessActivity_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13264,7 +13264,7 @@ impl IMFSensorProcessActivity_Vtbl {
             let this = (*this).get_impl();
             match this.GetReportTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pft = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pft, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13299,7 +13299,7 @@ impl IMFSensorProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfileId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13315,7 +13315,7 @@ impl IMFSensorProfile_Vtbl {
             let this = (*this).get_impl();
             match this.IsMediaTypeSupported(::core::mem::transmute_copy(&streamid), ::core::mem::transmute(&pmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13359,7 +13359,7 @@ impl IMFSensorProfileCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfile(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13375,7 +13375,7 @@ impl IMFSensorProfileCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindProfile(::core::mem::transmute_copy(&profileid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13421,7 +13421,7 @@ impl IMFSensorStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaTypeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13432,7 +13432,7 @@ impl IMFSensorStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaType(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13443,7 +13443,7 @@ impl IMFSensorStream_Vtbl {
             let this = (*this).get_impl();
             match this.CloneSensorStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13478,7 +13478,7 @@ impl IMFSensorTransformFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetFactoryAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13494,7 +13494,7 @@ impl IMFSensorTransformFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13510,7 +13510,7 @@ impl IMFSensorTransformFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransform(::core::mem::transmute_copy(&guidsensortransformid), ::core::mem::transmute(&pattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevicemft = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevicemft, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13544,7 +13544,7 @@ impl IMFSequencerSource_Vtbl {
             let this = (*this).get_impl();
             match this.AppendTopology(::core::mem::transmute(&ptopology), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13594,7 +13594,7 @@ impl IMFSharingEngineClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pattr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppengine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppengine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13623,7 +13623,7 @@ impl IMFShutdown_Vtbl {
             let this = (*this).get_impl();
             match this.GetShutdownStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13678,7 +13678,7 @@ impl IMFSimpleAudioVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetMasterVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13694,7 +13694,7 @@ impl IMFSimpleAudioVolume_Vtbl {
             let this = (*this).get_impl();
             match this.GetMute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13733,7 +13733,7 @@ impl IMFSinkWriter_Vtbl {
             let this = (*this).get_impl();
             match this.AddStream(::core::mem::transmute(&ptargetmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstreamindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstreamindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13789,7 +13789,7 @@ impl IMFSinkWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatistics(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13942,7 +13942,7 @@ impl IMFSourceBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetBuffered() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffered = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffered, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14160,7 +14160,7 @@ impl IMFSourceReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSelection(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfselected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfselected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14176,7 +14176,7 @@ impl IMFSourceReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetNativeMediaType(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute_copy(&dwmediatypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14187,7 +14187,7 @@ impl IMFSourceReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentMediaType(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14223,7 +14223,7 @@ impl IMFSourceReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresentationAttribute(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute_copy(&guidattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarattribute = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarattribute, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14325,7 +14325,7 @@ impl IMFSourceReaderEx_Vtbl {
             let this = (*this).get_impl();
             match this.SetNativeMediaType(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute(&pmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstreamflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstreamflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14446,7 +14446,7 @@ impl IMFSpatialAudioObjectBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pu32id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pu32id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14462,7 +14462,7 @@ impl IMFSpatialAudioObjectBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14473,7 +14473,7 @@ impl IMFSpatialAudioObjectBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadataitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadataitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14508,7 +14508,7 @@ impl IMFSpatialAudioSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwobjectcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwobjectcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14524,7 +14524,7 @@ impl IMFSpatialAudioSample_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpatialAudioObjectByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaudioobjbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaudioobjbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14556,7 +14556,7 @@ impl IMFStreamDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstreamidentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstreamidentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14567,7 +14567,7 @@ impl IMFStreamDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaTypeHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatypehandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatypehandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14602,7 +14602,7 @@ impl IMFStreamSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaSink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediasink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediasink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14613,7 +14613,7 @@ impl IMFStreamSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwidentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwidentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14624,7 +14624,7 @@ impl IMFStreamSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaTypeHandler() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14728,7 +14728,7 @@ impl IMFTimecodeTranslate_Vtbl {
             let this = (*this).get_impl();
             match this.EndConvertTimecodeToHNS(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phnstime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phnstime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14744,7 +14744,7 @@ impl IMFTimecodeTranslate_Vtbl {
             let this = (*this).get_impl();
             match this.EndConvertHNSToTimecode(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvartimecode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvartimecode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14799,7 +14799,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.AddDataSource(::core::mem::transmute(&bytestream), ::core::mem::transmute(&label), ::core::mem::transmute(&language), ::core::mem::transmute_copy(&kind), ::core::mem::transmute_copy(&isdefault)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *trackid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(trackid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14810,7 +14810,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.AddDataSourceFromUrl(::core::mem::transmute(&url), ::core::mem::transmute(&label), ::core::mem::transmute(&language), ::core::mem::transmute_copy(&kind), ::core::mem::transmute_copy(&isdefault)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *trackid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(trackid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14821,7 +14821,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.AddTrack(::core::mem::transmute(&label), ::core::mem::transmute(&language), ::core::mem::transmute_copy(&kind)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *track = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(track, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14837,7 +14837,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.GetCueTimeOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14853,7 +14853,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.GetTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tracks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tracks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14864,7 +14864,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *activetracks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(activetracks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14875,7 +14875,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *texttracks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(texttracks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14886,7 +14886,7 @@ impl IMFTimedText_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *metadatatracks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metadatatracks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14954,7 +14954,7 @@ impl IMFTimedTextBouten_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoutenType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14965,7 +14965,7 @@ impl IMFTimedTextBouten_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoutenColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14976,7 +14976,7 @@ impl IMFTimedTextBouten_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoutenPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15019,7 +15019,7 @@ impl IMFTimedTextCue_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *originalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(originalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15050,7 +15050,7 @@ impl IMFTimedTextCue_Vtbl {
             let this = (*this).get_impl();
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *data = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(data, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15061,7 +15061,7 @@ impl IMFTimedTextCue_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *region = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(region, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15072,7 +15072,7 @@ impl IMFTimedTextCue_Vtbl {
             let this = (*this).get_impl();
             match this.GetStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *style = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(style, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15088,7 +15088,7 @@ impl IMFTimedTextCue_Vtbl {
             let this = (*this).get_impl();
             match this.GetLine(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *line = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(line, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15135,7 +15135,7 @@ impl IMFTimedTextCueList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCueByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15146,7 +15146,7 @@ impl IMFTimedTextCueList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCueById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15157,7 +15157,7 @@ impl IMFTimedTextCueList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCueByOriginalId(::core::mem::transmute(&originalid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15168,7 +15168,7 @@ impl IMFTimedTextCueList_Vtbl {
             let this = (*this).get_impl();
             match this.AddTextCue(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&duration), ::core::mem::transmute(&text)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15179,7 +15179,7 @@ impl IMFTimedTextCueList_Vtbl {
             let this = (*this).get_impl();
             match this.AddDataCue(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&datasize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15218,7 +15218,7 @@ impl IMFTimedTextFormattedText_Vtbl {
             let this = (*this).get_impl();
             match this.GetText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15335,7 +15335,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15356,7 +15356,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bgcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bgcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15367,7 +15367,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetWritingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *writingmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(writingmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15378,7 +15378,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayalign = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayalign, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15394,7 +15394,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipOverflow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clipoverflow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clipoverflow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15410,7 +15410,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetWrap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wrap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wrap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15421,7 +15421,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetZIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *zindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(zindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15432,7 +15432,7 @@ impl IMFTimedTextRegion_Vtbl {
             let this = (*this).get_impl();
             match this.GetScrollMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scrollmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scrollmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15472,7 +15472,7 @@ impl IMFTimedTextRuby_Vtbl {
             let this = (*this).get_impl();
             match this.GetRubyText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rubytext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rubytext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15483,7 +15483,7 @@ impl IMFTimedTextRuby_Vtbl {
             let this = (*this).get_impl();
             match this.GetRubyPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15494,7 +15494,7 @@ impl IMFTimedTextRuby_Vtbl {
             let this = (*this).get_impl();
             match this.GetRubyAlign() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15505,7 +15505,7 @@ impl IMFTimedTextRuby_Vtbl {
             let this = (*this).get_impl();
             match this.GetRubyReserve() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15549,7 +15549,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15565,7 +15565,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFamily() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfamily = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfamily, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15581,7 +15581,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *color = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(color, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15592,7 +15592,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bgcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bgcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15603,7 +15603,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetShowBackgroundAlways() {
                 ::core::result::Result::Ok(ok__) => {
-                    *showbackgroundalways = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(showbackgroundalways, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15614,7 +15614,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15625,7 +15625,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetBold() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bold = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bold, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15636,7 +15636,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetRightToLeft() {
                 ::core::result::Result::Ok(ok__) => {
-                    *righttoleft = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(righttoleft, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15647,7 +15647,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *textalign = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textalign, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15658,7 +15658,7 @@ impl IMFTimedTextStyle_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextDecoration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *textdecoration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(textdecoration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15707,7 +15707,7 @@ impl IMFTimedTextStyle2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRuby() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ruby = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ruby, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15718,7 +15718,7 @@ impl IMFTimedTextStyle2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBouten() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bouten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bouten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15729,7 +15729,7 @@ impl IMFTimedTextStyle2_Vtbl {
             let this = (*this).get_impl();
             match this.IsTextCombined() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15740,7 +15740,7 @@ impl IMFTimedTextStyle2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontAngleInDegrees() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15789,7 +15789,7 @@ impl IMFTimedTextTrack_Vtbl {
             let this = (*this).get_impl();
             match this.GetLabel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *label = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(label, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15805,7 +15805,7 @@ impl IMFTimedTextTrack_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *language = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(language, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15826,7 +15826,7 @@ impl IMFTimedTextTrack_Vtbl {
             let this = (*this).get_impl();
             match this.GetInBandMetadataTrackDispatchType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dispatchtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dispatchtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15852,7 +15852,7 @@ impl IMFTimedTextTrack_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15868,7 +15868,7 @@ impl IMFTimedTextTrack_Vtbl {
             let this = (*this).get_impl();
             match this.GetCueList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15913,7 +15913,7 @@ impl IMFTimedTextTrackList_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrack(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *track = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(track, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15924,7 +15924,7 @@ impl IMFTimedTextTrackList_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrackById(::core::mem::transmute_copy(&trackid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *track = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(track, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15953,7 +15953,7 @@ impl IMFTimer_Vtbl {
             let this = (*this).get_impl();
             match this.SetTimer(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&llclocktime), ::core::mem::transmute(&pcallback), ::core::mem::transmute(&punkstate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16014,7 +16014,7 @@ impl IMFTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetTopologyID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16035,7 +16035,7 @@ impl IMFTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetNodeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwnodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwnodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16046,7 +16046,7 @@ impl IMFTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetNode(::core::mem::transmute_copy(&windex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16067,7 +16067,7 @@ impl IMFTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetNodeByID(::core::mem::transmute_copy(&qwtoponodeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16078,7 +16078,7 @@ impl IMFTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceNodeCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16089,7 +16089,7 @@ impl IMFTopology_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputNodeCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16147,7 +16147,7 @@ impl IMFTopologyNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16158,7 +16158,7 @@ impl IMFTopologyNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetNodeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16169,7 +16169,7 @@ impl IMFTopologyNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetTopoNodeID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16185,7 +16185,7 @@ impl IMFTopologyNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcinputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcinputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16196,7 +16196,7 @@ impl IMFTopologyNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcoutputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcoutputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16232,7 +16232,7 @@ impl IMFTopologyNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputPrefType(::core::mem::transmute_copy(&dwoutputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16248,7 +16248,7 @@ impl IMFTopologyNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputPrefType(::core::mem::transmute_copy(&dwinputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16382,7 +16382,7 @@ impl IMFTranscodeProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16398,7 +16398,7 @@ impl IMFTranscodeProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16414,7 +16414,7 @@ impl IMFTranscodeProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16463,7 +16463,7 @@ impl IMFTranscodeSinkInfoProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSinkInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psinkinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psinkinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16529,7 +16529,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStreamInfo(::core::mem::transmute_copy(&dwinputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstreaminfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstreaminfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16540,7 +16540,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamInfo(::core::mem::transmute_copy(&dwoutputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstreaminfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstreaminfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16551,7 +16551,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16562,7 +16562,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStreamAttributes(::core::mem::transmute_copy(&dwinputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16573,7 +16573,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamAttributes(::core::mem::transmute_copy(&dwoutputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16594,7 +16594,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputAvailableType(::core::mem::transmute_copy(&dwinputstreamid), ::core::mem::transmute_copy(&dwtypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16605,7 +16605,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputAvailableType(::core::mem::transmute_copy(&dwoutputstreamid), ::core::mem::transmute_copy(&dwtypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16626,7 +16626,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCurrentType(::core::mem::transmute_copy(&dwinputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16637,7 +16637,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCurrentType(::core::mem::transmute_copy(&dwoutputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16648,7 +16648,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStatus(::core::mem::transmute_copy(&dwinputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16659,7 +16659,7 @@ impl IMFTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16732,7 +16732,7 @@ impl IMFTrustedInput_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputTrustAuthority(::core::mem::transmute_copy(&dwstreamid), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16760,7 +16760,7 @@ impl IMFTrustedOutput_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputTrustAuthorityCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcoutputtrustauthorities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcoutputtrustauthorities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16771,7 +16771,7 @@ impl IMFTrustedOutput_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputTrustAuthorityByIndex(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppauthority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppauthority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16782,7 +16782,7 @@ impl IMFTrustedOutput_Vtbl {
             let this = (*this).get_impl();
             match this.IsFinal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisfinal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisfinal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16830,7 +16830,7 @@ impl IMFVideoDeviceID_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16896,7 +16896,7 @@ impl IMFVideoDisplayControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetAspectRatioMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwaspectratiomode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwaspectratiomode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16912,7 +16912,7 @@ impl IMFVideoDisplayControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndvideo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndvideo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16938,7 +16938,7 @@ impl IMFVideoDisplayControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetBorderColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16954,7 +16954,7 @@ impl IMFVideoDisplayControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderingPrefs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrenderflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrenderflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16970,7 +16970,7 @@ impl IMFVideoDisplayControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullscreen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pffullscreen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pffullscreen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17062,7 +17062,7 @@ impl IMFVideoMixerBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlphaBitmapParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmpparms = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmpparms, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17099,7 +17099,7 @@ impl IMFVideoMixerControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamZOrder(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17115,7 +17115,7 @@ impl IMFVideoMixerControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamOutputRect(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnrcoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnrcoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17150,7 +17150,7 @@ impl IMFVideoMixerControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMixingPrefs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmixflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmixflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17203,7 +17203,7 @@ impl IMFVideoPresenter_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17249,7 +17249,7 @@ impl IMFVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorCaps(::core::mem::transmute_copy(&lpvideoprocessormode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpvideoprocessorcaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpvideoprocessorcaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17260,7 +17260,7 @@ impl IMFVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoProcessorMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17276,7 +17276,7 @@ impl IMFVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcAmpRange(::core::mem::transmute_copy(&dwproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17287,7 +17287,7 @@ impl IMFVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcAmpValues(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *values = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(values, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17303,7 +17303,7 @@ impl IMFVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteringRange(::core::mem::transmute_copy(&dwproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17314,7 +17314,7 @@ impl IMFVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteringValue(::core::mem::transmute_copy(&dwproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17330,7 +17330,7 @@ impl IMFVideoProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpclrbkg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpclrbkg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17445,7 +17445,7 @@ impl IMFVideoProcessorControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedHardwareEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puisupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puisupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17479,7 +17479,7 @@ impl IMFVideoProcessorControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNaturalOutputType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17578,7 +17578,7 @@ impl IMFVideoSampleAllocator_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateSample() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17613,7 +17613,7 @@ impl IMFVideoSampleAllocatorCallback_Vtbl {
             let this = (*this).get_impl();
             match this.GetFreeSampleCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsamples = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsamples, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17737,7 +17737,7 @@ impl IMFVirtualCamera_Vtbl {
             let this = (*this).get_impl();
             match this.GetMediaSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediasource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediasource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17753,7 +17753,7 @@ impl IMFVirtualCamera_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSyncEvent(::core::mem::transmute_copy(&kseventset), ::core::mem::transmute_copy(&kseventid), ::core::mem::transmute_copy(&kseventflags), ::core::mem::transmute_copy(&eventhandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *camerasyncobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(camerasyncobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17764,7 +17764,7 @@ impl IMFVirtualCamera_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSyncSemaphore(::core::mem::transmute_copy(&kseventset), ::core::mem::transmute_copy(&kseventid), ::core::mem::transmute_copy(&kseventflags), ::core::mem::transmute_copy(&semaphorehandle), ::core::mem::transmute_copy(&semaphoreadjustment)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *camerasyncobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(camerasyncobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17841,7 +17841,7 @@ impl IMFWorkQueueServices_Vtbl {
             let this = (*this).get_impl();
             match this.GetTopologyWorkQueueMMCSSTaskId(::core::mem::transmute_copy(&dwtopologyworkqueueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtaskid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtaskid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17857,7 +17857,7 @@ impl IMFWorkQueueServices_Vtbl {
             let this = (*this).get_impl();
             match this.EndRegisterPlatformWorkQueueWithMMCSS(::core::mem::transmute(&presult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtaskid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtaskid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17883,7 +17883,7 @@ impl IMFWorkQueueServices_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlatformWorkQueueMMCSSTaskId(::core::mem::transmute_copy(&dwplatformworkqueueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtaskid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtaskid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17922,7 +17922,7 @@ impl IMFWorkQueueServicesEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetTopologyWorkQueueMMCSSPriority(::core::mem::transmute_copy(&dwtopologyworkqueueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17938,7 +17938,7 @@ impl IMFWorkQueueServicesEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlatformWorkQueueMMCSSPriority(::core::mem::transmute_copy(&dwplatformworkqueueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17980,7 +17980,7 @@ impl IOPMVideoOutput_Vtbl {
             let this = (*this).get_impl();
             match this.GetInformation(::core::mem::transmute_copy(&pparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestedinformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestedinformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17991,7 +17991,7 @@ impl IOPMVideoOutput_Vtbl {
             let this = (*this).get_impl();
             match this.COPPCompatibleGetInformation(::core::mem::transmute_copy(&pparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestedinformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestedinformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18053,7 +18053,7 @@ impl IPlayToControlWithCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18076,7 +18076,7 @@ impl IPlayToSourceClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pcontrol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18144,7 +18144,7 @@ impl IToc_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntryListByIndex(::core::mem::transmute_copy(&wentrylistindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppentrylist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppentrylist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18204,7 +18204,7 @@ impl ITocCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntryByIndex(::core::mem::transmute_copy(&dwentryindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18327,7 +18327,7 @@ impl ITocEntryList_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntryByIndex(::core::mem::transmute_copy(&dwentryindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18389,7 +18389,7 @@ impl ITocParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetTocByIndex(::core::mem::transmute_copy(&enumtocpostype), ::core::mem::transmute_copy(&dwtocindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18400,7 +18400,7 @@ impl ITocParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetTocByType(::core::mem::transmute_copy(&enumtocpostype), ::core::mem::transmute(&guidtoctype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptocs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptocs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
@@ -55,7 +55,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Xml(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&sortproperty), ::core::mem::transmute_copy(&sortorder), ::core::mem::transmute_copy(&filterflags), ::core::mem::transmute_copy(&includeflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *xml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -66,7 +66,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -82,7 +82,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Url() {
                 ::core::result::Result::Ok(ok__) => {
-                    *feedurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(feedurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LocalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *feedguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(feedguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -109,7 +109,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -125,7 +125,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -136,7 +136,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastWriteTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastwrite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastwrite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -167,7 +167,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.SyncSetting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *syncsetting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(syncsetting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -183,7 +183,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Interval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minutes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minutes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -199,7 +199,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastdownload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastdownload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -210,7 +210,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LocalEnclosurePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -221,7 +221,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Items() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -232,7 +232,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&itemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -243,7 +243,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *title = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(title, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -254,7 +254,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Link() {
                 ::core::result::Result::Ok(ok__) => {
-                    *homepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(homepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Image() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imageurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imageurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -287,7 +287,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastBuildDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastbuilddate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastbuilddate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.PubDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastpopulatedate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastpopulatedate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -309,7 +309,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Ttl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ttl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ttl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -320,7 +320,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *language = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(language, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -331,7 +331,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Copyright() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copyright = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copyright, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -342,7 +342,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.MaxItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadEnclosuresAutomatically() {
                 ::core::result::Result::Ok(ok__) => {
-                    *downloadenclosuresautomatically = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(downloadenclosuresautomatically, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -374,7 +374,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -385,7 +385,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *error = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(error, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -401,7 +401,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *feedurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(feedurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -412,7 +412,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.IsList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *islist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(islist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -428,7 +428,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.GetWatcher(::core::mem::transmute_copy(&scope), ::core::mem::transmute_copy(&mask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -439,7 +439,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.UnreadItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -450,7 +450,7 @@ impl IFeed_Vtbl {
             let this = (*this).get_impl();
             match this.ItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -527,7 +527,7 @@ impl IFeed2_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemByEffectiveId(::core::mem::transmute_copy(&itemeffectiveid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -538,7 +538,7 @@ impl IFeed2_Vtbl {
             let this = (*this).get_impl();
             match this.LastItemDownloadTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastitemdownloadtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastitemdownloadtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -549,7 +549,7 @@ impl IFeed2_Vtbl {
             let this = (*this).get_impl();
             match this.Username() {
                 ::core::result::Result::Ok(ok__) => {
-                    *username = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(username, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -560,7 +560,7 @@ impl IFeed2_Vtbl {
             let this = (*this).get_impl();
             match this.Password() {
                 ::core::result::Result::Ok(ok__) => {
-                    *password = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(password, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -616,7 +616,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.Url() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enclosureurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enclosureurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -627,7 +627,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mimetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mimetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -638,7 +638,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -659,7 +659,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -670,7 +670,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *error = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(error, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -681,7 +681,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.LocalPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *localpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -692,7 +692,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -703,7 +703,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enclosureurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enclosureurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -714,7 +714,7 @@ impl IFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadMimeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mimetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mimetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -854,7 +854,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Feeds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -865,7 +865,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Subfolders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -876,7 +876,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFeed(::core::mem::transmute(&feedname), ::core::mem::transmute(&feedurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -887,7 +887,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSubfolder(::core::mem::transmute(&foldername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -898,7 +898,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.ExistsFeed(::core::mem::transmute(&feedname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *exists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -909,7 +909,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeed(::core::mem::transmute(&feedname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -920,7 +920,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.ExistsSubfolder(::core::mem::transmute(&foldername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *exists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -931,7 +931,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubfolder(::core::mem::transmute(&foldername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -947,7 +947,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *foldername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(foldername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -963,7 +963,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *folderpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(folderpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -979,7 +979,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -990,7 +990,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.IsRoot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isroot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isroot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1001,7 +1001,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.TotalUnreadItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1012,7 +1012,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.TotalItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1023,7 +1023,7 @@ impl IFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetWatcher(::core::mem::transmute_copy(&scope), ::core::mem::transmute_copy(&mask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1213,7 +1213,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Xml(::core::mem::transmute_copy(&includeflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *xml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1224,7 +1224,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *title = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(title, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1235,7 +1235,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Link() {
                 ::core::result::Result::Ok(ok__) => {
-                    *linkurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(linkurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1246,7 +1246,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1257,7 +1257,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1268,7 +1268,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.PubDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pubdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pubdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1279,7 +1279,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Comments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *comments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(comments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1290,7 +1290,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Author() {
                 ::core::result::Result::Ok(ok__) => {
-                    *author = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(author, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1301,7 +1301,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Enclosure() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1312,7 +1312,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsRead() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1328,7 +1328,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.LocalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1339,7 +1339,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1355,7 +1355,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1366,7 +1366,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastdownload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastdownload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1377,7 +1377,7 @@ impl IFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1422,7 +1422,7 @@ impl IFeedItem2_Vtbl {
             let this = (*this).get_impl();
             match this.EffectiveId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *effectiveid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(effectiveid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1450,7 +1450,7 @@ impl IFeedsEnum_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1461,7 +1461,7 @@ impl IFeedsEnum_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1472,7 +1472,7 @@ impl IFeedsEnum_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1518,7 +1518,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.RootFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1529,7 +1529,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.IsSubscribed(::core::mem::transmute(&feedurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *subscribed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subscribed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1540,7 +1540,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.ExistsFeed(::core::mem::transmute(&feedpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *exists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1551,7 +1551,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeed(::core::mem::transmute(&feedpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1562,7 +1562,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFeedByUrl(::core::mem::transmute(&feedurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1573,7 +1573,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.ExistsFolder(::core::mem::transmute(&folderpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *exists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1584,7 +1584,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolder(::core::mem::transmute(&folderpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1610,7 +1610,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.BackgroundSyncStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1621,7 +1621,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minutes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minutes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1642,7 +1642,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.Normalize(::core::mem::transmute(&feedxmlin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *feedxmlout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(feedxmlout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1653,7 +1653,7 @@ impl IFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.ItemCountLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemcountlimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemcountlimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1734,7 +1734,7 @@ impl IWMPCdrom_Vtbl {
             let this = (*this).get_impl();
             match this.playlist() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplaylist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplaylist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1813,7 +1813,7 @@ impl IWMPCdromBurn_Vtbl {
             let this = (*this).get_impl();
             match this.burnPlaylist() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplaylist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplaylist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1897,7 +1897,7 @@ impl IWMPCdromCollection_Vtbl {
             let this = (*this).get_impl();
             match this.item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1908,7 +1908,7 @@ impl IWMPCdromCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getByDriveSpecifier(::core::mem::transmute(&bstrdrivespecifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcdrom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcdrom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2108,7 +2108,7 @@ impl IWMPContentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontentid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontentid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2119,7 +2119,7 @@ impl IWMPContentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2130,7 +2130,7 @@ impl IWMPContentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2141,7 +2141,7 @@ impl IWMPContentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2152,7 +2152,7 @@ impl IWMPContentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentPrice(::core::mem::transmute_copy(&idxcontent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2163,7 +2163,7 @@ impl IWMPContentContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentID(::core::mem::transmute_copy(&idxcontent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontentid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontentid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2196,7 +2196,7 @@ impl IWMPContentContainerList_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransactionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwmptt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwmptt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2207,7 +2207,7 @@ impl IWMPContentContainerList_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainerCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccontainer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccontainer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2218,7 +2218,7 @@ impl IWMPContentContainerList_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainer(::core::mem::transmute_copy(&idxcontainer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2281,7 +2281,7 @@ impl IWMPContentPartner_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemInfo(::core::mem::transmute(&bstrinfoname), ::core::mem::transmute_copy(&pcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2292,7 +2292,7 @@ impl IWMPContentPartner_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentPartnerInfo(::core::mem::transmute(&bstrinfoname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2323,7 +2323,7 @@ impl IWMPContentPartner_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamingURL(::core::mem::transmute_copy(&st), ::core::mem::transmute_copy(&pstreamcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2394,7 +2394,7 @@ impl IWMPContentPartner_Vtbl {
             let this = (*this).get_impl();
             match this.CompareContainerListPrices(::core::mem::transmute(&plistbase), ::core::mem::transmute(&plistcompare)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2627,7 +2627,7 @@ impl IWMPControls_Vtbl {
             let this = (*this).get_impl();
             match this.currentItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwmpmedia = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwmpmedia, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2872,7 +2872,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.controls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontrol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontrol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2883,7 +2883,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.settings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2894,7 +2894,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.currentMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmedia = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmedia, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2910,7 +2910,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.mediaCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediacollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediacollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2921,7 +2921,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.playlistCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplaylistcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplaylistcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2942,7 +2942,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.network() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqni = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqni, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2953,7 +2953,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.currentPlaylist() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2969,7 +2969,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.cdromCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcdromcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcdromcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2980,7 +2980,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.closedCaption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclosedcaption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclosedcaption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2996,7 +2996,7 @@ impl IWMPCore_Vtbl {
             let this = (*this).get_impl();
             match this.error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3050,7 +3050,7 @@ impl IWMPCore2_Vtbl {
             let this = (*this).get_impl();
             match this.dvd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdvd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdvd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3077,7 +3077,7 @@ impl IWMPCore3_Vtbl {
             let this = (*this).get_impl();
             match this.newPlaylist(::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplaylist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplaylist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3088,7 +3088,7 @@ impl IWMPCore3_Vtbl {
             let this = (*this).get_impl();
             match this.newMedia(::core::mem::transmute(&bstrurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmedia = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmedia, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3191,7 +3191,7 @@ impl IWMPDownloadCollection_Vtbl {
             let this = (*this).get_impl();
             match this.item(::core::mem::transmute_copy(&litem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdownload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdownload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3202,7 +3202,7 @@ impl IWMPDownloadCollection_Vtbl {
             let this = (*this).get_impl();
             match this.startDownload(::core::mem::transmute(&bstrsourceurl), ::core::mem::transmute(&bstrtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdownload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdownload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3339,7 +3339,7 @@ impl IWMPDownloadManager_Vtbl {
             let this = (*this).get_impl();
             match this.getDownloadCollection(::core::mem::transmute_copy(&lcollectionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3350,7 +3350,7 @@ impl IWMPDownloadManager_Vtbl {
             let this = (*this).get_impl();
             match this.createDownloadCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3544,7 +3544,7 @@ impl IWMPError_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperroritem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperroritem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4294,7 +4294,7 @@ impl IWMPLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.mediaCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwmpmediacollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwmpmediacollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4354,7 +4354,7 @@ impl IWMPLibraryServices_Vtbl {
             let this = (*this).get_impl();
             match this.getLibraryByType(::core::mem::transmute_copy(&wmplt), ::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwmplibrary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwmplibrary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4560,7 +4560,7 @@ impl IWMPMedia2_Vtbl {
             let this = (*this).get_impl();
             match this.error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwmperroritem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwmperroritem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4627,7 +4627,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.add(::core::mem::transmute(&bstrurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4638,7 +4638,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getAll() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4649,7 +4649,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getByName(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4660,7 +4660,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getByGenre(::core::mem::transmute(&bstrgenre)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4671,7 +4671,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getByAuthor(::core::mem::transmute(&bstrauthor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4682,7 +4682,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getByAlbum(::core::mem::transmute(&bstralbum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4693,7 +4693,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getByAttribute(::core::mem::transmute(&bstrattribute), ::core::mem::transmute(&bstrvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4709,7 +4709,7 @@ impl IWMPMediaCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getAttributeStringCollection(::core::mem::transmute(&bstrattribute), ::core::mem::transmute(&bstrmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstringcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstringcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4767,7 +4767,7 @@ impl IWMPMediaCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.createQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4778,7 +4778,7 @@ impl IWMPMediaCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.getPlaylistByQuery(::core::mem::transmute(&pquery), ::core::mem::transmute(&bstrmediatype), ::core::mem::transmute(&bstrsortattribute), ::core::mem::transmute_copy(&fsortascending)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplaylist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplaylist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4789,7 +4789,7 @@ impl IWMPMediaCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.getStringCollectionByQuery(::core::mem::transmute(&bstrattribute), ::core::mem::transmute(&pquery), ::core::mem::transmute(&bstrmediatype), ::core::mem::transmute(&bstrsortattribute), ::core::mem::transmute_copy(&fsortascending)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstringcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstringcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4800,7 +4800,7 @@ impl IWMPMediaCollection2_Vtbl {
             let this = (*this).get_impl();
             match this.getByAttributeAndMediaType(::core::mem::transmute(&bstrattribute), ::core::mem::transmute(&bstrvalue), ::core::mem::transmute(&bstrmediatype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmediaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmediaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5681,7 +5681,7 @@ impl IWMPPlayer4_Vtbl {
             let this = (*this).get_impl();
             match this.playerApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwmpplayerapplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwmpplayerapplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5871,7 +5871,7 @@ impl IWMPPlaylist_Vtbl {
             let this = (*this).get_impl();
             match this.get_item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiwmpmedia = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiwmpmedia, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5959,7 +5959,7 @@ impl IWMPPlaylistArray_Vtbl {
             let this = (*this).get_impl();
             match this.item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5995,7 +5995,7 @@ impl IWMPPlaylistCollection_Vtbl {
             let this = (*this).get_impl();
             match this.newPlaylist(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6006,7 +6006,7 @@ impl IWMPPlaylistCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getAll() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplaylistarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplaylistarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6017,7 +6017,7 @@ impl IWMPPlaylistCollection_Vtbl {
             let this = (*this).get_impl();
             match this.getByName(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppplaylistarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppplaylistarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6043,7 +6043,7 @@ impl IWMPPlaylistCollection_Vtbl {
             let this = (*this).get_impl();
             match this.importPlaylist(::core::mem::transmute(&pitem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimporteditem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimporteditem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6953,7 +6953,7 @@ impl IWMPSyncServices_Vtbl {
             let this = (*this).get_impl();
             match this.getDevice(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7100,7 +7100,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Xml(::core::mem::transmute_copy(&uiitemcount), ::core::mem::transmute_copy(&sortproperty), ::core::mem::transmute_copy(&sortorder), ::core::mem::transmute_copy(&filterflags), ::core::mem::transmute_copy(&includeflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7111,7 +7111,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7127,7 +7127,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Url() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7143,7 +7143,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LocalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7154,7 +7154,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7175,7 +7175,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastWriteTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstlastwritetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstlastwritetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7206,7 +7206,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.SyncSetting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfss = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfss, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7222,7 +7222,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Interval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiinterval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiinterval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7238,7 +7238,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstlastdownloadtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstlastdownloadtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7249,7 +7249,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LocalEnclosurePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7260,7 +7260,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Items() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7281,7 +7281,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.MaxItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puimaxitemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puimaxitemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7297,7 +7297,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadEnclosuresAutomatically() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdownloadenclosuresautomatically = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdownloadenclosuresautomatically, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7313,7 +7313,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7324,7 +7324,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfde = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfde, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7340,7 +7340,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7351,7 +7351,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7362,7 +7362,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7373,7 +7373,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Link() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszhomepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszhomepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7384,7 +7384,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Image() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszimageurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszimageurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7395,7 +7395,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.LastBuildDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstlastbuilddate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstlastbuilddate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7406,7 +7406,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.PubDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstpubdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstpubdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7417,7 +7417,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Ttl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puittl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puittl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7428,7 +7428,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Language() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszlanguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszlanguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7439,7 +7439,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.Copyright() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcopyright = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcopyright, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7450,7 +7450,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.IsList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbislist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbislist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7466,7 +7466,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.UnreadItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiunreaditemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiunreaditemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7477,7 +7477,7 @@ impl IXFeed_Vtbl {
             let this = (*this).get_impl();
             match this.ItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiitemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiitemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7559,7 +7559,7 @@ impl IXFeed2_Vtbl {
             let this = (*this).get_impl();
             match this.LastItemDownloadTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstlastitemdownloadtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstlastitemdownloadtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7570,7 +7570,7 @@ impl IXFeed2_Vtbl {
             let this = (*this).get_impl();
             match this.Username() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7581,7 +7581,7 @@ impl IXFeed2_Vtbl {
             let this = (*this).get_impl();
             match this.Password() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpassword = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpassword, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7634,7 +7634,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.Url() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7645,7 +7645,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszmimetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszmimetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7656,7 +7656,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puilength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puilength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7677,7 +7677,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7688,7 +7688,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfde = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfde, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7699,7 +7699,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.LocalPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7715,7 +7715,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7726,7 +7726,7 @@ impl IXFeedEnclosure_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadMimeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszmimetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszmimetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7863,7 +7863,7 @@ impl IXFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Feeds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7874,7 +7874,7 @@ impl IXFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Subfolders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7920,7 +7920,7 @@ impl IXFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7936,7 +7936,7 @@ impl IXFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7957,7 +7957,7 @@ impl IXFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.IsRoot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisrootfeedfolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisrootfeedfolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7973,7 +7973,7 @@ impl IXFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.TotalUnreadItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puitotalunreaditemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puitotalunreaditemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7984,7 +7984,7 @@ impl IXFeedFolder_Vtbl {
             let this = (*this).get_impl();
             match this.TotalItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puitotalitemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puitotalitemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8171,7 +8171,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Xml(::core::mem::transmute_copy(&fxif)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8182,7 +8182,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8193,7 +8193,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Link() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8204,7 +8204,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8215,7 +8215,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8226,7 +8226,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.PubDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstpubdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstpubdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8237,7 +8237,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Comments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8248,7 +8248,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Author() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszauthor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszauthor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8264,7 +8264,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsRead() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8280,7 +8280,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.LocalId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8301,7 +8301,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8312,7 +8312,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.LastDownloadTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstlastdownloadtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstlastdownloadtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8323,7 +8323,7 @@ impl IXFeedItem_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstmodifiedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstmodifiedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8368,7 +8368,7 @@ impl IXFeedItem2_Vtbl {
             let this = (*this).get_impl();
             match this.EffectiveId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puieffectiveid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puieffectiveid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8392,7 +8392,7 @@ impl IXFeedsEnum_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puicount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puicount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8443,7 +8443,7 @@ impl IXFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.IsSubscribed(::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsubscribed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsubscribed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8454,7 +8454,7 @@ impl IXFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.ExistsFeed(::core::mem::transmute(&pszpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbfeedexists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbfeedexists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8475,7 +8475,7 @@ impl IXFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.ExistsFolder(::core::mem::transmute(&pszpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbfolderexists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbfolderexists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8506,7 +8506,7 @@ impl IXFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.BackgroundSyncStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfbss = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfbss, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8517,7 +8517,7 @@ impl IXFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiinterval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiinterval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8538,7 +8538,7 @@ impl IXFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.Normalize(::core::mem::transmute(&pstreamin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstreamout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstreamout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8549,7 +8549,7 @@ impl IXFeedsManager_Vtbl {
             let this = (*this).get_impl();
             match this.ItemCountLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiitemcountlimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiitemcountlimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
@@ -31,7 +31,7 @@ impl IAVIEditStream_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
@@ -14,7 +14,7 @@ impl IPhotoAcquire_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePhotoSource(::core::mem::transmute(&pszdevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphotoacquiresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphotoacquiresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30,7 +30,7 @@ impl IPhotoAcquire_Vtbl {
             let this = (*this).get_impl();
             match this.EnumResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumfilepaths = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumfilepaths, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -106,7 +106,7 @@ impl IPhotoAcquireItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstritemname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstritemname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -117,7 +117,7 @@ impl IPhotoAcquireItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnail(::core::mem::transmute(&sizethumbnail)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbmpthumbnail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbmpthumbnail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -128,7 +128,7 @@ impl IPhotoAcquireItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -144,7 +144,7 @@ impl IPhotoAcquireItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -155,7 +155,7 @@ impl IPhotoAcquireItem_Vtbl {
             let this = (*this).get_impl();
             match this.CanDelete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcandelete = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcandelete, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -171,7 +171,7 @@ impl IPhotoAcquireItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -182,7 +182,7 @@ impl IPhotoAcquireItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubItemAt(::core::mem::transmute_copy(&nitemindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphotoacquireitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphotoacquireitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -228,7 +228,7 @@ impl IPhotoAcquireOptionsDialog_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&hwndparent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnddialog = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnddialog, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -338,7 +338,7 @@ impl IPhotoAcquireProgressCB_Vtbl {
             let this = (*this).get_impl();
             match this.Cancelled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcancelled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcancelled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -424,7 +424,7 @@ impl IPhotoAcquireProgressCB_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeleteAfterAcquire() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdeleteafteracquire = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdeleteafteracquire, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -435,7 +435,7 @@ impl IPhotoAcquireProgressCB_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorAdvise(::core::mem::transmute_copy(&hr), ::core::mem::transmute(&pszerrormessage), ::core::mem::transmute_copy(&nmessagetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnerroradviseresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnerroradviseresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -534,7 +534,7 @@ impl IPhotoAcquireSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwphotoacquireflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwphotoacquireflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -545,7 +545,7 @@ impl IPhotoAcquireSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputFilenameTemplate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IPhotoAcquireSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetSequencePaddingWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -567,7 +567,7 @@ impl IPhotoAcquireSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetSequenceZeroPadding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfzeropad = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfzeropad, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -578,7 +578,7 @@ impl IPhotoAcquireSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroupTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrgrouptag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrgrouptag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -589,7 +589,7 @@ impl IPhotoAcquireSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetAcquisitionTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftacquisitiontime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftacquisitiontime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -637,7 +637,7 @@ impl IPhotoAcquireSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetFriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl IPhotoAcquireSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnitemcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnitemcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl IPhotoAcquireSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemAt(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphotoacquireitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphotoacquireitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl IPhotoAcquireSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetPhotoAcquireSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphotoacquiresettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphotoacquiresettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -691,7 +691,7 @@ impl IPhotoAcquireSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdeviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdeviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -774,7 +774,7 @@ impl IPhotoProgressDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndprogressdialog = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndprogressdialog, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -815,7 +815,7 @@ impl IPhotoProgressDialog_Vtbl {
             let this = (*this).get_impl();
             match this.IsCheckboxChecked(::core::mem::transmute_copy(&ncheckboxid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfchecked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfchecked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -861,7 +861,7 @@ impl IPhotoProgressDialog_Vtbl {
             let this = (*this).get_impl();
             match this.IsCancelled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcancelled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcancelled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -921,7 +921,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubmitButtonText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubmitbuttontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubmitbuttontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -932,7 +932,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrompt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprompttitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprompttitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstringid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstringid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnstringtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnstringtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -965,7 +965,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetTooltipText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtooltiptext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtooltiptext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -976,7 +976,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchmaxlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchmaxlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -987,7 +987,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefault() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdefault = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdefault, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -998,7 +998,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetMruCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnmrucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnmrucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1009,7 +1009,7 @@ impl IUserInputString_Vtbl {
             let this = (*this).get_impl();
             match this.GetMruEntryAt(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmruentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmruentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
@@ -29,7 +29,7 @@ impl IEnumSpObjectTokens_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40,7 +40,7 @@ impl IEnumSpObjectTokens_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -212,7 +212,7 @@ impl ISpDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute(&pszvaluename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -233,7 +233,7 @@ impl ISpDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.OpenKey(::core::mem::transmute(&pszsubkeyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -244,7 +244,7 @@ impl ISpDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.CreateKey(::core::mem::transmute(&pszsubkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl ISpDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.EnumKeys(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszsubkeyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszsubkeyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl ISpDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.EnumValues(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszvaluename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszvaluename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -836,7 +836,7 @@ impl ISpObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomemtokenid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomemtokenid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -847,7 +847,7 @@ impl ISpObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptokencategory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptokencategory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -863,7 +863,7 @@ impl ISpObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorageFileName(::core::mem::transmute_copy(&clsidcaller), ::core::mem::transmute(&pszvaluename), ::core::mem::transmute(&pszfilenamespecifier), ::core::mem::transmute_copy(&nfolder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszfilepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszfilepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -936,7 +936,7 @@ impl ISpObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomemcategoryid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomemcategoryid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -947,7 +947,7 @@ impl ISpObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataKey(::core::mem::transmute_copy(&spdkl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdatakey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdatakey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -958,7 +958,7 @@ impl ISpObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTokens(::core::mem::transmute(&pzsreqattribs), ::core::mem::transmute(&pszoptattribs)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -974,7 +974,7 @@ impl ISpObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultTokenId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomemtokenid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomemtokenid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1031,7 +1031,7 @@ impl ISpObjectWithToken_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1059,7 +1059,7 @@ impl ISpPhoneConverter_Vtbl {
             let this = (*this).get_impl();
             match this.PhoneToId(::core::mem::transmute(&pszphone)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1098,7 +1098,7 @@ impl ISpPhoneticAlphabetConverter_Vtbl {
             let this = (*this).get_impl();
             match this.GetLangId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plangid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plangid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1124,7 +1124,7 @@ impl ISpPhoneticAlphabetConverter_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxConvertLength(::core::mem::transmute_copy(&csrclength), ::core::mem::transmute_copy(&bsapi2ups)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmaxdestlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmaxdestlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1158,7 +1158,7 @@ impl ISpPhoneticAlphabetSelection_Vtbl {
             let this = (*this).get_impl();
             match this.IsAlphabetUPS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1196,7 +1196,7 @@ impl ISpPhrase_Vtbl {
             let this = (*this).get_impl();
             match this.GetPhrase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomemphrase = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomemphrase, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1207,7 +1207,7 @@ impl ISpPhrase_Vtbl {
             let this = (*this).get_impl();
             match this.GetSerializedPhrase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomemphrase = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomemphrase, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1261,7 +1261,7 @@ impl ISpPhrase2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudio(::core::mem::transmute_copy(&ulstartelement), ::core::mem::transmute_copy(&celements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1337,7 +1337,7 @@ impl ISpProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyString(::core::mem::transmute(&pname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomemvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomemvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1386,7 +1386,7 @@ impl ISpRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecognizer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprecognizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprecognizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1397,7 +1397,7 @@ impl ISpRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGrammar(::core::mem::transmute_copy(&ullgrammarid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgrammar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgrammar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1433,7 +1433,7 @@ impl ISpRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.DeserializeResult(::core::mem::transmute_copy(&pserializedresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1469,7 +1469,7 @@ impl ISpRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetVoice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvoice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvoice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1591,7 +1591,7 @@ impl ISpRecoGrammar_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecoContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprecoctxt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprecoctxt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1672,7 +1672,7 @@ impl ISpRecoGrammar_Vtbl {
             let this = (*this).get_impl();
             match this.SaveCmd(::core::mem::transmute(&pstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomemerrortext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomemerrortext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1811,7 +1811,7 @@ impl ISpRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudio(::core::mem::transmute_copy(&ulstartelement), ::core::mem::transmute_copy(&celements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1837,7 +1837,7 @@ impl ISpRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecoContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprecocontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprecocontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1874,7 +1874,7 @@ impl ISpRecoResult2_Vtbl {
             let this = (*this).get_impl();
             match this.CommitAlternate(::core::mem::transmute(&pphrasealt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1935,7 +1935,7 @@ impl ISpRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecognizer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprecognizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprecognizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1951,7 +1951,7 @@ impl ISpRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputObjectToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1962,7 +1962,7 @@ impl ISpRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1973,7 +1973,7 @@ impl ISpRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRecoContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewctxt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewctxt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1984,7 +1984,7 @@ impl ISpRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecoProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2206,7 +2206,7 @@ impl ISpShortcut_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeneration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwgeneration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwgeneration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2270,7 +2270,7 @@ impl ISpStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetBaseStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2312,7 +2312,7 @@ impl ISpStreamFormat_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat(::core::mem::transmute_copy(&pguidformatid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomemwaveformatex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomemwaveformatex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2348,7 +2348,7 @@ impl ISpStreamFormatConverter_Vtbl {
             let this = (*this).get_impl();
             match this.GetBaseStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2369,7 +2369,7 @@ impl ISpStreamFormatConverter_Vtbl {
             let this = (*this).get_impl();
             match this.ScaleConvertedToBaseOffset(::core::mem::transmute_copy(&ulloffsetconvertedstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulloffsetbasestream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulloffsetbasestream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2380,7 +2380,7 @@ impl ISpStreamFormatConverter_Vtbl {
             let this = (*this).get_impl();
             match this.ScaleBaseToConvertedOffset(::core::mem::transmute_copy(&ulloffsetbasestream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulloffsetconvertedstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulloffsetconvertedstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2412,7 +2412,7 @@ impl ISpTranscript_Vtbl {
             let this = (*this).get_impl();
             match this.GetTranscript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztranscript = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztranscript, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2476,7 +2476,7 @@ impl ISpVoice_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputObjectToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjecttoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjecttoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2487,7 +2487,7 @@ impl ISpVoice_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2513,7 +2513,7 @@ impl ISpVoice_Vtbl {
             let this = (*this).get_impl();
             match this.GetVoice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2524,7 +2524,7 @@ impl ISpVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Speak(::core::mem::transmute(&pwcs), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstreamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstreamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2535,7 +2535,7 @@ impl ISpVoice_Vtbl {
             let this = (*this).get_impl();
             match this.SpeakStream(::core::mem::transmute(&pstream), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstreamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstreamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2706,7 +2706,7 @@ impl ISpeechAudio_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2717,7 +2717,7 @@ impl ISpeechAudio_Vtbl {
             let this = (*this).get_impl();
             match this.BufferInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bufferinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bufferinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2728,7 +2728,7 @@ impl ISpeechAudio_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2739,7 +2739,7 @@ impl ISpeechAudio_Vtbl {
             let this = (*this).get_impl();
             match this.Volume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *volume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(volume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2755,7 +2755,7 @@ impl ISpeechAudio_Vtbl {
             let this = (*this).get_impl();
             match this.BufferNotifySize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffernotifysize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffernotifysize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2771,7 +2771,7 @@ impl ISpeechAudio_Vtbl {
             let this = (*this).get_impl();
             match this.EventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2818,7 +2818,7 @@ impl ISpeechAudioBufferInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MinNotification() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minnotification = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minnotification, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2834,7 +2834,7 @@ impl ISpeechAudioBufferInfo_Vtbl {
             let this = (*this).get_impl();
             match this.BufferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffersize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffersize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2850,7 +2850,7 @@ impl ISpeechAudioBufferInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EventBias() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventbias = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventbias, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2894,7 +2894,7 @@ impl ISpeechAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2910,7 +2910,7 @@ impl ISpeechAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2926,7 +2926,7 @@ impl ISpeechAudioFormat_Vtbl {
             let this = (*this).get_impl();
             match this.GetWaveFormatEx() {
                 ::core::result::Result::Ok(ok__) => {
-                    *speechwaveformatex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(speechwaveformatex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2969,7 +2969,7 @@ impl ISpeechAudioStatus_Vtbl {
             let this = (*this).get_impl();
             match this.FreeBufferSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *freebufferspace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(freebufferspace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2980,7 +2980,7 @@ impl ISpeechAudioStatus_Vtbl {
             let this = (*this).get_impl();
             match this.NonBlockingIO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nonblockingio = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nonblockingio, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2991,7 +2991,7 @@ impl ISpeechAudioStatus_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3002,7 +3002,7 @@ impl ISpeechAudioStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentSeekPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentseekposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentseekposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3013,7 +3013,7 @@ impl ISpeechAudioStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDevicePosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentdeviceposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentdeviceposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3050,7 +3050,7 @@ impl ISpeechBaseStream_Vtbl {
             let this = (*this).get_impl();
             match this.Format() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3071,7 +3071,7 @@ impl ISpeechBaseStream_Vtbl {
             let this = (*this).get_impl();
             match this.Write(::core::mem::transmute(&buffer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3082,7 +3082,7 @@ impl ISpeechBaseStream_Vtbl {
             let this = (*this).get_impl();
             match this.Seek(::core::mem::transmute(&position), ::core::mem::transmute_copy(&origin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3116,7 +3116,7 @@ impl ISpeechCustomStream_Vtbl {
             let this = (*this).get_impl();
             match this.BaseStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3167,7 +3167,7 @@ impl ISpeechDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetBinaryValue(::core::mem::transmute(&valuename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3183,7 +3183,7 @@ impl ISpeechDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute(&valuename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3199,7 +3199,7 @@ impl ISpeechDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetLongValue(::core::mem::transmute(&valuename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3210,7 +3210,7 @@ impl ISpeechDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.OpenKey(::core::mem::transmute(&subkeyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *subkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3221,7 +3221,7 @@ impl ISpeechDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.CreateKey(::core::mem::transmute(&subkeyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *subkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3242,7 +3242,7 @@ impl ISpeechDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.EnumKeys(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *subkeyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subkeyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3253,7 +3253,7 @@ impl ISpeechDataKey_Vtbl {
             let this = (*this).get_impl();
             match this.EnumValues(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *valuename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(valuename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3325,7 +3325,7 @@ impl ISpeechGrammarRule_Vtbl {
             let this = (*this).get_impl();
             match this.Attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3336,7 +3336,7 @@ impl ISpeechGrammarRule_Vtbl {
             let this = (*this).get_impl();
             match this.InitialState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3347,7 +3347,7 @@ impl ISpeechGrammarRule_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3358,7 +3358,7 @@ impl ISpeechGrammarRule_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3379,7 +3379,7 @@ impl ISpeechGrammarRule_Vtbl {
             let this = (*this).get_impl();
             match this.AddState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3418,7 +3418,7 @@ impl ISpeechGrammarRuleState_Vtbl {
             let this = (*this).get_impl();
             match this.Rule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3429,7 +3429,7 @@ impl ISpeechGrammarRuleState_Vtbl {
             let this = (*this).get_impl();
             match this.Transitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3484,7 +3484,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3495,7 +3495,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.Text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3506,7 +3506,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.Rule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3517,7 +3517,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.Weight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *weight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(weight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3528,7 +3528,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3539,7 +3539,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3550,7 +3550,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3561,7 +3561,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
             let this = (*this).get_impl();
             match this.NextState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3599,7 +3599,7 @@ impl ISpeechGrammarRuleStateTransitions_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3610,7 +3610,7 @@ impl ISpeechGrammarRuleStateTransitions_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3621,7 +3621,7 @@ impl ISpeechGrammarRuleStateTransitions_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3659,7 +3659,7 @@ impl ISpeechGrammarRules_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3670,7 +3670,7 @@ impl ISpeechGrammarRules_Vtbl {
             let this = (*this).get_impl();
             match this.FindRule(::core::mem::transmute(&rulenameorid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3681,7 +3681,7 @@ impl ISpeechGrammarRules_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3692,7 +3692,7 @@ impl ISpeechGrammarRules_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3703,7 +3703,7 @@ impl ISpeechGrammarRules_Vtbl {
             let this = (*this).get_impl();
             match this.Dynamic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dynamic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dynamic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3714,7 +3714,7 @@ impl ISpeechGrammarRules_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&rulename), ::core::mem::transmute_copy(&attributes), ::core::mem::transmute_copy(&ruleid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3767,7 +3767,7 @@ impl ISpeechLexicon_Vtbl {
             let this = (*this).get_impl();
             match this.GenerationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *generationid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(generationid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3803,7 +3803,7 @@ impl ISpeechLexicon_Vtbl {
             let this = (*this).get_impl();
             match this.GetPronunciations(::core::mem::transmute(&bstrword), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&typeflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppronunciations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppronunciations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3848,7 +3848,7 @@ impl ISpeechLexiconPronunciation_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lexicontype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lexicontype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3859,7 +3859,7 @@ impl ISpeechLexiconPronunciation_Vtbl {
             let this = (*this).get_impl();
             match this.LangId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *langid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(langid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3870,7 +3870,7 @@ impl ISpeechLexiconPronunciation_Vtbl {
             let this = (*this).get_impl();
             match this.PartOfSpeech() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partofspeech = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partofspeech, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3881,7 +3881,7 @@ impl ISpeechLexiconPronunciation_Vtbl {
             let this = (*this).get_impl();
             match this.PhoneIds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phoneids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phoneids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3892,7 +3892,7 @@ impl ISpeechLexiconPronunciation_Vtbl {
             let this = (*this).get_impl();
             match this.Symbolic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbolic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbolic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3927,7 +3927,7 @@ impl ISpeechLexiconPronunciations_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3938,7 +3938,7 @@ impl ISpeechLexiconPronunciations_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pronunciation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pronunciation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3949,7 +3949,7 @@ impl ISpeechLexiconPronunciations_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3983,7 +3983,7 @@ impl ISpeechLexiconWord_Vtbl {
             let this = (*this).get_impl();
             match this.LangId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *langid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(langid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3994,7 +3994,7 @@ impl ISpeechLexiconWord_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wordtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wordtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4005,7 +4005,7 @@ impl ISpeechLexiconWord_Vtbl {
             let this = (*this).get_impl();
             match this.Word() {
                 ::core::result::Result::Ok(ok__) => {
-                    *word = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(word, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4016,7 +4016,7 @@ impl ISpeechLexiconWord_Vtbl {
             let this = (*this).get_impl();
             match this.Pronunciations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pronunciations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pronunciations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4050,7 +4050,7 @@ impl ISpeechLexiconWords_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4061,7 +4061,7 @@ impl ISpeechLexiconWords_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *word = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(word, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4072,7 +4072,7 @@ impl ISpeechLexiconWords_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4107,7 +4107,7 @@ impl ISpeechMMSysAudio_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4123,7 +4123,7 @@ impl ISpeechMMSysAudio_Vtbl {
             let this = (*this).get_impl();
             match this.LineId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lineid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lineid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4139,7 +4139,7 @@ impl ISpeechMMSysAudio_Vtbl {
             let this = (*this).get_impl();
             match this.MMHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4178,7 +4178,7 @@ impl ISpeechMemoryStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4220,7 +4220,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objectid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objectid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4231,7 +4231,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.DataKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *datakey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(datakey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4242,7 +4242,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.Category() {
                 ::core::result::Result::Ok(ok__) => {
-                    *category = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(category, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4253,7 +4253,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription(::core::mem::transmute_copy(&locale)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4269,7 +4269,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttribute(::core::mem::transmute(&attributename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributevalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributevalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4280,7 +4280,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&clscontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4296,7 +4296,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorageFileName(::core::mem::transmute(&objectstorageclsid), ::core::mem::transmute(&keyname), ::core::mem::transmute(&filename), ::core::mem::transmute_copy(&folder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4312,7 +4312,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.IsUISupported(::core::mem::transmute(&typeofui), ::core::mem::transmute_copy(&extradata), ::core::mem::transmute(&object)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4328,7 +4328,7 @@ impl ISpeechObjectToken_Vtbl {
             let this = (*this).get_impl();
             match this.MatchesAttributes(::core::mem::transmute(&attributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4374,7 +4374,7 @@ impl ISpeechObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4390,7 +4390,7 @@ impl ISpeechObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.Default() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tokenid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tokenid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4406,7 +4406,7 @@ impl ISpeechObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataKey(::core::mem::transmute_copy(&location)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *datakey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(datakey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4417,7 +4417,7 @@ impl ISpeechObjectTokenCategory_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateTokens(::core::mem::transmute(&requiredattributes), ::core::mem::transmute(&optionalattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tokens = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tokens, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4453,7 +4453,7 @@ impl ISpeechObjectTokens_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4464,7 +4464,7 @@ impl ISpeechObjectTokens_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *token = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(token, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4475,7 +4475,7 @@ impl ISpeechObjectTokens_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4509,7 +4509,7 @@ impl ISpeechPhoneConverter_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *languageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(languageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4525,7 +4525,7 @@ impl ISpeechPhoneConverter_Vtbl {
             let this = (*this).get_impl();
             match this.PhoneToId(::core::mem::transmute(&phonemes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *idarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(idarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4536,7 +4536,7 @@ impl ISpeechPhoneConverter_Vtbl {
             let this = (*this).get_impl();
             match this.IdToPhone(::core::mem::transmute(&idarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phonemes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phonemes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4572,7 +4572,7 @@ impl ISpeechPhraseAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.RecoResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recoresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recoresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4583,7 +4583,7 @@ impl ISpeechPhraseAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.StartElementInResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *startelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(startelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4594,7 +4594,7 @@ impl ISpeechPhraseAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfElementsInResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numberofelements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numberofelements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4605,7 +4605,7 @@ impl ISpeechPhraseAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.PhraseInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phraseinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phraseinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4645,7 +4645,7 @@ impl ISpeechPhraseAlternates_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4656,7 +4656,7 @@ impl ISpeechPhraseAlternates_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrasealternate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrasealternate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4667,7 +4667,7 @@ impl ISpeechPhraseAlternates_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4710,7 +4710,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.AudioTimeOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiotimeoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiotimeoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4721,7 +4721,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.AudioSizeTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiosizetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiosizetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4732,7 +4732,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.AudioStreamOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiostreamoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiostreamoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4743,7 +4743,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.AudioSizeBytes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiosizebytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiosizebytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4754,7 +4754,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.RetainedStreamOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retainedstreamoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retainedstreamoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4765,7 +4765,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.RetainedSizeBytes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retainedsizebytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retainedsizebytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4776,7 +4776,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displaytext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displaytext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4787,7 +4787,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.LexicalForm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lexicalform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lexicalform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4798,7 +4798,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.Pronunciation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pronunciation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pronunciation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4809,7 +4809,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4820,7 +4820,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.RequiredConfidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requiredconfidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requiredconfidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4831,7 +4831,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.ActualConfidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *actualconfidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actualconfidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4842,7 +4842,7 @@ impl ISpeechPhraseElement_Vtbl {
             let this = (*this).get_impl();
             match this.EngineConfidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *engineconfidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(engineconfidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4885,7 +4885,7 @@ impl ISpeechPhraseElements_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4896,7 +4896,7 @@ impl ISpeechPhraseElements_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4907,7 +4907,7 @@ impl ISpeechPhraseElements_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4953,7 +4953,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *languageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(languageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4964,7 +4964,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GrammarId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *grammarid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(grammarid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4975,7 +4975,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *starttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(starttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4986,7 +4986,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AudioStreamPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiostreamposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiostreamposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4997,7 +4997,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AudioSizeBytes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paudiosizebytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paudiosizebytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5008,7 +5008,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RetainedSizeBytes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retainedsizebytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retainedsizebytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5019,7 +5019,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AudioSizeTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiosizetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiosizetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5030,7 +5030,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Rule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5041,7 +5041,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *properties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(properties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5052,7 +5052,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Elements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *elements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(elements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5063,7 +5063,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Replacements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *replacements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(replacements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5074,7 +5074,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EngineId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *engineidguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(engineidguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5085,7 +5085,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EnginePrivateData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *privatedata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(privatedata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5096,7 +5096,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SaveToMemory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phraseblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phraseblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5107,7 +5107,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetText(::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements), ::core::mem::transmute_copy(&usereplacements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5118,7 +5118,7 @@ impl ISpeechPhraseInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayAttributes(::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements), ::core::mem::transmute_copy(&usereplacements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5162,7 +5162,7 @@ impl ISpeechPhraseInfoBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.RestorePhraseFromMemory(::core::mem::transmute_copy(&phraseinmemory)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phraseinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phraseinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5193,7 +5193,7 @@ impl ISpeechPhraseProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5204,7 +5204,7 @@ impl ISpeechPhraseProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *property = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(property, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5215,7 +5215,7 @@ impl ISpeechPhraseProperties_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5254,7 +5254,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5265,7 +5265,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5276,7 +5276,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5287,7 +5287,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.FirstElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *firstelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(firstelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5298,7 +5298,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfElements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numberofelements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numberofelements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5309,7 +5309,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.EngineConfidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *confidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(confidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5320,7 +5320,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Confidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *confidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(confidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5331,7 +5331,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parentproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parentproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5342,7 +5342,7 @@ impl ISpeechPhraseProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *children = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(children, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5382,7 +5382,7 @@ impl ISpeechPhraseReplacement_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5393,7 +5393,7 @@ impl ISpeechPhraseReplacement_Vtbl {
             let this = (*this).get_impl();
             match this.Text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5404,7 +5404,7 @@ impl ISpeechPhraseReplacement_Vtbl {
             let this = (*this).get_impl();
             match this.FirstElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *firstelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(firstelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5415,7 +5415,7 @@ impl ISpeechPhraseReplacement_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfElements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numberofelements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numberofelements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5449,7 +5449,7 @@ impl ISpeechPhraseReplacements_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5460,7 +5460,7 @@ impl ISpeechPhraseReplacements_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *reps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5471,7 +5471,7 @@ impl ISpeechPhraseReplacements_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5509,7 +5509,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5520,7 +5520,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5531,7 +5531,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.FirstElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *firstelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(firstelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5542,7 +5542,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfElements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numberofelements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numberofelements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5553,7 +5553,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5564,7 +5564,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.Children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *children = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(children, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5575,7 +5575,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.Confidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *actualconfidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actualconfidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5586,7 +5586,7 @@ impl ISpeechPhraseRule_Vtbl {
             let this = (*this).get_impl();
             match this.EngineConfidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *engineconfidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(engineconfidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5624,7 +5624,7 @@ impl ISpeechPhraseRules_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5635,7 +5635,7 @@ impl ISpeechPhraseRules_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5646,7 +5646,7 @@ impl ISpeechPhraseRules_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5701,7 +5701,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.Recognizer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recognizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recognizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5712,7 +5712,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.AudioInputInterferenceStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5723,7 +5723,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedUIType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uitype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uitype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5739,7 +5739,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.Voice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *voice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(voice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5755,7 +5755,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.AllowVoiceFormatMatchingOnNextSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pallow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pallow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5771,7 +5771,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.VoicePurgeEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventinterest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventinterest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5787,7 +5787,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.EventInterests() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventinterest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventinterest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5803,7 +5803,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.CmdMaxAlternates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxalternates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxalternates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5819,7 +5819,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5835,7 +5835,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.RetainedAudio() {
                 ::core::result::Result::Ok(ok__) => {
-                    *option = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(option, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5851,7 +5851,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.RetainedAudioFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5872,7 +5872,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGrammar(::core::mem::transmute(&grammarid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *grammar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(grammar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5883,7 +5883,7 @@ impl ISpeechRecoContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateResultFromMemory(::core::mem::transmute_copy(&resultblock)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5964,7 +5964,7 @@ impl ISpeechRecoGrammar_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5975,7 +5975,7 @@ impl ISpeechRecoGrammar_Vtbl {
             let this = (*this).get_impl();
             match this.RecoContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recocontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recocontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5991,7 +5991,7 @@ impl ISpeechRecoGrammar_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6002,7 +6002,7 @@ impl ISpeechRecoGrammar_Vtbl {
             let this = (*this).get_impl();
             match this.Rules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6078,7 +6078,7 @@ impl ISpeechRecoGrammar_Vtbl {
             let this = (*this).get_impl();
             match this.IsPronounceable(::core::mem::transmute(&word)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *wordpronounceable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wordpronounceable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6134,7 +6134,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.RecoContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recocontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recocontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6145,7 +6145,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.Times() {
                 ::core::result::Result::Ok(ok__) => {
-                    *times = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(times, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6161,7 +6161,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.AudioFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6172,7 +6172,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.PhraseInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phraseinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phraseinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6183,7 +6183,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.Alternates(::core::mem::transmute_copy(&requestcount), ::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *alternates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(alternates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6194,7 +6194,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.Audio(::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6205,7 +6205,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.SpeakAudio(::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6216,7 +6216,7 @@ impl ISpeechRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.SaveToMemory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6291,7 +6291,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.RecoContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recocontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recocontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6302,7 +6302,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.Times() {
                 ::core::result::Result::Ok(ok__) => {
-                    *times = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(times, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6318,7 +6318,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.AudioFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6329,7 +6329,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.PhraseInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phraseinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phraseinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6340,7 +6340,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.Alternates(::core::mem::transmute_copy(&requestcount), ::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *alternates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(alternates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6351,7 +6351,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.Audio(::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6362,7 +6362,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.SpeakAudio(::core::mem::transmute_copy(&startelement), ::core::mem::transmute_copy(&elements), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6373,7 +6373,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.SaveToMemory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6389,7 +6389,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.GetXMLResult(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6443,7 +6443,7 @@ impl ISpeechRecoResultTimes_Vtbl {
             let this = (*this).get_impl();
             match this.StreamTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *time = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(time, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6454,7 +6454,7 @@ impl ISpeechRecoResultTimes_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6465,7 +6465,7 @@ impl ISpeechRecoResultTimes_Vtbl {
             let this = (*this).get_impl();
             match this.TickCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tickcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tickcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6476,7 +6476,7 @@ impl ISpeechRecoResultTimes_Vtbl {
             let this = (*this).get_impl();
             match this.OffsetFromStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offsetfromstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offsetfromstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6538,7 +6538,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Recognizer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recognizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recognizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6554,7 +6554,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.AllowAudioInputFormatChangesOnNextSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6570,7 +6570,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.AudioInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioinput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioinput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6586,7 +6586,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.AudioInputStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audioinputstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audioinputstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6597,7 +6597,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.IsShared() {
                 ::core::result::Result::Ok(ok__) => {
-                    *shared = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(shared, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6613,7 +6613,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6624,7 +6624,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6640,7 +6640,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *profile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(profile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6656,7 +6656,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRecoContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6667,7 +6667,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6678,7 +6678,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.SetPropertyNumber(::core::mem::transmute(&name), ::core::mem::transmute_copy(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6694,7 +6694,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.SetPropertyString(::core::mem::transmute(&name), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6710,7 +6710,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.IsUISupported(::core::mem::transmute(&typeofui), ::core::mem::transmute_copy(&extradata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6726,7 +6726,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecognizers(::core::mem::transmute(&requiredattributes), ::core::mem::transmute(&optionalattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objecttokens = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objecttokens, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6737,7 +6737,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioInputs(::core::mem::transmute(&requiredattributes), ::core::mem::transmute(&optionalattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objecttokens = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objecttokens, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6748,7 +6748,7 @@ impl ISpeechRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfiles(::core::mem::transmute(&requiredattributes), ::core::mem::transmute(&optionalattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objecttokens = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objecttokens, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6807,7 +6807,7 @@ impl ISpeechRecognizerStatus_Vtbl {
             let this = (*this).get_impl();
             match this.AudioStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiostatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiostatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6818,7 +6818,7 @@ impl ISpeechRecognizerStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentStreamPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcurrentstreampos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcurrentstreampos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6829,7 +6829,7 @@ impl ISpeechRecognizerStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentStreamNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6840,7 +6840,7 @@ impl ISpeechRecognizerStatus_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfActiveRules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numberofactiverules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numberofactiverules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6851,7 +6851,7 @@ impl ISpeechRecognizerStatus_Vtbl {
             let this = (*this).get_impl();
             match this.ClsidEngine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clsidengine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clsidengine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6862,7 +6862,7 @@ impl ISpeechRecognizerStatus_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedLanguages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedlanguages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedlanguages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6945,7 +6945,7 @@ impl ISpeechTextSelectionInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ActiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *activeoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(activeoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6961,7 +6961,7 @@ impl ISpeechTextSelectionInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ActiveLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *activelength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(activelength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6977,7 +6977,7 @@ impl ISpeechTextSelectionInformation_Vtbl {
             let this = (*this).get_impl();
             match this.SelectionOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selectionoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selectionoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6993,7 +6993,7 @@ impl ISpeechTextSelectionInformation_Vtbl {
             let this = (*this).get_impl();
             match this.SelectionLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selectionlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selectionlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7060,7 +7060,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7071,7 +7071,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Voice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *voice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(voice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7087,7 +7087,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.AudioOutput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiooutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiooutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7103,7 +7103,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.AudioOutputStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *audiooutputstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(audiooutputstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7119,7 +7119,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Rate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7135,7 +7135,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Volume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *volume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(volume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7156,7 +7156,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.AllowAudioOutputFormatChangesOnNextSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7167,7 +7167,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.EventInterests() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventinterestflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventinterestflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7188,7 +7188,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *priority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(priority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7204,7 +7204,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.AlertBoundary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *boundary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(boundary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7220,7 +7220,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.SynchronousSpeakTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mstimeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mstimeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7231,7 +7231,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Speak(::core::mem::transmute(&text), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7242,7 +7242,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.SpeakStream(::core::mem::transmute(&stream), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7263,7 +7263,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.Skip(::core::mem::transmute(&r#type), ::core::mem::transmute_copy(&numitems)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *numskipped = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numskipped, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7274,7 +7274,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.GetVoices(::core::mem::transmute(&requiredattributes), ::core::mem::transmute(&optionalattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objecttokens = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objecttokens, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7285,7 +7285,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioOutputs(::core::mem::transmute(&requiredattributes), ::core::mem::transmute(&optionalattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objecttokens = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objecttokens, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7296,7 +7296,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.WaitUntilDone(::core::mem::transmute_copy(&mstimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *done = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(done, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7307,7 +7307,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.SpeakCompleteEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7318,7 +7318,7 @@ impl ISpeechVoice_Vtbl {
             let this = (*this).get_impl();
             match this.IsUISupported(::core::mem::transmute(&typeofui), ::core::mem::transmute_copy(&extradata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7394,7 +7394,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentStreamNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7405,7 +7405,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.LastStreamNumberQueued() {
                 ::core::result::Result::Ok(ok__) => {
-                    *streamnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streamnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7416,7 +7416,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.LastHResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7427,7 +7427,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.RunningState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7438,7 +7438,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.InputWordPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *position = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(position, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7449,7 +7449,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.InputWordLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7460,7 +7460,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.InputSentencePosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *position = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(position, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7471,7 +7471,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.InputSentenceLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7482,7 +7482,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.LastBookmark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bookmark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bookmark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7493,7 +7493,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.LastBookmarkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bookmarkid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bookmarkid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7504,7 +7504,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.PhonemeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phoneid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phoneid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7515,7 +7515,7 @@ impl ISpeechVoiceStatus_Vtbl {
             let this = (*this).get_impl();
             match this.VisemeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visemeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visemeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7568,7 +7568,7 @@ impl ISpeechWaveFormatEx_Vtbl {
             let this = (*this).get_impl();
             match this.FormatTag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formattag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formattag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7584,7 +7584,7 @@ impl ISpeechWaveFormatEx_Vtbl {
             let this = (*this).get_impl();
             match this.Channels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *channels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(channels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7600,7 +7600,7 @@ impl ISpeechWaveFormatEx_Vtbl {
             let this = (*this).get_impl();
             match this.SamplesPerSec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *samplespersec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(samplespersec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7616,7 +7616,7 @@ impl ISpeechWaveFormatEx_Vtbl {
             let this = (*this).get_impl();
             match this.AvgBytesPerSec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *avgbytespersec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(avgbytespersec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7632,7 +7632,7 @@ impl ISpeechWaveFormatEx_Vtbl {
             let this = (*this).get_impl();
             match this.BlockAlign() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blockalign = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blockalign, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7648,7 +7648,7 @@ impl ISpeechWaveFormatEx_Vtbl {
             let this = (*this).get_impl();
             match this.BitsPerSample() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitspersample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitspersample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7664,7 +7664,7 @@ impl ISpeechWaveFormatEx_Vtbl {
             let this = (*this).get_impl();
             match this.ExtraData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *extradata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(extradata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7712,7 +7712,7 @@ impl ISpeechXMLRecoResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetXMLResult(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/Streaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Streaming/impl.rs
@@ -36,7 +36,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputAvailableType(::core::mem::transmute_copy(&dwinputstreamid), ::core::mem::transmute_copy(&dwtypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -47,7 +47,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCurrentType(::core::mem::transmute_copy(&dwinputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -58,7 +58,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStreamAttributes(::core::mem::transmute_copy(&dwinputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -69,7 +69,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputAvailableType(::core::mem::transmute_copy(&dwoutputstreamid), ::core::mem::transmute_copy(&dwtypeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -80,7 +80,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCurrentType(::core::mem::transmute_copy(&dwoutputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -91,7 +91,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamAttributes(::core::mem::transmute_copy(&dwoutputstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -137,7 +137,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputStreamState(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -153,7 +153,7 @@ impl IMFDeviceTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputStreamState(::core::mem::transmute_copy(&dwstreamid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
@@ -66,7 +66,7 @@ impl INSNetSourceCreator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetSourceProperties(::core::mem::transmute(&pszstreamname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertiesnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertiesnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -77,7 +77,7 @@ impl INSNetSourceCreator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetSourceSharedNamespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsharednamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsharednamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -88,7 +88,7 @@ impl INSNetSourceCreator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetSourceAdminInterface(::core::mem::transmute(&pszstreamname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -99,7 +99,7 @@ impl INSNetSourceCreator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumProtocolsSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcprotocols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcprotocols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -146,7 +146,7 @@ impl INSSBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -162,7 +162,7 @@ impl INSSBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -173,7 +173,7 @@ impl INSSBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdwbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdwbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -209,7 +209,7 @@ impl INSSBuffer2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSampleProperties(::core::mem::transmute_copy(&cbproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -269,7 +269,7 @@ impl INSSBuffer4_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbufferproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbufferproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -304,7 +304,7 @@ impl IWMAddressAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccessEntryCount(::core::mem::transmute_copy(&aetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcentries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcentries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -315,7 +315,7 @@ impl IWMAddressAccess_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccessEntry(::core::mem::transmute_copy(&aetype), ::core::mem::transmute_copy(&dwentrynum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *paddraccessentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paddraccessentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -386,7 +386,7 @@ impl IWMAuthorizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccerts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccerts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -397,7 +397,7 @@ impl IWMAuthorizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCert(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbcertdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbcertdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -408,7 +408,7 @@ impl IWMAuthorizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetSharedData(::core::mem::transmute_copy(&dwcertindex), ::core::mem::transmute_copy(&pbshareddata), ::core::mem::transmute_copy(&pbcert)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbshareddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbshareddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -441,7 +441,7 @@ impl IWMBackupRestoreProps_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -500,7 +500,7 @@ impl IWMBandwidthSharing_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -545,7 +545,7 @@ impl IWMClientConnections_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcclients = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcclients, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IWMClientConnections_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientProperties(::core::mem::transmute_copy(&dwclientnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclientproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclientproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -639,7 +639,7 @@ impl IWMCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodecInfoCount(::core::mem::transmute_copy(&guidtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccodecs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccodecs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -650,7 +650,7 @@ impl IWMCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodecFormatCount(::core::mem::transmute_copy(&guidtype), ::core::mem::transmute_copy(&dwcodecindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -661,7 +661,7 @@ impl IWMCodecInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodecFormat(::core::mem::transmute_copy(&guidtype), ::core::mem::transmute_copy(&dwcodecindex), ::core::mem::transmute_copy(&dwformatindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppistreamconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppistreamconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -984,7 +984,7 @@ impl IWMDRMTranscryptionManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTranscryptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptranscryptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptranscryptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1067,7 +1067,7 @@ impl IWMDRMTranscryptor2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSeekStartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcnstime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcnstime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1078,7 +1078,7 @@ impl IWMDRMTranscryptor2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcnsduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcnsduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1193,7 +1193,7 @@ impl IWMDeviceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterDevice(::core::mem::transmute_copy(&dwregistertype), ::core::mem::transmute_copy(&pbcertificate), ::core::mem::transmute_copy(&cbcertificate), ::core::mem::transmute(&serialnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1209,7 +1209,7 @@ impl IWMDeviceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegistrationStats(::core::mem::transmute_copy(&dwregistertype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcregistereddevices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcregistereddevices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1220,7 +1220,7 @@ impl IWMDeviceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstRegisteredDevice(::core::mem::transmute_copy(&dwregistertype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1231,7 +1231,7 @@ impl IWMDeviceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextRegisteredDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1242,7 +1242,7 @@ impl IWMDeviceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegisteredDeviceByID(::core::mem::transmute_copy(&dwregistertype), ::core::mem::transmute_copy(&pbcertificate), ::core::mem::transmute_copy(&cbcertificate), ::core::mem::transmute(&serialnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1273,7 +1273,7 @@ impl IWMGetSecureChannel_Vtbl {
             let this = (*this).get_impl();
             match this.GetPeerSecureChannelInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppeer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppeer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1310,7 +1310,7 @@ impl IWMHeaderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeCount(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1336,7 +1336,7 @@ impl IWMHeaderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMarkerCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmarkers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmarkers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1362,7 +1362,7 @@ impl IWMHeaderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetScriptCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcscripts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcscripts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1415,7 +1415,7 @@ impl IWMHeaderInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodecInfoCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccodecinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccodecinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1453,7 +1453,7 @@ impl IWMHeaderInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeCountEx(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1533,7 +1533,7 @@ impl IWMImageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcimages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcimages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1641,7 +1641,7 @@ impl IWMLanguageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguageCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1657,7 +1657,7 @@ impl IWMLanguageList_Vtbl {
             let this = (*this).get_impl();
             match this.AddLanguageByRFC1766String(::core::mem::transmute(&pwszlanguagestring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1771,7 +1771,7 @@ impl IWMMediaProps_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1861,7 +1861,7 @@ impl IWMMutualExclusion_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1912,7 +1912,7 @@ impl IWMMutualExclusion2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwrecordcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwrecordcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2013,7 +2013,7 @@ impl IWMPacketSize_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxPacketSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxpacketsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxpacketsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2046,7 +2046,7 @@ impl IWMPacketSize2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinPacketSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwminpacketsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwminpacketsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2095,7 +2095,7 @@ impl IWMPlayerTimestampHook_Vtbl {
             let this = (*this).get_impl();
             match this.MapTimestamp(::core::mem::transmute_copy(&rtin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prtout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prtout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2135,7 +2135,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2166,7 +2166,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstreams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstreams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2177,7 +2177,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream(::core::mem::transmute_copy(&dwstreamindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2188,7 +2188,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamByNumber(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2219,7 +2219,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNewStream(::core::mem::transmute_copy(&guidstreamtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconfig = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconfig, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2230,7 +2230,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetMutualExclusionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcme = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcme, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2241,7 +2241,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetMutualExclusion(::core::mem::transmute_copy(&dwmeindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppme = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppme, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2262,7 +2262,7 @@ impl IWMProfile_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNewMutualExclusion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppme = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppme, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2305,7 +2305,7 @@ impl IWMProfile2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfileID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2339,7 +2339,7 @@ impl IWMProfile3_Vtbl {
             let this = (*this).get_impl();
             match this.GetStorageFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnstorageformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnstorageformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2355,7 +2355,7 @@ impl IWMProfile3_Vtbl {
             let this = (*this).get_impl();
             match this.GetBandwidthSharingCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2366,7 +2366,7 @@ impl IWMProfile3_Vtbl {
             let this = (*this).get_impl();
             match this.GetBandwidthSharing(::core::mem::transmute_copy(&dwbsindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2387,7 +2387,7 @@ impl IWMProfile3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNewBandwidthSharing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2398,7 +2398,7 @@ impl IWMProfile3_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamPrioritization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2419,7 +2419,7 @@ impl IWMProfile3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNewStreamPrioritization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2430,7 +2430,7 @@ impl IWMProfile3_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpectedPacketCount(::core::mem::transmute_copy(&msduration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcpackets = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcpackets, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2472,7 +2472,7 @@ impl IWMProfileManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEmptyProfile(::core::mem::transmute_copy(&dwversion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2483,7 +2483,7 @@ impl IWMProfileManager_Vtbl {
             let this = (*this).get_impl();
             match this.LoadProfileByID(::core::mem::transmute_copy(&guidprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2494,7 +2494,7 @@ impl IWMProfileManager_Vtbl {
             let this = (*this).get_impl();
             match this.LoadProfileByData(::core::mem::transmute(&pwszprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2510,7 +2510,7 @@ impl IWMProfileManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemProfileCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcprofiles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcprofiles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2521,7 +2521,7 @@ impl IWMProfileManager_Vtbl {
             let this = (*this).get_impl();
             match this.LoadSystemProfile(::core::mem::transmute_copy(&dwprofileindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2698,7 +2698,7 @@ impl IWMReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcoutputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcoutputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2709,7 +2709,7 @@ impl IWMReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputProps(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2725,7 +2725,7 @@ impl IWMReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputFormatCount(::core::mem::transmute_copy(&dwoutputnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2736,7 +2736,7 @@ impl IWMReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputFormat(::core::mem::transmute_copy(&dwoutputnumber), ::core::mem::transmute_copy(&dwformatnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2849,7 +2849,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserProvidedClock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfuserclock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfuserclock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2870,7 +2870,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetManualStreamSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfselection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfselection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2886,7 +2886,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSelected(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pselection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pselection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2902,7 +2902,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetReceiveSelectionCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfgetcallbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfgetcallbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2918,7 +2918,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetReceiveStreamSamples(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfreceivestreamsamples = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfreceivestreamsamples, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2934,7 +2934,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocateForOutput(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallocate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallocate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2950,7 +2950,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocateForStream(::core::mem::transmute_copy(&dwsreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallocate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallocate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2971,7 +2971,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxOutputSampleSize(::core::mem::transmute_copy(&dwoutput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2982,7 +2982,7 @@ impl IWMReaderAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxStreamSampleSize(::core::mem::transmute_copy(&wstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3054,7 +3054,7 @@ impl IWMReaderAdvanced2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPlayMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3075,7 +3075,7 @@ impl IWMReaderAdvanced2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSaveAsProgress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwpercent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwpercent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3121,7 +3121,7 @@ impl IWMReaderAdvanced2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogClientID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflogclientid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflogclientid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3212,7 +3212,7 @@ impl IWMReaderAdvanced4_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguageCount(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwlanguagecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwlanguagecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3228,7 +3228,7 @@ impl IWMReaderAdvanced4_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxSpeedFactor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdblfactor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdblfactor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3239,7 +3239,7 @@ impl IWMReaderAdvanced4_Vtbl {
             let this = (*this).get_impl();
             match this.IsUsingFastCache() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfusingfastcache = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfusingfastcache, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3260,7 +3260,7 @@ impl IWMReaderAdvanced4_Vtbl {
             let this = (*this).get_impl();
             match this.CanSaveFileAs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcansave = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcansave, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3481,7 +3481,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetBufferingTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcnsbufferingtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcnsbufferingtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3507,7 +3507,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetProxySettings(::core::mem::transmute(&pwszprotocol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproxysetting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproxysetting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3533,7 +3533,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetProxyPort(::core::mem::transmute(&pwszprotocol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3559,7 +3559,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetProxyBypassForLocal(::core::mem::transmute(&pwszprotocol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfbypassforlocal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfbypassforlocal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3575,7 +3575,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetForceRerunAutoProxyDetection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfforcererundetection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfforcererundetection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3591,7 +3591,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableMulticast() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenablemulticast = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenablemulticast, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3607,7 +3607,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableHTTP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenablehttp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenablehttp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3623,7 +3623,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableUDP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenableudp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenableudp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3639,7 +3639,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableTCP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabletcp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabletcp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3660,7 +3660,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionBandwidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconnectionbandwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconnectionbandwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3676,7 +3676,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumProtocolsSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcprotocols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcprotocols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3702,7 +3702,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetLoggingUrlCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwurlcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwurlcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3780,7 +3780,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableContentCaching() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenablecontentcaching = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenablecontentcaching, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3796,7 +3796,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableFastCache() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenablefastcache = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenablefastcache, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3812,7 +3812,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAcceleratedStreamingDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcnsaccelduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcnsaccelduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3828,7 +3828,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutoReconnectLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwautoreconnectlimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwautoreconnectlimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3844,7 +3844,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableResends() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenableresends = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenableresends, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3860,7 +3860,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnableThinning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenablethinning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenablethinning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3876,7 +3876,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxNetPacketSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxnetpacketsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxnetpacketsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3922,7 +3922,7 @@ impl IWMReaderPlaylistBurn_Vtbl {
             let this = (*this).get_impl();
             match this.GetInitResults(::core::mem::transmute_copy(&cfiles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrstati = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrstati, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3968,7 +3968,7 @@ impl IWMReaderStreamClock_Vtbl {
             let this = (*this).get_impl();
             match this.SetTimer(::core::mem::transmute_copy(&cnswhen), ::core::mem::transmute_copy(&pvparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtimerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtimerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4002,7 +4002,7 @@ impl IWMReaderTimecode_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimecodeRangeCount(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwrangecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwrangecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4094,7 +4094,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceSerialNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pserialnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pserialnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4105,7 +4105,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcertificate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcertificate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4116,7 +4116,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4127,7 +4127,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4143,7 +4143,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeByName(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4164,7 +4164,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IsValid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4175,7 +4175,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IsApproved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfapproved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfapproved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4186,7 +4186,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IsWmdrmCompliant() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcompliant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcompliant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4197,7 +4197,7 @@ impl IWMRegisteredDevice_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpened() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfopened = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfopened, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4247,7 +4247,7 @@ impl IWMSBufferAllocator_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateBuffer(::core::mem::transmute_copy(&dwmaxbuffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4258,7 +4258,7 @@ impl IWMSBufferAllocator_Vtbl {
             let this = (*this).get_impl();
             match this.AllocatePageSizeBuffer(::core::mem::transmute_copy(&dwmaxbuffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4303,7 +4303,7 @@ impl IWMSInternalAdminNetSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetSourceCreator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetsourcecreator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetsourcecreator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4329,7 +4329,7 @@ impl IWMSInternalAdminNetSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetCredentialFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4360,7 +4360,7 @@ impl IWMSInternalAdminNetSource_Vtbl {
             let this = (*this).get_impl();
             match this.IsUsingIE(::core::mem::transmute_copy(&dwproxycontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisusingie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisusingie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4449,7 +4449,7 @@ impl IWMSInternalAdminNetSource3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetSourceCreator2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetsourcecreator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetsourcecreator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4475,7 +4475,7 @@ impl IWMSInternalAdminNetSource3_Vtbl {
             let this = (*this).get_impl();
             match this.IsUsingIE2(::core::mem::transmute_copy(&qwproxycontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisusingie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisusingie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4545,7 +4545,7 @@ impl IWMSecureChannel_Vtbl {
             let this = (*this).get_impl();
             match this.WMSC_IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4643,7 +4643,7 @@ impl IWMStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidstreamtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidstreamtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4654,7 +4654,7 @@ impl IWMStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwstreamnum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwstreamnum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4690,7 +4690,7 @@ impl IWMStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitrate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwbitrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwbitrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4706,7 +4706,7 @@ impl IWMStreamConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetBufferWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmsbufferwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmsbufferwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4752,7 +4752,7 @@ impl IWMStreamConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransportType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pntransporttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pntransporttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4773,7 +4773,7 @@ impl IWMStreamConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataUnitExtensionCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcdataunitextensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcdataunitextensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4958,7 +4958,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamSelected(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pselection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pselection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4974,7 +4974,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetReadStreamSamples(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcompressed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcompressed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4995,7 +4995,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcoutputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcoutputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5006,7 +5006,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputProps(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5022,7 +5022,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputFormatCount(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5033,7 +5033,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputFormat(::core::mem::transmute_copy(&dwoutputnum), ::core::mem::transmute_copy(&dwformatnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5044,7 +5044,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputNumberForStream(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwoutputnum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwoutputnum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5055,7 +5055,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreamNumberForOutput(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwstreamnum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwstreamnum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5066,7 +5066,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxOutputSampleSize(::core::mem::transmute_copy(&dwoutput)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5077,7 +5077,7 @@ impl IWMSyncReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxStreamSampleSize(::core::mem::transmute_copy(&wstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5141,7 +5141,7 @@ impl IWMSyncReader2_Vtbl {
             let this = (*this).get_impl();
             match this.SetRangeByFrameEx(::core::mem::transmute_copy(&wstreamnum), ::core::mem::transmute_copy(&qwframenumber), ::core::mem::transmute_copy(&cframestoread)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcnsstarttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcnsstarttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5157,7 +5157,7 @@ impl IWMSyncReader2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocateForOutput(::core::mem::transmute_copy(&dwoutputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppallocator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppallocator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5173,7 +5173,7 @@ impl IWMSyncReader2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocateForStream(::core::mem::transmute_copy(&dwsreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppallocator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppallocator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5210,7 +5210,7 @@ impl IWMVideoMediaProps_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxKeyFrameSpacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plltime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plltime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5226,7 +5226,7 @@ impl IWMVideoMediaProps_Vtbl {
             let this = (*this).get_impl();
             match this.GetQuality() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwquality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwquality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5261,7 +5261,7 @@ impl IWMWatermarkInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetWatermarkEntryCount(::core::mem::transmute_copy(&wmettype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5272,7 +5272,7 @@ impl IWMWatermarkInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetWatermarkEntry(::core::mem::transmute_copy(&wmettype), ::core::mem::transmute_copy(&dwentrynum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5326,7 +5326,7 @@ impl IWMWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcinputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcinputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5337,7 +5337,7 @@ impl IWMWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputProps(::core::mem::transmute_copy(&dwinputnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5353,7 +5353,7 @@ impl IWMWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputFormatCount(::core::mem::transmute_copy(&dwinputnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5364,7 +5364,7 @@ impl IWMWriter_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputFormat(::core::mem::transmute_copy(&dwinputnumber), ::core::mem::transmute_copy(&dwformatnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5385,7 +5385,7 @@ impl IWMWriter_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateSample(::core::mem::transmute_copy(&dwsamplesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsample = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsample, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5446,7 +5446,7 @@ impl IWMWriterAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetSinkCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcsinks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcsinks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5457,7 +5457,7 @@ impl IWMWriterAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetSink(::core::mem::transmute_copy(&dwsinknum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5488,7 +5488,7 @@ impl IWMWriterAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.IsRealTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrealtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrealtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5499,7 +5499,7 @@ impl IWMWriterAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetWriterTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcnscurrenttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcnscurrenttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5510,7 +5510,7 @@ impl IWMWriterAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatistics(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5526,7 +5526,7 @@ impl IWMWriterAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncTolerance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmswindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmswindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5596,7 +5596,7 @@ impl IWMWriterAdvanced3_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatisticsEx(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5667,7 +5667,7 @@ impl IWMWriterFileSink2_Vtbl {
             let this = (*this).get_impl();
             match this.IsStopped() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfstopped = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfstopped, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5678,7 +5678,7 @@ impl IWMWriterFileSink2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcnsduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcnsduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5689,7 +5689,7 @@ impl IWMWriterFileSink2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5705,7 +5705,7 @@ impl IWMWriterFileSink2_Vtbl {
             let this = (*this).get_impl();
             match this.IsClosed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfclosed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfclosed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5752,7 +5752,7 @@ impl IWMWriterFileSink3_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutoIndexing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfautoindexing = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfautoindexing, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5768,7 +5768,7 @@ impl IWMWriterFileSink3_Vtbl {
             let this = (*this).get_impl();
             match this.GetMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwfilesinkmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwfilesinkmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5789,7 +5789,7 @@ impl IWMWriterFileSink3_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnbufferedIO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfunbufferedio = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfunbufferedio, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5842,7 +5842,7 @@ impl IWMWriterNetworkSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumClients() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxclients = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxclients, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5858,7 +5858,7 @@ impl IWMWriterNetworkSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkProtocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotocol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotocol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5932,7 +5932,7 @@ impl IWMWriterPostView_Vtbl {
             let this = (*this).get_impl();
             match this.GetReceivePostViewSamples(::core::mem::transmute_copy(&wstreamnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfreceivepostviewsamples = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfreceivepostviewsamples, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5943,7 +5943,7 @@ impl IWMWriterPostView_Vtbl {
             let this = (*this).get_impl();
             match this.GetPostViewProps(::core::mem::transmute_copy(&wstreamnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoutput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoutput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5959,7 +5959,7 @@ impl IWMWriterPostView_Vtbl {
             let this = (*this).get_impl();
             match this.GetPostViewFormatCount(::core::mem::transmute_copy(&wstreamnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5970,7 +5970,7 @@ impl IWMWriterPostView_Vtbl {
             let this = (*this).get_impl();
             match this.GetPostViewFormat(::core::mem::transmute_copy(&wstreamnumber), ::core::mem::transmute_copy(&dwformatnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5986,7 +5986,7 @@ impl IWMWriterPostView_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllocateForPostView(::core::mem::transmute_copy(&wstreamnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallocate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallocate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6051,7 +6051,7 @@ impl IWMWriterPreprocess_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxPreprocessingPasses(::core::mem::transmute_copy(&dwinputnum), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxnumpasses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxnumpasses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6150,7 +6150,7 @@ impl IWMWriterSink_Vtbl {
             let this = (*this).get_impl();
             match this.IsRealTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrealtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrealtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6161,7 +6161,7 @@ impl IWMWriterSink_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateDataUnit(::core::mem::transmute_copy(&cbdataunit)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataunit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataunit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/impl.rs
@@ -15,7 +15,7 @@ impl IReferenceClock_Vtbl {
             let this = (*this).get_impl();
             match this.GetTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26,7 +26,7 @@ impl IReferenceClock_Vtbl {
             let this = (*this).get_impl();
             match this.AdviseTime(::core::mem::transmute_copy(&basetime), ::core::mem::transmute_copy(&streamtime), ::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwadvisecookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwadvisecookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37,7 +37,7 @@ impl IReferenceClock_Vtbl {
             let this = (*this).get_impl();
             match this.AdvisePeriodic(::core::mem::transmute_copy(&starttime), ::core::mem::transmute_copy(&periodtime), ::core::mem::transmute_copy(&hsemaphore)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwadvisecookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwadvisecookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -90,7 +90,7 @@ impl IReferenceClockTimerControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultTimerResolution() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimerresolution = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimerresolution, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
@@ -31,7 +31,7 @@ impl IMbnConnection_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *connectionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(connectionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IMbnConnection_Vtbl {
             let this = (*this).get_impl();
             match this.InterfaceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interfaceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interfaceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -53,7 +53,7 @@ impl IMbnConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Connect(::core::mem::transmute_copy(&connectionmode), ::core::mem::transmute(&strprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -64,7 +64,7 @@ impl IMbnConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Disconnect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -80,7 +80,7 @@ impl IMbnConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetVoiceCallState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *voicecallstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(voicecallstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -91,7 +91,7 @@ impl IMbnConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivationNetworkError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *networkerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(networkerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -127,7 +127,7 @@ impl IMbnConnectionContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetProvisionedContexts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *provisionedcontexts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(provisionedcontexts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -138,7 +138,7 @@ impl IMbnConnectionContext_Vtbl {
             let this = (*this).get_impl();
             match this.SetProvisionedContext(::core::mem::transmute(&provisionedcontexts), ::core::mem::transmute(&providerid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -237,7 +237,7 @@ impl IMbnConnectionManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnection(::core::mem::transmute(&connectionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mbnconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mbnconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -248,7 +248,7 @@ impl IMbnConnectionManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mbnconnections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mbnconnections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -307,7 +307,7 @@ impl IMbnConnectionProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfileXmlData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *profiledata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(profiledata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -367,7 +367,7 @@ impl IMbnConnectionProfileManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionProfiles(::core::mem::transmute(&mbninterface)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *connectionprofiles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(connectionprofiles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -378,7 +378,7 @@ impl IMbnConnectionProfileManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionProfile(::core::mem::transmute(&mbninterface), ::core::mem::transmute(&profilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *connectionprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(connectionprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -452,7 +452,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySupportedCommands() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -463,7 +463,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.OpenCommandSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -474,7 +474,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.CloseCommandSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -485,7 +485,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.SetCommand(::core::mem::transmute_copy(&commandid), ::core::mem::transmute_copy(&deviceservicedata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -496,7 +496,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.QueryCommand(::core::mem::transmute_copy(&commandid), ::core::mem::transmute_copy(&deviceservicedata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -507,7 +507,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.OpenDataSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -518,7 +518,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.CloseDataSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -529,7 +529,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.WriteData(::core::mem::transmute_copy(&deviceservicedata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.InterfaceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interfaceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interfaceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -551,7 +551,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceServiceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deviceserviceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deviceserviceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -562,7 +562,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.IsCommandSessionOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -573,7 +573,7 @@ impl IMbnDeviceService_Vtbl {
             let this = (*this).get_impl();
             match this.IsDataSessionOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -636,7 +636,7 @@ impl IMbnDeviceServicesContext_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateDeviceServices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deviceservices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deviceservices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -647,7 +647,7 @@ impl IMbnDeviceServicesContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceService(::core::mem::transmute(&deviceserviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mbndeviceservice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mbndeviceservice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl IMbnDeviceServicesContext_Vtbl {
             let this = (*this).get_impl();
             match this.MaxCommandSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxcommandsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxcommandsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl IMbnDeviceServicesContext_Vtbl {
             let this = (*this).get_impl();
             match this.MaxDataSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxdatasize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxdatasize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -794,7 +794,7 @@ impl IMbnDeviceServicesManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceServicesContext(::core::mem::transmute(&networkinterfaceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mbndevicescontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mbndevicescontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -830,7 +830,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.InterfaceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interfaceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interfaceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -841,7 +841,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterfaceCapability() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interfacecaps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interfacecaps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -852,7 +852,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscriberInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *subscriberinformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subscriberinformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -863,7 +863,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetReadyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *readystate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(readystate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -874,7 +874,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.InEmergencyMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *emergencymode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(emergencymode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -885,7 +885,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetHomeProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *homeprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(homeprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -896,7 +896,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preferredproviders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preferredproviders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -907,7 +907,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.SetPreferredProviders(::core::mem::transmute_copy(&preferredproviders)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -923,7 +923,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.ScanNetwork() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -934,7 +934,7 @@ impl IMbnInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mbnconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mbnconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1043,7 +1043,7 @@ impl IMbnInterfaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterface(::core::mem::transmute(&interfaceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mbninterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mbninterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1054,7 +1054,7 @@ impl IMbnInterfaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mbninterfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mbninterfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1116,7 +1116,7 @@ impl IMbnMultiCarrier_Vtbl {
             let this = (*this).get_impl();
             match this.SetHomeProvider(::core::mem::transmute_copy(&homeprovider)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1127,7 +1127,7 @@ impl IMbnMultiCarrier_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preferredmulticarrierproviders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preferredmulticarrierproviders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1143,7 +1143,7 @@ impl IMbnMultiCarrier_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedCellularClasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cellularclasses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cellularclasses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1154,7 +1154,7 @@ impl IMbnMultiCarrier_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentCellularClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentcellularclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentcellularclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1165,7 +1165,7 @@ impl IMbnMultiCarrier_Vtbl {
             let this = (*this).get_impl();
             match this.ScanNetwork() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1254,7 +1254,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.PinType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pintype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pintype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1265,7 +1265,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.PinFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1276,7 +1276,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.PinLengthMin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinlengthmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinlengthmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1287,7 +1287,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.PinLengthMax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinlengthmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinlengthmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1298,7 +1298,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.PinMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1309,7 +1309,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.Enable(::core::mem::transmute(&pin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1320,7 +1320,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.Disable(::core::mem::transmute(&pin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1331,7 +1331,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.Enter(::core::mem::transmute(&pin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1342,7 +1342,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.Change(::core::mem::transmute(&pin), ::core::mem::transmute(&newpin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1353,7 +1353,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.Unblock(::core::mem::transmute(&puk), ::core::mem::transmute(&newpin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1364,7 +1364,7 @@ impl IMbnPin_Vtbl {
             let this = (*this).get_impl();
             match this.GetPinManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1453,7 +1453,7 @@ impl IMbnPinManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetPinList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1464,7 +1464,7 @@ impl IMbnPinManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetPin(::core::mem::transmute_copy(&pintype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1475,7 +1475,7 @@ impl IMbnPinManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetPinState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1532,7 +1532,7 @@ impl IMbnRadio_Vtbl {
             let this = (*this).get_impl();
             match this.SoftwareRadioState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *softwareradiostate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(softwareradiostate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1543,7 +1543,7 @@ impl IMbnRadio_Vtbl {
             let this = (*this).get_impl();
             match this.HardwareRadioState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hardwareradiostate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hardwareradiostate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1554,7 +1554,7 @@ impl IMbnRadio_Vtbl {
             let this = (*this).get_impl();
             match this.SetSoftwareRadioState(::core::mem::transmute_copy(&radiostate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1621,7 +1621,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegisterState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *registerstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(registerstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1632,7 +1632,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegisterMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *registermode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(registermode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1643,7 +1643,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *providerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(providerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1654,7 +1654,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *providername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(providername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1665,7 +1665,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetRoamingText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *roamingtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(roamingtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1676,7 +1676,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableDataClasses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *availabledataclasses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(availabledataclasses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1687,7 +1687,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentDataClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentdataclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentdataclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1698,7 +1698,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegistrationNetworkError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *registrationnetworkerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(registrationnetworkerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1709,7 +1709,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetPacketAttachNetworkError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packetattachnetworkerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packetattachnetworkerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1720,7 +1720,7 @@ impl IMbnRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.SetRegisterMode(::core::mem::transmute_copy(&registermode), ::core::mem::transmute(&providerid), ::core::mem::transmute_copy(&dataclass)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1799,7 +1799,7 @@ impl IMbnServiceActivation_Vtbl {
             let this = (*this).get_impl();
             match this.Activate(::core::mem::transmute_copy(&vendorspecificdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1843,7 +1843,7 @@ impl IMbnSignal_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignalStrength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signalstrength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signalstrength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1854,7 +1854,7 @@ impl IMbnSignal_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignalError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signalerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signalerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1908,7 +1908,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.GetSmsConfiguration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *smsconfiguration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(smsconfiguration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1919,7 +1919,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.SetSmsConfiguration(::core::mem::transmute(&smsconfiguration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1930,7 +1930,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.SmsSendPdu(::core::mem::transmute(&pdudata), ::core::mem::transmute_copy(&size)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1941,7 +1941,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.SmsSendCdma(::core::mem::transmute(&address), ::core::mem::transmute_copy(&encoding), ::core::mem::transmute_copy(&language), ::core::mem::transmute_copy(&sizeincharacters), ::core::mem::transmute_copy(&message)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1952,7 +1952,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.SmsSendCdmaPdu(::core::mem::transmute_copy(&message)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1963,7 +1963,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.SmsRead(::core::mem::transmute_copy(&smsfilter), ::core::mem::transmute_copy(&smsformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1974,7 +1974,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.SmsDelete(::core::mem::transmute_copy(&smsfilter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1985,7 +1985,7 @@ impl IMbnSms_Vtbl {
             let this = (*this).get_impl();
             match this.GetSmsStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *smsstatusinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(smsstatusinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2026,7 +2026,7 @@ impl IMbnSmsConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceCenterAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2042,7 +2042,7 @@ impl IMbnSmsConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.MaxMessageIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2053,7 +2053,7 @@ impl IMbnSmsConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.CdmaShortMsgSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *shortmsgsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(shortmsgsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2064,7 +2064,7 @@ impl IMbnSmsConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SmsFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *smsformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(smsformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2171,7 +2171,7 @@ impl IMbnSmsReadMsgPdu_Vtbl {
             let this = (*this).get_impl();
             match this.Index() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2182,7 +2182,7 @@ impl IMbnSmsReadMsgPdu_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2193,7 +2193,7 @@ impl IMbnSmsReadMsgPdu_Vtbl {
             let this = (*this).get_impl();
             match this.PduData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdudata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdudata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2204,7 +2204,7 @@ impl IMbnSmsReadMsgPdu_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *message = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(message, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2243,7 +2243,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.Index() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2254,7 +2254,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2265,7 +2265,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *address = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(address, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2276,7 +2276,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.Timestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timestamp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timestamp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2287,7 +2287,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.EncodingID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *encodingid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(encodingid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2298,7 +2298,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *languageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(languageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2309,7 +2309,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.SizeInCharacters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sizeincharacters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sizeincharacters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2320,7 +2320,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *message = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(message, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2358,7 +2358,7 @@ impl IMbnSubscriberInformation_Vtbl {
             let this = (*this).get_impl();
             match this.SubscriberID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *subscriberid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subscriberid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2369,7 +2369,7 @@ impl IMbnSubscriberInformation_Vtbl {
             let this = (*this).get_impl();
             match this.SimIccID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *simiccid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(simiccid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2380,7 +2380,7 @@ impl IMbnSubscriberInformation_Vtbl {
             let this = (*this).get_impl();
             match this.TelephoneNumbers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *telephonenumbers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(telephonenumbers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2441,7 +2441,7 @@ impl IMbnVendorSpecificOperation_Vtbl {
             let this = (*this).get_impl();
             match this.SetVendorSpecific(::core::mem::transmute_copy(&vendorspecificdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
@@ -27,7 +27,7 @@ impl IEnumNetCfgBindingInterface_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -74,7 +74,7 @@ impl IEnumNetCfgBindingPath_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -121,7 +121,7 @@ impl IEnumNetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -176,7 +176,7 @@ impl INetCfg_Vtbl {
             let this = (*this).get_impl();
             match this.EnumComponents(::core::mem::transmute_copy(&pguidclass)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -187,7 +187,7 @@ impl INetCfg_Vtbl {
             let this = (*this).get_impl();
             match this.FindComponent(::core::mem::transmute(&pszwinfid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -226,7 +226,7 @@ impl INetCfgBindingInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwinterfacename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwinterfacename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -237,7 +237,7 @@ impl INetCfgBindingInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpperComponent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnccitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnccitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -248,7 +248,7 @@ impl INetCfgBindingInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetLowerComponent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnccitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnccitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -306,7 +306,7 @@ impl INetCfgBindingPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetPathToken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwpathtoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwpathtoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl INetCfgBindingPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -328,7 +328,7 @@ impl INetCfgBindingPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcinterfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcinterfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -339,7 +339,7 @@ impl INetCfgBindingPath_Vtbl {
             let this = (*this).get_impl();
             match this.EnumBindingInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenuminterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenuminterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -373,7 +373,7 @@ impl INetCfgClass_Vtbl {
             let this = (*this).get_impl();
             match this.FindComponent(::core::mem::transmute(&pszwinfid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnccitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnccitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -384,7 +384,7 @@ impl INetCfgClass_Vtbl {
             let this = (*this).get_impl();
             match this.EnumComponents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -416,7 +416,7 @@ impl INetCfgClassSetup_Vtbl {
             let this = (*this).get_impl();
             match this.SelectAndInstall(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&pobotoken)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnccitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnccitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -427,7 +427,7 @@ impl INetCfgClassSetup_Vtbl {
             let this = (*this).get_impl();
             match this.Install(::core::mem::transmute(&pszwinfid), ::core::mem::transmute_copy(&pobotoken), ::core::mem::transmute_copy(&dwsetupflags), ::core::mem::transmute_copy(&dwupgradefrombuildno), ::core::mem::transmute(&pszwanswerfile), ::core::mem::transmute(&pszwanswersections)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnccitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnccitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -497,7 +497,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -513,7 +513,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelpText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszwhelptext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszwhelptext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -524,7 +524,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -535,7 +535,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharacteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcharacteristics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcharacteristics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -546,7 +546,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -557,7 +557,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetPnpDevNodeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwdevnodeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwdevnodeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -568,7 +568,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetClassGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -579,7 +579,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetBindName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwbindname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwbindname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -590,7 +590,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -601,7 +601,7 @@ impl INetCfgComponent_Vtbl {
             let this = (*this).get_impl();
             match this.OpenParamKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -675,7 +675,7 @@ impl INetCfgComponentBindings_Vtbl {
             let this = (*this).get_impl();
             match this.EnumBindingPaths(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -792,7 +792,7 @@ impl INetCfgComponentNotifyGlobal_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedNotifications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwnotifications = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwnotifications, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -964,7 +964,7 @@ impl INetCfgLock_Vtbl {
             let this = (*this).get_impl();
             match this.AcquireWriteLock(::core::mem::transmute_copy(&cmstimeout), ::core::mem::transmute(&pszwclientdescription)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwclientdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwclientdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -980,7 +980,7 @@ impl INetCfgLock_Vtbl {
             let this = (*this).get_impl();
             match this.IsWriteLocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwclientdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwclientdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1069,7 +1069,7 @@ impl INetLanConnectionUiInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1095,7 +1095,7 @@ impl INetRasConnectionIpUiInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetUiInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1127,7 +1127,7 @@ impl IProvisioningDomain_Vtbl {
             let this = (*this).get_impl();
             match this.Query(::core::mem::transmute(&pszwdomain), ::core::mem::transmute(&pszwlanguage), ::core::mem::transmute(&pszwxpathquery)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1153,7 +1153,7 @@ impl IProvisioningProfileWireless_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProfile(::core::mem::transmute(&bstrxmlwirelessconfigprofile), ::core::mem::transmute(&bstrxmlconnectionconfigprofile), ::core::mem::transmute_copy(&padapterinstanceguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
@@ -54,7 +54,7 @@ impl INetDiagHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetDiagnosticsInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -115,7 +115,7 @@ impl INetDiagHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetLifeTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plifetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plifetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -131,7 +131,7 @@ impl INetDiagHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetCacheTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcachetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcachetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
@@ -18,7 +18,7 @@ impl ISdo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyInfo(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29,7 +29,7 @@ impl ISdo_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -60,7 +60,7 @@ impl ISdo_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -102,7 +102,7 @@ impl ISdoCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl ISdoCollection_Vtbl {
             let this = (*this).get_impl();
             match this.IsNameUnique(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -144,7 +144,7 @@ impl ISdoCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -155,7 +155,7 @@ impl ISdoCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -200,7 +200,7 @@ impl ISdoDictionaryOld_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeInfo(::core::mem::transmute_copy(&id), ::core::mem::transmute_copy(&pinfoids)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfovalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfovalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -216,7 +216,7 @@ impl ISdoDictionaryOld_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAttribute(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattributeobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattributeobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -227,7 +227,7 @@ impl ISdoDictionaryOld_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeID(::core::mem::transmute(&bstrattributename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -273,7 +273,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionarySDO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdictionarysdo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdictionarysdo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -284,7 +284,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceSDO(::core::mem::transmute_copy(&edatastore), ::core::mem::transmute(&bstrservicename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservicesdo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservicesdo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -295,7 +295,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserSDO(::core::mem::transmute_copy(&edatastore), ::core::mem::transmute(&bstrusername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppusersdo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppusersdo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -306,7 +306,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.GetOSType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eostype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eostype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.GetDomainType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *edomaintype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(edomaintype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -328,7 +328,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.IsDirectoryAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *booldirectoryavailable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(booldirectoryavailable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -339,7 +339,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttachedComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrcomputername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrcomputername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -350,7 +350,7 @@ impl ISdoMachine_Vtbl {
             let this = (*this).get_impl();
             match this.GetSDOSchema() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdoschema = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdoschema, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -391,7 +391,7 @@ impl ISdoMachine2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTemplatesSDO(::core::mem::transmute(&bstrservicename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplatessdo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplatessdo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -457,7 +457,7 @@ impl ISdoServiceControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetServiceStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
@@ -22,7 +22,7 @@ impl IDot11AdHocInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetFriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -48,7 +48,7 @@ impl IDot11AdHocInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveNetwork() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -59,7 +59,7 @@ impl IDot11AdHocInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetIEnumSecuritySettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -70,7 +70,7 @@ impl IDot11AdHocInterface_Vtbl {
             let this = (*this).get_impl();
             match this.GetIEnumDot11AdHocNetworks(::core::mem::transmute_copy(&pfilterguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl IDot11AdHocManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNetwork(::core::mem::transmute(&name), ::core::mem::transmute(&password), ::core::mem::transmute_copy(&geographicalid), ::core::mem::transmute(&pinterface), ::core::mem::transmute(&psecurity), ::core::mem::transmute_copy(&pcontextguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piadhoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piadhoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -149,7 +149,7 @@ impl IDot11AdHocManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetIEnumDot11AdHocNetworks(::core::mem::transmute_copy(&pcontextguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -160,7 +160,7 @@ impl IDot11AdHocManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetIEnumDot11AdHocInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -171,7 +171,7 @@ impl IDot11AdHocManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetwork(::core::mem::transmute_copy(&networksignature)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -261,7 +261,7 @@ impl IDot11AdHocNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetSSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwssid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwssid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -277,7 +277,7 @@ impl IDot11AdHocNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszwprofilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszwprofilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IDot11AdHocNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecuritySetting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *padhocsecuritysetting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(padhocsecuritysetting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -319,7 +319,7 @@ impl IDot11AdHocNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *padhocinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(padhocinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -438,7 +438,7 @@ impl IEnumDot11AdHocInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -485,7 +485,7 @@ impl IEnumDot11AdHocNetworks_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -532,7 +532,7 @@ impl IEnumDot11AdHocSecuritySettings_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
@@ -61,7 +61,7 @@ impl IWCNDevice_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntegerAttribute(::core::mem::transmute_copy(&attributetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puinteger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puinteger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
@@ -25,7 +25,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ExternalIPAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36,7 +36,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteHost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -47,7 +47,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ExternalPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -58,7 +58,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Protocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -69,7 +69,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.InternalPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -80,7 +80,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.InternalClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -91,7 +91,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -102,7 +102,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -113,7 +113,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.LeaseDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IDynamicPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.RenewLease(::core::mem::transmute_copy(&lleasedurationdesired)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pleasedurationreturned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pleasedurationreturned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl IDynamicPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IDynamicPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&bstrremotehost), ::core::mem::transmute_copy(&lexternalport), ::core::mem::transmute(&bstrprotocol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdpm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdpm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -212,7 +212,7 @@ impl IDynamicPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -228,7 +228,7 @@ impl IDynamicPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&bstrremotehost), ::core::mem::transmute_copy(&lexternalport), ::core::mem::transmute(&bstrprotocol), ::core::mem::transmute_copy(&linternalport), ::core::mem::transmute(&bstrinternalclient), ::core::mem::transmute_copy(&benabled), ::core::mem::transmute(&bstrdescription), ::core::mem::transmute_copy(&lleaseduration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdpm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdpm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl IEnumNetConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -326,7 +326,7 @@ impl IEnumNetSharingEveryConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -376,7 +376,7 @@ impl IEnumNetSharingPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -426,7 +426,7 @@ impl IEnumNetSharingPrivateConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -476,7 +476,7 @@ impl IEnumNetSharingPublicConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -593,7 +593,7 @@ impl INetConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Duplicate(::core::mem::transmute(&pszwduplicatename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -604,7 +604,7 @@ impl INetConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -615,7 +615,7 @@ impl INetConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetUiObjectClassId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -689,7 +689,7 @@ impl INetConnectionManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumConnections(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -720,7 +720,7 @@ impl INetConnectionProps_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -731,7 +731,7 @@ impl INetConnectionProps_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -742,7 +742,7 @@ impl INetConnectionProps_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -753,7 +753,7 @@ impl INetConnectionProps_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -764,7 +764,7 @@ impl INetConnectionProps_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -775,7 +775,7 @@ impl INetConnectionProps_Vtbl {
             let this = (*this).get_impl();
             match this.Characteristics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -820,7 +820,7 @@ impl INetFwAuthorizedApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -836,7 +836,7 @@ impl INetFwAuthorizedApplication_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessImageFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagefilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagefilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -852,7 +852,7 @@ impl INetFwAuthorizedApplication_Vtbl {
             let this = (*this).get_impl();
             match this.IpVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ipversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ipversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -868,7 +868,7 @@ impl INetFwAuthorizedApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -884,7 +884,7 @@ impl INetFwAuthorizedApplication_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remoteaddrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remoteaddrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -900,7 +900,7 @@ impl INetFwAuthorizedApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -949,7 +949,7 @@ impl INetFwAuthorizedApplications_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -970,7 +970,7 @@ impl INetFwAuthorizedApplications_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&imagefilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *app = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(app, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -981,7 +981,7 @@ impl INetFwAuthorizedApplications_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1033,7 +1033,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowOutboundDestinationUnreachable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1049,7 +1049,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowRedirect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1065,7 +1065,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowInboundEchoRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1081,7 +1081,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowOutboundTimeExceeded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1097,7 +1097,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowOutboundParameterProblem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1113,7 +1113,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowOutboundSourceQuench() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1129,7 +1129,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowInboundRouterRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1145,7 +1145,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowInboundTimestampRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1161,7 +1161,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowInboundMaskRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1177,7 +1177,7 @@ impl INetFwIcmpSettings_Vtbl {
             let this = (*this).get_impl();
             match this.AllowOutboundPacketTooBig() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1234,7 +1234,7 @@ impl INetFwMgr_Vtbl {
             let this = (*this).get_impl();
             match this.LocalPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *localpolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localpolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1245,7 +1245,7 @@ impl INetFwMgr_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentProfileType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *profiletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(profiletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1307,7 +1307,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1323,7 +1323,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.IpVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ipversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ipversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1339,7 +1339,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.Protocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ipprotocol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ipprotocol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1355,7 +1355,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.Port() {
                 ::core::result::Result::Ok(ok__) => {
-                    *portnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(portnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1371,7 +1371,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.Scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1387,7 +1387,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remoteaddrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remoteaddrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1403,7 +1403,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1419,7 +1419,7 @@ impl INetFwOpenPort_Vtbl {
             let this = (*this).get_impl();
             match this.BuiltIn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *builtin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(builtin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1466,7 +1466,7 @@ impl INetFwOpenPorts_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1487,7 +1487,7 @@ impl INetFwOpenPorts_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&portnumber), ::core::mem::transmute_copy(&ipprotocol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *openport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(openport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1498,7 +1498,7 @@ impl INetFwOpenPorts_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1532,7 +1532,7 @@ impl INetFwPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *profile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(profile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1543,7 +1543,7 @@ impl INetFwPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfileByType(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *profile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(profile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1594,7 +1594,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentProfileTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *profiletypesbitmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(profiletypesbitmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1605,7 +1605,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_FirewallEnabled(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1621,7 +1621,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_ExcludedInterfaces(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *interfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1637,7 +1637,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_BlockAllInboundTraffic(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *block = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(block, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1653,7 +1653,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_NotificationsDisabled(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1669,7 +1669,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_UnicastResponsesToMulticastBroadcastDisabled(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *disabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1685,7 +1685,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.Rules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1696,7 +1696,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceRestriction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *servicerestriction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(servicerestriction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1712,7 +1712,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.IsRuleGroupEnabled(::core::mem::transmute_copy(&profiletypesbitmask), ::core::mem::transmute(&group)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1728,7 +1728,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_DefaultInboundAction(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1744,7 +1744,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_DefaultOutboundAction(::core::mem::transmute_copy(&profiletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1760,7 +1760,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_IsRuleGroupCurrentlyEnabled(::core::mem::transmute(&group)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1771,7 +1771,7 @@ impl INetFwPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.LocalPolicyModifyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modifystate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modifystate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1825,7 +1825,7 @@ impl INetFwProduct_Vtbl {
             let this = (*this).get_impl();
             match this.RuleCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rulecategories = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rulecategories, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1841,7 +1841,7 @@ impl INetFwProduct_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1857,7 +1857,7 @@ impl INetFwProduct_Vtbl {
             let this = (*this).get_impl();
             match this.PathToSignedProductExe() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1893,7 +1893,7 @@ impl INetFwProducts_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1904,7 +1904,7 @@ impl INetFwProducts_Vtbl {
             let this = (*this).get_impl();
             match this.Register(::core::mem::transmute(&product)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *registration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(registration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1915,7 +1915,7 @@ impl INetFwProducts_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *product = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(product, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1926,7 +1926,7 @@ impl INetFwProducts_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1971,7 +1971,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1982,7 +1982,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.FirewallEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1998,7 +1998,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ExceptionsNotAllowed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *notallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(notallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2014,7 +2014,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.NotificationsDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2030,7 +2030,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.UnicastResponsesToMulticastBroadcastDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2046,7 +2046,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteAdminSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remoteadminsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remoteadminsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2057,7 +2057,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.IcmpSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icmpsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icmpsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2068,7 +2068,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.GloballyOpenPorts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *openports = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(openports, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2079,7 +2079,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.Services() {
                 ::core::result::Result::Ok(ok__) => {
-                    *services = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(services, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2090,7 +2090,7 @@ impl INetFwProfile_Vtbl {
             let this = (*this).get_impl();
             match this.AuthorizedApplications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *apps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(apps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2139,7 +2139,7 @@ impl INetFwRemoteAdminSettings_Vtbl {
             let this = (*this).get_impl();
             match this.IpVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ipversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ipversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2155,7 +2155,7 @@ impl INetFwRemoteAdminSettings_Vtbl {
             let this = (*this).get_impl();
             match this.Scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2171,7 +2171,7 @@ impl INetFwRemoteAdminSettings_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remoteaddrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remoteaddrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2187,7 +2187,7 @@ impl INetFwRemoteAdminSettings_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2263,7 +2263,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2279,7 +2279,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *desc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(desc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2295,7 +2295,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagefilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagefilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2311,7 +2311,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *servicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(servicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2327,7 +2327,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Protocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *protocol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(protocol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2343,7 +2343,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.LocalPorts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *portnumbers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(portnumbers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2359,7 +2359,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.RemotePorts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *portnumbers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(portnumbers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2375,7 +2375,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.LocalAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *localaddrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(localaddrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2391,7 +2391,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remoteaddrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remoteaddrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2407,7 +2407,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.IcmpTypesAndCodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icmptypesandcodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icmptypesandcodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2423,7 +2423,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Direction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2439,7 +2439,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Interfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2455,7 +2455,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.InterfaceTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interfacetypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interfacetypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2471,7 +2471,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2487,7 +2487,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Grouping() {
                 ::core::result::Result::Ok(ok__) => {
-                    *context = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(context, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2503,7 +2503,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Profiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *profiletypesbitmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(profiletypesbitmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2519,7 +2519,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.EdgeTraversal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2535,7 +2535,7 @@ impl INetFwRule_Vtbl {
             let this = (*this).get_impl();
             match this.Action() {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2605,7 +2605,7 @@ impl INetFwRule2_Vtbl {
             let this = (*this).get_impl();
             match this.EdgeTraversalOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *loptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(loptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2651,7 +2651,7 @@ impl INetFwRule3_Vtbl {
             let this = (*this).get_impl();
             match this.LocalAppPackageId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wszpackageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wszpackageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2667,7 +2667,7 @@ impl INetFwRule3_Vtbl {
             let this = (*this).get_impl();
             match this.LocalUserOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wszuserowner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wszuserowner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2683,7 +2683,7 @@ impl INetFwRule3_Vtbl {
             let this = (*this).get_impl();
             match this.LocalUserAuthorizedList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wszuserauthlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wszuserauthlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2699,7 +2699,7 @@ impl INetFwRule3_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteUserAuthorizedList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wszuserauthlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wszuserauthlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2715,7 +2715,7 @@ impl INetFwRule3_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteMachineAuthorizedList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wszuserauthlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wszuserauthlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2731,7 +2731,7 @@ impl INetFwRule3_Vtbl {
             let this = (*this).get_impl();
             match this.SecureFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *loptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(loptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2780,7 +2780,7 @@ impl INetFwRules_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2801,7 +2801,7 @@ impl INetFwRules_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2812,7 +2812,7 @@ impl INetFwRules_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2856,7 +2856,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2867,7 +2867,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2878,7 +2878,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.Customized() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customized = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customized, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2889,7 +2889,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.IpVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ipversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ipversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2905,7 +2905,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.Scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2921,7 +2921,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remoteaddrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remoteaddrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2937,7 +2937,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2953,7 +2953,7 @@ impl INetFwService_Vtbl {
             let this = (*this).get_impl();
             match this.GloballyOpenPorts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *openports = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(openports, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3000,7 +3000,7 @@ impl INetFwServiceRestriction_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceRestricted(::core::mem::transmute(&servicename), ::core::mem::transmute(&appname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *servicerestricted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(servicerestricted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3011,7 +3011,7 @@ impl INetFwServiceRestriction_Vtbl {
             let this = (*this).get_impl();
             match this.Rules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3044,7 +3044,7 @@ impl INetFwServices_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3055,7 +3055,7 @@ impl INetFwServices_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&svctype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *service = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(service, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3066,7 +3066,7 @@ impl INetFwServices_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3106,7 +3106,7 @@ impl INetSharingConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SharingEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3117,7 +3117,7 @@ impl INetSharingConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SharingConnectionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3138,7 +3138,7 @@ impl INetSharingConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.InternetFirewallEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3159,7 +3159,7 @@ impl INetSharingConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.get_EnumPortMappings(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcoll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcoll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3170,7 +3170,7 @@ impl INetSharingConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.AddPortMapping(::core::mem::transmute(&bstrname), ::core::mem::transmute_copy(&ucipprotocol), ::core::mem::transmute_copy(&usexternalport), ::core::mem::transmute_copy(&usinternalport), ::core::mem::transmute_copy(&dwoptions), ::core::mem::transmute(&bstrtargetnameoripaddress), ::core::mem::transmute_copy(&etargettype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmapping = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmapping, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3214,7 +3214,7 @@ impl INetSharingEveryConnectionCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3225,7 +3225,7 @@ impl INetSharingEveryConnectionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3260,7 +3260,7 @@ impl INetSharingManager_Vtbl {
             let this = (*this).get_impl();
             match this.SharingInstalled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbinstalled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbinstalled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3271,7 +3271,7 @@ impl INetSharingManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_EnumPublicConnections(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcoll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcoll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3282,7 +3282,7 @@ impl INetSharingManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_EnumPrivateConnections(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcoll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcoll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3293,7 +3293,7 @@ impl INetSharingManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_INetSharingConfigurationForINetConnection(::core::mem::transmute(&pnetconnection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetsharingconfiguration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetsharingconfiguration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3304,7 +3304,7 @@ impl INetSharingManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumEveryConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcoll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcoll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3315,7 +3315,7 @@ impl INetSharingManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_NetConnectionProps(::core::mem::transmute(&pnetconnection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3362,7 +3362,7 @@ impl INetSharingPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnspmp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnspmp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3400,7 +3400,7 @@ impl INetSharingPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3411,7 +3411,7 @@ impl INetSharingPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3448,7 +3448,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3459,7 +3459,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.IPProtocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucipprot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucipprot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3470,7 +3470,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.ExternalPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pusport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pusport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3481,7 +3481,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.InternalPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pusport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pusport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3492,7 +3492,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.Options() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3503,7 +3503,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.TargetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtargetname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtargetname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3514,7 +3514,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.TargetIPAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtargetipaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtargetipaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3525,7 +3525,7 @@ impl INetSharingPortMappingProps_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3562,7 +3562,7 @@ impl INetSharingPrivateConnectionCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3573,7 +3573,7 @@ impl INetSharingPrivateConnectionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3604,7 +3604,7 @@ impl INetSharingPublicConnectionCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3615,7 +3615,7 @@ impl INetSharingPublicConnectionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3655,7 +3655,7 @@ impl IStaticPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ExternalIPAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3666,7 +3666,7 @@ impl IStaticPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ExternalPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3677,7 +3677,7 @@ impl IStaticPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.InternalPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3688,7 +3688,7 @@ impl IStaticPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Protocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3699,7 +3699,7 @@ impl IStaticPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.InternalClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3710,7 +3710,7 @@ impl IStaticPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3721,7 +3721,7 @@ impl IStaticPortMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3784,7 +3784,7 @@ impl IStaticPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3795,7 +3795,7 @@ impl IStaticPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lexternalport), ::core::mem::transmute(&bstrprotocol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppspm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppspm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3806,7 +3806,7 @@ impl IStaticPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3822,7 +3822,7 @@ impl IStaticPortMappingCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute_copy(&lexternalport), ::core::mem::transmute(&bstrprotocol), ::core::mem::transmute_copy(&linternalport), ::core::mem::transmute(&bstrinternalclient), ::core::mem::transmute_copy(&benabled), ::core::mem::transmute(&bstrdescription)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppspm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppspm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3857,7 +3857,7 @@ impl IUPnPNAT_Vtbl {
             let this = (*this).get_impl();
             match this.StaticPortMappingCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppspms = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppspms, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3868,7 +3868,7 @@ impl IUPnPNAT_Vtbl {
             let this = (*this).get_impl();
             match this.DynamicPortMappingCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdpms = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdpms, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3879,7 +3879,7 @@ impl IUPnPNAT_Vtbl {
             let this = (*this).get_impl();
             match this.NATEventManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
@@ -24,7 +24,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35,7 +35,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.Class() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -46,7 +46,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.GUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -57,7 +57,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.ADsPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -68,7 +68,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -79,7 +79,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.Schema() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -100,7 +100,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.Get(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -116,7 +116,7 @@ impl IADs_Vtbl {
             let this = (*this).get_impl();
             match this.GetEx(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -179,7 +179,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.UserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ComputerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SiteName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -212,7 +212,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DomainShortName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -223,7 +223,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DomainDNSName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ForestDNSName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PDCRoleOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -256,7 +256,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SchemaRoleOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -267,7 +267,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsNativeMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -278,7 +278,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnyDCName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdcname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdcname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -289,7 +289,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDCSiteName(::core::mem::transmute(&szserver)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszsitename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszsitename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl IADsADSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrees() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvtrees = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvtrees, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -359,7 +359,7 @@ impl IADsAccessControlEntry_Vtbl {
             let this = (*this).get_impl();
             match this.AccessMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -375,7 +375,7 @@ impl IADsAccessControlEntry_Vtbl {
             let this = (*this).get_impl();
             match this.AceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -391,7 +391,7 @@ impl IADsAccessControlEntry_Vtbl {
             let this = (*this).get_impl();
             match this.AceFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -407,7 +407,7 @@ impl IADsAccessControlEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -423,7 +423,7 @@ impl IADsAccessControlEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -439,7 +439,7 @@ impl IADsAccessControlEntry_Vtbl {
             let this = (*this).get_impl();
             match this.InheritedObjectType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -455,7 +455,7 @@ impl IADsAccessControlEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Trustee() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -509,7 +509,7 @@ impl IADsAccessControlList_Vtbl {
             let this = (*this).get_impl();
             match this.AclRevision() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -525,7 +525,7 @@ impl IADsAccessControlList_Vtbl {
             let this = (*this).get_impl();
             match this.AceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -551,7 +551,7 @@ impl IADsAccessControlList_Vtbl {
             let this = (*this).get_impl();
             match this.CopyAccessList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaccesscontrollist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaccesscontrollist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -562,7 +562,7 @@ impl IADsAccessControlList_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -604,7 +604,7 @@ impl IADsAcl_Vtbl {
             let this = (*this).get_impl();
             match this.ProtectedAttrName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -620,7 +620,7 @@ impl IADsAcl_Vtbl {
             let this = (*this).get_impl();
             match this.SubjectName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -636,7 +636,7 @@ impl IADsAcl_Vtbl {
             let this = (*this).get_impl();
             match this.Privileges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -652,7 +652,7 @@ impl IADsAcl_Vtbl {
             let this = (*this).get_impl();
             match this.CopyAcl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppacl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppacl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -758,7 +758,7 @@ impl IADsBackLink_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -774,7 +774,7 @@ impl IADsBackLink_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -812,7 +812,7 @@ impl IADsCaseIgnoreList_Vtbl {
             let this = (*this).get_impl();
             match this.CaseIgnoreList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -876,7 +876,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.PrimaryInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -887,7 +887,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.CLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -903,7 +903,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.OID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -919,7 +919,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.Abstract() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -935,7 +935,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.Auxiliary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -951,7 +951,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.MandatoryProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -967,7 +967,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.OptionalProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -983,7 +983,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.NamingProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -999,7 +999,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.DerivedFrom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1015,7 +1015,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.AuxDerivedFrom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1031,7 +1031,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.PossibleSuperiors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1047,7 +1047,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.Containment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1063,7 +1063,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.Container() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1079,7 +1079,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.HelpFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1095,7 +1095,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.HelpFileContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1111,7 +1111,7 @@ impl IADsClass_Vtbl {
             let this = (*this).get_impl();
             match this.Qualifiers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqualifiers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqualifiers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1172,7 +1172,7 @@ impl IADsCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1193,7 +1193,7 @@ impl IADsCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1256,7 +1256,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.ComputerID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1267,7 +1267,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Site() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1278,7 +1278,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1294,7 +1294,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Location() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1310,7 +1310,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.PrimaryUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1326,7 +1326,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Owner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1342,7 +1342,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Division() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1358,7 +1358,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Department() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1374,7 +1374,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Role() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1390,7 +1390,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.OperatingSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1406,7 +1406,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.OperatingSystemVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1422,7 +1422,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Model() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1438,7 +1438,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.Processor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1454,7 +1454,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1470,7 +1470,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.MemorySize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1486,7 +1486,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.StorageCapacity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1502,7 +1502,7 @@ impl IADsComputer_Vtbl {
             let this = (*this).get_impl();
             match this.NetAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1568,7 +1568,7 @@ impl IADsComputerOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1609,7 +1609,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1620,7 +1620,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1631,7 +1631,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Filter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1647,7 +1647,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Hints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1663,7 +1663,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject(::core::mem::transmute(&classname), ::core::mem::transmute(&relativename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1674,7 +1674,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&classname), ::core::mem::transmute(&relativename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1690,7 +1690,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this.CopyHere(::core::mem::transmute(&sourcename), ::core::mem::transmute(&newname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1701,7 +1701,7 @@ impl IADsContainer_Vtbl {
             let this = (*this).get_impl();
             match this.MoveHere(::core::mem::transmute(&sourcename), ::core::mem::transmute(&newname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1743,7 +1743,7 @@ impl IADsDNWithBinary_Vtbl {
             let this = (*this).get_impl();
             match this.BinaryValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1759,7 +1759,7 @@ impl IADsDNWithBinary_Vtbl {
             let this = (*this).get_impl();
             match this.DNString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1799,7 +1799,7 @@ impl IADsDNWithString_Vtbl {
             let this = (*this).get_impl();
             match this.StringValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1815,7 +1815,7 @@ impl IADsDNWithString_Vtbl {
             let this = (*this).get_impl();
             match this.DNString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1888,7 +1888,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorkgroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1899,7 +1899,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.MinPasswordLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1915,7 +1915,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.MinPasswordAge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1931,7 +1931,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.MaxPasswordAge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1947,7 +1947,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.MaxBadPasswordsAllowed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1963,7 +1963,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.PasswordHistoryLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1979,7 +1979,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.PasswordAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1995,7 +1995,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.AutoUnlockInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2011,7 +2011,7 @@ impl IADsDomain_Vtbl {
             let this = (*this).get_impl();
             match this.LockoutObservationInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2064,7 +2064,7 @@ impl IADsEmail_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2080,7 +2080,7 @@ impl IADsEmail_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2124,7 +2124,7 @@ impl IADsExtension_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateGetIDsOfNames(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&rgsznames), ::core::mem::transmute_copy(&cnames), ::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rgdispid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rgdispid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2163,7 +2163,7 @@ impl IADsFaxNumber_Vtbl {
             let this = (*this).get_impl();
             match this.TelephoneNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2179,7 +2179,7 @@ impl IADsFaxNumber_Vtbl {
             let this = (*this).get_impl();
             match this.Parameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2219,7 +2219,7 @@ impl IADsFileService_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2235,7 +2235,7 @@ impl IADsFileService_Vtbl {
             let this = (*this).get_impl();
             match this.MaxUserCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2273,7 +2273,7 @@ impl IADsFileServiceOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Sessions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsessions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsessions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2284,7 +2284,7 @@ impl IADsFileServiceOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Resources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2322,7 +2322,7 @@ impl IADsFileShare_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUserCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2333,7 +2333,7 @@ impl IADsFileShare_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2349,7 +2349,7 @@ impl IADsFileShare_Vtbl {
             let this = (*this).get_impl();
             match this.HostComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2365,7 +2365,7 @@ impl IADsFileShare_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2381,7 +2381,7 @@ impl IADsFileShare_Vtbl {
             let this = (*this).get_impl();
             match this.MaxUserCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2428,7 +2428,7 @@ impl IADsGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2444,7 +2444,7 @@ impl IADsGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Members() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmembers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmembers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2455,7 +2455,7 @@ impl IADsGroup_Vtbl {
             let this = (*this).get_impl();
             match this.IsMember(::core::mem::transmute(&bstrmember)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bmember = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bmember, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2502,7 +2502,7 @@ impl IADsHold_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2518,7 +2518,7 @@ impl IADsHold_Vtbl {
             let this = (*this).get_impl();
             match this.Amount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2558,7 +2558,7 @@ impl IADsLargeInteger_Vtbl {
             let this = (*this).get_impl();
             match this.HighPart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2574,7 +2574,7 @@ impl IADsLargeInteger_Vtbl {
             let this = (*this).get_impl();
             match this.LowPart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2618,7 +2618,7 @@ impl IADsLocality_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2634,7 +2634,7 @@ impl IADsLocality_Vtbl {
             let this = (*this).get_impl();
             match this.LocalityName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2650,7 +2650,7 @@ impl IADsLocality_Vtbl {
             let this = (*this).get_impl();
             match this.PostalAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2666,7 +2666,7 @@ impl IADsLocality_Vtbl {
             let this = (*this).get_impl();
             match this.SeeAlso() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2710,7 +2710,7 @@ impl IADsMembers_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2721,7 +2721,7 @@ impl IADsMembers_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2732,7 +2732,7 @@ impl IADsMembers_Vtbl {
             let this = (*this).get_impl();
             match this.Filter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2795,7 +2795,7 @@ impl IADsNameTranslate_Vtbl {
             let this = (*this).get_impl();
             match this.Get(::core::mem::transmute_copy(&lnformattype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstradspath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstradspath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2811,7 +2811,7 @@ impl IADsNameTranslate_Vtbl {
             let this = (*this).get_impl();
             match this.GetEx(::core::mem::transmute_copy(&lnformattype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2847,7 +2847,7 @@ impl IADsNamespaces_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2885,7 +2885,7 @@ impl IADsNetAddress_Vtbl {
             let this = (*this).get_impl();
             match this.AddressType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2901,7 +2901,7 @@ impl IADsNetAddress_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2949,7 +2949,7 @@ impl IADsO_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2965,7 +2965,7 @@ impl IADsO_Vtbl {
             let this = (*this).get_impl();
             match this.LocalityName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2981,7 +2981,7 @@ impl IADsO_Vtbl {
             let this = (*this).get_impl();
             match this.PostalAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2997,7 +2997,7 @@ impl IADsO_Vtbl {
             let this = (*this).get_impl();
             match this.TelephoneNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3013,7 +3013,7 @@ impl IADsO_Vtbl {
             let this = (*this).get_impl();
             match this.FaxNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3029,7 +3029,7 @@ impl IADsO_Vtbl {
             let this = (*this).get_impl();
             match this.SeeAlso() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3087,7 +3087,7 @@ impl IADsOU_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3103,7 +3103,7 @@ impl IADsOU_Vtbl {
             let this = (*this).get_impl();
             match this.LocalityName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3119,7 +3119,7 @@ impl IADsOU_Vtbl {
             let this = (*this).get_impl();
             match this.PostalAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3135,7 +3135,7 @@ impl IADsOU_Vtbl {
             let this = (*this).get_impl();
             match this.TelephoneNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3151,7 +3151,7 @@ impl IADsOU_Vtbl {
             let this = (*this).get_impl();
             match this.FaxNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3167,7 +3167,7 @@ impl IADsOU_Vtbl {
             let this = (*this).get_impl();
             match this.SeeAlso() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3183,7 +3183,7 @@ impl IADsOU_Vtbl {
             let this = (*this).get_impl();
             match this.BusinessCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3231,7 +3231,7 @@ impl IADsObjectOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetOption(::core::mem::transmute_copy(&lnoption)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3267,7 +3267,7 @@ impl IADsOctetList_Vtbl {
             let this = (*this).get_impl();
             match this.OctetList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3302,7 +3302,7 @@ impl IADsOpenDSObject_Vtbl {
             let this = (*this).get_impl();
             match this.OpenDSObject(::core::mem::transmute(&lpszdnname), ::core::mem::transmute(&lpszusername), ::core::mem::transmute(&lpszpassword), ::core::mem::transmute_copy(&lnreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoledsobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoledsobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3333,7 +3333,7 @@ impl IADsPath_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3349,7 +3349,7 @@ impl IADsPath_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3365,7 +3365,7 @@ impl IADsPath_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3424,7 +3424,7 @@ impl IADsPathname_Vtbl {
             let this = (*this).get_impl();
             match this.Retrieve(::core::mem::transmute_copy(&lnformattype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstradspath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstradspath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3435,7 +3435,7 @@ impl IADsPathname_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumElements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnnumpathelements = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnnumpathelements, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3446,7 +3446,7 @@ impl IADsPathname_Vtbl {
             let this = (*this).get_impl();
             match this.GetElement(::core::mem::transmute_copy(&lnelementindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3467,7 +3467,7 @@ impl IADsPathname_Vtbl {
             let this = (*this).get_impl();
             match this.CopyPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppadspath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppadspath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3478,7 +3478,7 @@ impl IADsPathname_Vtbl {
             let this = (*this).get_impl();
             match this.GetEscapedElement(::core::mem::transmute_copy(&lnreserved), ::core::mem::transmute(&bstrinstr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstroutstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstroutstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3489,7 +3489,7 @@ impl IADsPathname_Vtbl {
             let this = (*this).get_impl();
             match this.EscapedMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3534,7 +3534,7 @@ impl IADsPostalAddress_Vtbl {
             let this = (*this).get_impl();
             match this.PostalAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3586,7 +3586,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.HostPrintQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3597,7 +3597,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3608,7 +3608,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.UserPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3619,7 +3619,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.TimeSubmitted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3630,7 +3630,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.TotalPages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3641,7 +3641,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3652,7 +3652,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3668,7 +3668,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3684,7 +3684,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3700,7 +3700,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.UntilTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3716,7 +3716,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.Notify() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3732,7 +3732,7 @@ impl IADsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.NotifyPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3789,7 +3789,7 @@ impl IADsPrintJobOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3800,7 +3800,7 @@ impl IADsPrintJobOperations_Vtbl {
             let this = (*this).get_impl();
             match this.TimeElapsed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3811,7 +3811,7 @@ impl IADsPrintJobOperations_Vtbl {
             let this = (*this).get_impl();
             match this.PagesPrinted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3822,7 +3822,7 @@ impl IADsPrintJobOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Position() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3897,7 +3897,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.PrinterPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3913,7 +3913,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Model() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3929,7 +3929,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Datatype() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3945,7 +3945,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.PrintProcessor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3961,7 +3961,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3977,7 +3977,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Location() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3993,7 +3993,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4009,7 +4009,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.UntilTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4025,7 +4025,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultJobPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4041,7 +4041,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4057,7 +4057,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.BannerPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4073,7 +4073,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.PrintDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4089,7 +4089,7 @@ impl IADsPrintQueue_Vtbl {
             let this = (*this).get_impl();
             match this.NetAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4152,7 +4152,7 @@ impl IADsPrintQueueOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4163,7 +4163,7 @@ impl IADsPrintQueueOperations_Vtbl {
             let this = (*this).get_impl();
             match this.PrintJobs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4221,7 +4221,7 @@ impl IADsProperty_Vtbl {
             let this = (*this).get_impl();
             match this.OID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4237,7 +4237,7 @@ impl IADsProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Syntax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4253,7 +4253,7 @@ impl IADsProperty_Vtbl {
             let this = (*this).get_impl();
             match this.MaxRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4269,7 +4269,7 @@ impl IADsProperty_Vtbl {
             let this = (*this).get_impl();
             match this.MinRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4285,7 +4285,7 @@ impl IADsProperty_Vtbl {
             let this = (*this).get_impl();
             match this.MultiValued() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4301,7 +4301,7 @@ impl IADsProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Qualifiers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqualifiers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqualifiers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4353,7 +4353,7 @@ impl IADsPropertyEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4369,7 +4369,7 @@ impl IADsPropertyEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ADsType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4385,7 +4385,7 @@ impl IADsPropertyEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ControlCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4401,7 +4401,7 @@ impl IADsPropertyEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Values() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4451,7 +4451,7 @@ impl IADsPropertyList_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4477,7 +4477,7 @@ impl IADsPropertyList_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4488,7 +4488,7 @@ impl IADsPropertyList_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyItem(::core::mem::transmute(&bstrname), ::core::mem::transmute_copy(&lnadstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4569,7 +4569,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.ADsType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4585,7 +4585,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.DNString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4601,7 +4601,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.CaseExactString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4617,7 +4617,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.CaseIgnoreString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4633,7 +4633,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.PrintableString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4649,7 +4649,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.NumericString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4665,7 +4665,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Boolean() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4681,7 +4681,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Integer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4697,7 +4697,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.OctetString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4713,7 +4713,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.SecurityDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4729,7 +4729,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.LargeInteger() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4745,7 +4745,7 @@ impl IADsPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.UTCTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4842,7 +4842,7 @@ impl IADsReplicaPointer_Vtbl {
             let this = (*this).get_impl();
             match this.ServerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4858,7 +4858,7 @@ impl IADsReplicaPointer_Vtbl {
             let this = (*this).get_impl();
             match this.ReplicaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4874,7 +4874,7 @@ impl IADsReplicaPointer_Vtbl {
             let this = (*this).get_impl();
             match this.ReplicaNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4890,7 +4890,7 @@ impl IADsReplicaPointer_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4906,7 +4906,7 @@ impl IADsReplicaPointer_Vtbl {
             let this = (*this).get_impl();
             match this.ReplicaAddressHints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4952,7 +4952,7 @@ impl IADsResource_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4963,7 +4963,7 @@ impl IADsResource_Vtbl {
             let this = (*this).get_impl();
             match this.UserPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4974,7 +4974,7 @@ impl IADsResource_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4985,7 +4985,7 @@ impl IADsResource_Vtbl {
             let this = (*this).get_impl();
             match this.LockCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5037,7 +5037,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Revision() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5053,7 +5053,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Control() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5069,7 +5069,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Owner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5085,7 +5085,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerDefaulted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5101,7 +5101,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.Group() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5117,7 +5117,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.GroupDefaulted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5133,7 +5133,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.DiscretionaryAcl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5149,7 +5149,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.DaclDefaulted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5165,7 +5165,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.SystemAcl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5181,7 +5181,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.SaclDefaulted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5197,7 +5197,7 @@ impl IADsSecurityDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.CopySecurityDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecuritydescriptor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecuritydescriptor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5250,7 +5250,7 @@ impl IADsSecurityUtility_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityDescriptor(::core::mem::transmute(&varpath), ::core::mem::transmute_copy(&lpathformat), ::core::mem::transmute_copy(&lformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5266,7 +5266,7 @@ impl IADsSecurityUtility_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertSecurityDescriptor(::core::mem::transmute(&varsd), ::core::mem::transmute_copy(&ldataformat), ::core::mem::transmute_copy(&loutformat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5277,7 +5277,7 @@ impl IADsSecurityUtility_Vtbl {
             let this = (*this).get_impl();
             match this.SecurityMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5338,7 +5338,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.HostComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5354,7 +5354,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5370,7 +5370,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5386,7 +5386,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5402,7 +5402,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.StartType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5418,7 +5418,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5434,7 +5434,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.StartupParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5450,7 +5450,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5466,7 +5466,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.LoadOrderGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5482,7 +5482,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceAccountName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5498,7 +5498,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceAccountPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5514,7 +5514,7 @@ impl IADsService_Vtbl {
             let this = (*this).get_impl();
             match this.Dependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5576,7 +5576,7 @@ impl IADsServiceOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5640,7 +5640,7 @@ impl IADsSession_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5651,7 +5651,7 @@ impl IADsSession_Vtbl {
             let this = (*this).get_impl();
             match this.UserPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5662,7 +5662,7 @@ impl IADsSession_Vtbl {
             let this = (*this).get_impl();
             match this.Computer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5673,7 +5673,7 @@ impl IADsSession_Vtbl {
             let this = (*this).get_impl();
             match this.ComputerPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5684,7 +5684,7 @@ impl IADsSession_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5695,7 +5695,7 @@ impl IADsSession_Vtbl {
             let this = (*this).get_impl();
             match this.IdleTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5730,7 +5730,7 @@ impl IADsSyntax_Vtbl {
             let this = (*this).get_impl();
             match this.OleAutoDataType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5768,7 +5768,7 @@ impl IADsTimestamp_Vtbl {
             let this = (*this).get_impl();
             match this.WholeSeconds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5784,7 +5784,7 @@ impl IADsTimestamp_Vtbl {
             let this = (*this).get_impl();
             match this.EventID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5826,7 +5826,7 @@ impl IADsTypedName_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5842,7 +5842,7 @@ impl IADsTypedName_Vtbl {
             let this = (*this).get_impl();
             match this.Level() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5858,7 +5858,7 @@ impl IADsTypedName_Vtbl {
             let this = (*this).get_impl();
             match this.Interval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5987,7 +5987,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.BadLoginAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5998,7 +5998,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.BadLoginCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6009,7 +6009,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.LastLogin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6020,7 +6020,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.LastLogoff() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6031,7 +6031,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.LastFailedLogin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6042,7 +6042,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.PasswordLastChanged() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6053,7 +6053,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6069,7 +6069,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Division() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6085,7 +6085,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Department() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6101,7 +6101,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.EmployeeID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6117,7 +6117,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.FullName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6133,7 +6133,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.FirstName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6149,7 +6149,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.LastName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6165,7 +6165,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.OtherName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6181,7 +6181,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.NamePrefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6197,7 +6197,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.NameSuffix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6213,7 +6213,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6229,7 +6229,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Manager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6245,7 +6245,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.TelephoneHome() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6261,7 +6261,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.TelephoneMobile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6277,7 +6277,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.TelephoneNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6293,7 +6293,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.TelephonePager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6309,7 +6309,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.FaxNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6325,7 +6325,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.OfficeLocations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6341,7 +6341,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.PostalAddresses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6357,7 +6357,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.PostalCodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6373,7 +6373,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.SeeAlso() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6389,7 +6389,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.AccountDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6405,7 +6405,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.AccountExpirationDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6421,7 +6421,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.GraceLoginsAllowed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6437,7 +6437,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.GraceLoginsRemaining() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6453,7 +6453,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.IsAccountLocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6469,7 +6469,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.LoginHours() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6485,7 +6485,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.LoginWorkstations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6501,7 +6501,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.MaxLogins() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6517,7 +6517,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.MaxStorage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6533,7 +6533,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.PasswordExpirationDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6549,7 +6549,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.PasswordMinimumLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6565,7 +6565,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.PasswordRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6581,7 +6581,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.RequireUniquePassword() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6597,7 +6597,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.EmailAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6613,7 +6613,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.HomeDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6629,7 +6629,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Languages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6645,7 +6645,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6661,7 +6661,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.LoginScript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6677,7 +6677,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Picture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6693,7 +6693,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.HomePage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6709,7 +6709,7 @@ impl IADsUser_Vtbl {
             let this = (*this).get_impl();
             match this.Groups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6841,7 +6841,7 @@ impl IADsWinNTSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.UserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6852,7 +6852,7 @@ impl IADsWinNTSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ComputerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6863,7 +6863,7 @@ impl IADsWinNTSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DomainName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6874,7 +6874,7 @@ impl IADsWinNTSystemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6930,7 +6930,7 @@ impl IDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6946,7 +6946,7 @@ impl IDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.SetObjectAttributes(::core::mem::transmute_copy(&pattributeentries), ::core::mem::transmute_copy(&dwnumattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumattributesmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumattributesmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6957,7 +6957,7 @@ impl IDirectoryObject_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDSObject(::core::mem::transmute(&pszrdnname), ::core::mem::transmute_copy(&pattributeentries), ::core::mem::transmute_copy(&dwnumattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7081,7 +7081,7 @@ impl IDirectorySearch_Vtbl {
             let this = (*this).get_impl();
             match this.ExecuteSearch(::core::mem::transmute(&pszsearchfilter), ::core::mem::transmute_copy(&pattributenames), ::core::mem::transmute_copy(&dwnumberattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phsearchresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phsearchresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7117,7 +7117,7 @@ impl IDirectorySearch_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumn(::core::mem::transmute_copy(&hsearchresult), ::core::mem::transmute(&szcolumnname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psearchcolumn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psearchcolumn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7171,7 +7171,7 @@ impl IDsAdminCreateObj_Vtbl {
             let this = (*this).get_impl();
             match this.CreateModal(::core::mem::transmute_copy(&hwndparent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppadsobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppadsobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7510,7 +7510,7 @@ impl IDsObjectPicker_Vtbl {
             let this = (*this).get_impl();
             match this.InvokeDialog(::core::mem::transmute_copy(&hwndparent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdoselections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdoselections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7634,7 +7634,7 @@ impl IPrivateDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.ADSIGetTypeInfoCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pctinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pctinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7645,7 +7645,7 @@ impl IPrivateDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.ADSIGetTypeInfo(::core::mem::transmute_copy(&itinfo), ::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7656,7 +7656,7 @@ impl IPrivateDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.ADSIGetIDsOfNames(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&rgsznames), ::core::mem::transmute_copy(&cnames), ::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rgdispid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rgdispid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
@@ -80,7 +80,7 @@ impl IBITSExtensionSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetCleanupTaskName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptaskname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptaskname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -91,7 +91,7 @@ impl IBITSExtensionSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetCleanupTask(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -123,7 +123,7 @@ impl IBITSExtensionSetupFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppextensionsetup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppextensionsetup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -257,7 +257,7 @@ impl IBackgroundCopyError_Vtbl {
             let this = (*this).get_impl();
             match this.GetFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -268,7 +268,7 @@ impl IBackgroundCopyError_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorDescription(::core::mem::transmute_copy(&languageid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *perrordescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(perrordescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -279,7 +279,7 @@ impl IBackgroundCopyError_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorContextDescription(::core::mem::transmute_copy(&languageid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontextdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontextdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -290,7 +290,7 @@ impl IBackgroundCopyError_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotocol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotocol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -325,7 +325,7 @@ impl IBackgroundCopyFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetRemoteName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -336,7 +336,7 @@ impl IBackgroundCopyFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -347,7 +347,7 @@ impl IBackgroundCopyFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -411,7 +411,7 @@ impl IBackgroundCopyFile3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTemporaryName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -427,7 +427,7 @@ impl IBackgroundCopyFile3_Vtbl {
             let this = (*this).get_impl();
             match this.GetValidationState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -438,7 +438,7 @@ impl IBackgroundCopyFile3_Vtbl {
             let this = (*this).get_impl();
             match this.IsDownloadedFromPeer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -496,7 +496,7 @@ impl IBackgroundCopyFile5_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -577,7 +577,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProp(::core::mem::transmute_copy(&propid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -593,7 +593,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgress(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwprogress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwprogress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -609,7 +609,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetJob(::core::mem::transmute(&jobid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -635,7 +635,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -646,7 +646,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GroupID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidgroupid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidgroupid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -657,7 +657,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.CreateJob(::core::mem::transmute(&guidjobid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -668,7 +668,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.EnumJobs(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumjobs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumjobs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -684,7 +684,7 @@ impl IBackgroundCopyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.QueryNewJobInterface(::core::mem::transmute_copy(&iid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -773,7 +773,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -804,7 +804,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -815,7 +815,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -826,7 +826,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -837,7 +837,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -848,7 +848,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -859,7 +859,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -870,7 +870,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -886,7 +886,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -902,7 +902,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -918,7 +918,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -934,7 +934,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -950,7 +950,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -966,7 +966,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinimumRetryDelay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -982,7 +982,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetNoProgressTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -993,7 +993,7 @@ impl IBackgroundCopyJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1080,7 +1080,7 @@ impl IBackgroundCopyJob1_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgress(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwprogress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwprogress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1101,7 +1101,7 @@ impl IBackgroundCopyJob1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFile(::core::mem::transmute_copy(&cfileindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfileinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfileinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1112,7 +1112,7 @@ impl IBackgroundCopyJob1_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwfilecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwfilecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1128,7 +1128,7 @@ impl IBackgroundCopyJob1_Vtbl {
             let this = (*this).get_impl();
             match this.JobID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidjobid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidjobid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1196,7 +1196,7 @@ impl IBackgroundCopyJob2_Vtbl {
             let this = (*this).get_impl();
             match this.GetReplyFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preplyfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preplyfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1260,7 +1260,7 @@ impl IBackgroundCopyJob3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileACLFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1302,7 +1302,7 @@ impl IBackgroundCopyJob4_Vtbl {
             let this = (*this).get_impl();
             match this.GetPeerCachingFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1313,7 +1313,7 @@ impl IBackgroundCopyJob4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwnerIntegrityLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1324,7 +1324,7 @@ impl IBackgroundCopyJob4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwnerElevationState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pelevated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pelevated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1340,7 +1340,7 @@ impl IBackgroundCopyJob4_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumDownloadTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1380,7 +1380,7 @@ impl IBackgroundCopyJob5_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1439,7 +1439,7 @@ impl IBackgroundCopyJobHttpOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1455,7 +1455,7 @@ impl IBackgroundCopyJobHttpOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1494,7 +1494,7 @@ impl IBackgroundCopyJobHttpOptions2_Vtbl {
             let this = (*this).get_impl();
             match this.GetHttpMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *method = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(method, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1556,7 +1556,7 @@ impl IBackgroundCopyManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetJob(::core::mem::transmute_copy(&jobid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1567,7 +1567,7 @@ impl IBackgroundCopyManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumJobs(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1578,7 +1578,7 @@ impl IBackgroundCopyManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorDescription(::core::mem::transmute_copy(&hresult), ::core::mem::transmute_copy(&languageid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *perrordescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(perrordescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1609,7 +1609,7 @@ impl IBackgroundCopyQMgr_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGroup(::core::mem::transmute(&guidgroupid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1620,7 +1620,7 @@ impl IBackgroundCopyQMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroup(::core::mem::transmute(&groupid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1631,7 +1631,7 @@ impl IBackgroundCopyQMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumGroups(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumgroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumgroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1681,7 +1681,7 @@ impl IBitsPeer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPeerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1692,7 +1692,7 @@ impl IBitsPeer_Vtbl {
             let this = (*this).get_impl();
             match this.IsAuthenticated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pauth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pauth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1703,7 +1703,7 @@ impl IBitsPeer_Vtbl {
             let this = (*this).get_impl();
             match this.IsAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ponline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ponline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1744,7 +1744,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumCacheSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1760,7 +1760,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumContentAge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1776,7 +1776,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfigurationFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1792,7 +1792,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1803,7 +1803,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecord(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprecord = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprecord, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1829,7 +1829,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
             let this = (*this).get_impl();
             match this.EnumPeers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1887,7 +1887,7 @@ impl IBitsPeerCacheRecord_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1898,7 +1898,7 @@ impl IBitsPeerCacheRecord_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1909,7 +1909,7 @@ impl IBitsPeerCacheRecord_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1920,7 +1920,7 @@ impl IBitsPeerCacheRecord_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileModificationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1931,7 +1931,7 @@ impl IBitsPeerCacheRecord_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastAccessTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1982,7 +1982,7 @@ impl IBitsTokenOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelperTokenFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2003,7 +2003,7 @@ impl IBitsTokenOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelperTokenSid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2052,7 +2052,7 @@ impl IEnumBackgroundCopyFiles_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2063,7 +2063,7 @@ impl IEnumBackgroundCopyFiles_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2112,7 +2112,7 @@ impl IEnumBackgroundCopyGroups_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2123,7 +2123,7 @@ impl IEnumBackgroundCopyGroups_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2172,7 +2172,7 @@ impl IEnumBackgroundCopyJobs_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2183,7 +2183,7 @@ impl IEnumBackgroundCopyJobs_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2232,7 +2232,7 @@ impl IEnumBackgroundCopyJobs1_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2243,7 +2243,7 @@ impl IEnumBackgroundCopyJobs1_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2292,7 +2292,7 @@ impl IEnumBitsPeerCacheRecords_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2303,7 +2303,7 @@ impl IEnumBitsPeerCacheRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2352,7 +2352,7 @@ impl IEnumBitsPeers_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2363,7 +2363,7 @@ impl IEnumBitsPeers_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
@@ -230,7 +230,7 @@ impl ISClusApplication_Vtbl {
             let this = (*this).get_impl();
             match this.DomainNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdomains = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdomains, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -241,7 +241,7 @@ impl ISClusApplication_Vtbl {
             let this = (*this).get_impl();
             match this.get_ClusterNames(::core::mem::transmute(&bstrdomainname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -252,7 +252,7 @@ impl ISClusApplication_Vtbl {
             let this = (*this).get_impl();
             match this.OpenCluster(::core::mem::transmute(&bstrclustername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcluster = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcluster, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -288,7 +288,7 @@ impl ISClusCryptoKeys_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -299,7 +299,7 @@ impl ISClusCryptoKeys_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -315,7 +315,7 @@ impl ISClusCryptoKeys_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcyrptokey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcyrptokey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -362,7 +362,7 @@ impl ISClusDisk_Vtbl {
             let this = (*this).get_impl();
             match this.Signature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -373,7 +373,7 @@ impl ISClusDisk_Vtbl {
             let this = (*this).get_impl();
             match this.ScsiAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscsiaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscsiaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -384,7 +384,7 @@ impl ISClusDisk_Vtbl {
             let this = (*this).get_impl();
             match this.DiskNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldisknumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldisknumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -395,7 +395,7 @@ impl ISClusDisk_Vtbl {
             let this = (*this).get_impl();
             match this.Partitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppartitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppartitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl ISClusDisks_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl ISClusDisks_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -451,7 +451,7 @@ impl ISClusDisks_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -489,7 +489,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.CommonProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -500,7 +500,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -511,7 +511,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.CommonROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -522,7 +522,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -533,7 +533,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -544,7 +544,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -555,7 +555,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -566,7 +566,7 @@ impl ISClusNetInterface_Vtbl {
             let this = (*this).get_impl();
             match this.Cluster() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcluster = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcluster, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -605,7 +605,7 @@ impl ISClusNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -616,7 +616,7 @@ impl ISClusNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -632,7 +632,7 @@ impl ISClusNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusnetinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusnetinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -674,7 +674,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.CommonProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -685,7 +685,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -696,7 +696,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.CommonROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -707,7 +707,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -718,7 +718,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -729,7 +729,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -745,7 +745,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnetworkid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnetworkid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -756,7 +756,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -767,7 +767,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.NetInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusnetinterfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusnetinterfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -778,7 +778,7 @@ impl ISClusNetwork_Vtbl {
             let this = (*this).get_impl();
             match this.Cluster() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcluster = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcluster, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -820,7 +820,7 @@ impl ISClusNetworkNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -831,7 +831,7 @@ impl ISClusNetworkNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -847,7 +847,7 @@ impl ISClusNetworkNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusnetinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusnetinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -882,7 +882,7 @@ impl ISClusNetworks_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -893,7 +893,7 @@ impl ISClusNetworks_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -909,7 +909,7 @@ impl ISClusNetworks_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.CommonProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -965,7 +965,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -976,7 +976,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.CommonROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -987,7 +987,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -998,7 +998,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1009,7 +1009,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1020,7 +1020,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.NodeID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnodeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnodeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1031,7 +1031,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1057,7 +1057,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.ResourceGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresourcegroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresourcegroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1068,7 +1068,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.Cluster() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcluster = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcluster, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1079,7 +1079,7 @@ impl ISClusNode_Vtbl {
             let this = (*this).get_impl();
             match this.NetInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusnetinterfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusnetinterfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1124,7 +1124,7 @@ impl ISClusNodeNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1135,7 +1135,7 @@ impl ISClusNodeNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1151,7 +1151,7 @@ impl ISClusNodeNetInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusnetinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusnetinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1186,7 +1186,7 @@ impl ISClusNodes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1197,7 +1197,7 @@ impl ISClusNodes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1213,7 +1213,7 @@ impl ISClusNodes_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1251,7 +1251,7 @@ impl ISClusPartition_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1262,7 +1262,7 @@ impl ISClusPartition_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1273,7 +1273,7 @@ impl ISClusPartition_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeLabel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvolumelabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvolumelabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1284,7 +1284,7 @@ impl ISClusPartition_Vtbl {
             let this = (*this).get_impl();
             match this.SerialNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plserialnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plserialnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1295,7 +1295,7 @@ impl ISClusPartition_Vtbl {
             let this = (*this).get_impl();
             match this.MaximumComponentLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaximumcomponentlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaximumcomponentlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1306,7 +1306,7 @@ impl ISClusPartition_Vtbl {
             let this = (*this).get_impl();
             match this.FileSystemFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfilesystemflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfilesystemflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1317,7 +1317,7 @@ impl ISClusPartition_Vtbl {
             let this = (*this).get_impl();
             match this.FileSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfilesystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfilesystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1356,7 +1356,7 @@ impl ISClusPartitionEx_Vtbl {
             let this = (*this).get_impl();
             match this.TotalSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltotalsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltotalsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1367,7 +1367,7 @@ impl ISClusPartitionEx_Vtbl {
             let this = (*this).get_impl();
             match this.FreeSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfreespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfreespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1378,7 +1378,7 @@ impl ISClusPartitionEx_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldevicenumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldevicenumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1389,7 +1389,7 @@ impl ISClusPartitionEx_Vtbl {
             let this = (*this).get_impl();
             match this.PartitionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpartitionnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpartitionnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1400,7 +1400,7 @@ impl ISClusPartitionEx_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvolumeguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvolumeguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1435,7 +1435,7 @@ impl ISClusPartitions_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1446,7 +1446,7 @@ impl ISClusPartitions_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1457,7 +1457,7 @@ impl ISClusPartitions_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppartition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppartition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1498,7 +1498,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1509,7 +1509,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1525,7 +1525,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1536,7 +1536,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrname), ::core::mem::transmute(&varvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1552,7 +1552,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.SaveChanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1563,7 +1563,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreadonly = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreadonly, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1574,7 +1574,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Private() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprivate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprivate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1585,7 +1585,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Common() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcommon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcommon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1596,7 +1596,7 @@ impl ISClusProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1649,7 +1649,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1660,7 +1660,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1671,7 +1671,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.ValueCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1682,7 +1682,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Values() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterpropertyvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterpropertyvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1693,7 +1693,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1709,7 +1709,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1725,7 +1725,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Format() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1741,7 +1741,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreadonly = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreadonly, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1752,7 +1752,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Private() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprivate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprivate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1763,7 +1763,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Common() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcommon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcommon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1774,7 +1774,7 @@ impl ISClusProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1830,7 +1830,7 @@ impl ISClusPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1846,7 +1846,7 @@ impl ISClusPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1862,7 +1862,7 @@ impl ISClusPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Format() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1878,7 +1878,7 @@ impl ISClusPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1889,7 +1889,7 @@ impl ISClusPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.DataCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1900,7 +1900,7 @@ impl ISClusPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterpropertyvaluedata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterpropertyvaluedata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1941,7 +1941,7 @@ impl ISClusPropertyValueData_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1952,7 +1952,7 @@ impl ISClusPropertyValueData_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1963,7 +1963,7 @@ impl ISClusPropertyValueData_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1974,7 +1974,7 @@ impl ISClusPropertyValueData_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&varvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2016,7 +2016,7 @@ impl ISClusPropertyValues_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2027,7 +2027,7 @@ impl ISClusPropertyValues_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2038,7 +2038,7 @@ impl ISClusPropertyValues_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2049,7 +2049,7 @@ impl ISClusPropertyValues_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrname), ::core::mem::transmute(&varvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2087,7 +2087,7 @@ impl ISClusRefObject_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2118,7 +2118,7 @@ impl ISClusRegistryKeys_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2129,7 +2129,7 @@ impl ISClusRegistryKeys_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2145,7 +2145,7 @@ impl ISClusRegistryKeys_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrregistrykey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrregistrykey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2196,7 +2196,7 @@ impl ISClusResDependencies_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2207,7 +2207,7 @@ impl ISClusResDependencies_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2223,7 +2223,7 @@ impl ISClusResDependencies_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2234,7 +2234,7 @@ impl ISClusResDependencies_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrresourcename), ::core::mem::transmute(&bstrresourcetype), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2292,7 +2292,7 @@ impl ISClusResDependents_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2303,7 +2303,7 @@ impl ISClusResDependents_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2319,7 +2319,7 @@ impl ISClusResDependents_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2330,7 +2330,7 @@ impl ISClusResDependents_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrresourcename), ::core::mem::transmute(&bstrresourcetype), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2396,7 +2396,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.CommonProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2407,7 +2407,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2418,7 +2418,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.CommonROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2429,7 +2429,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2440,7 +2440,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2451,7 +2451,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2467,7 +2467,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2478,7 +2478,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppownernode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppownernode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2489,7 +2489,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Resources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclustergroupresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclustergroupresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2500,7 +2500,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredOwnerNodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppownernodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppownernodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2516,7 +2516,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Online(::core::mem::transmute(&vartimeout), ::core::mem::transmute(&varnode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpending = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpending, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2527,7 +2527,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Move(::core::mem::transmute(&vartimeout), ::core::mem::transmute(&varnode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpending = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpending, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2538,7 +2538,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Offline(::core::mem::transmute(&vartimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpending = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpending, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2549,7 +2549,7 @@ impl ISClusResGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Cluster() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcluster = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcluster, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2601,7 +2601,7 @@ impl ISClusResGroupPreferredOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2612,7 +2612,7 @@ impl ISClusResGroupPreferredOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2628,7 +2628,7 @@ impl ISClusResGroupPreferredOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2649,7 +2649,7 @@ impl ISClusResGroupPreferredOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2701,7 +2701,7 @@ impl ISClusResGroupResources_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2712,7 +2712,7 @@ impl ISClusResGroupResources_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2728,7 +2728,7 @@ impl ISClusResGroupResources_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2739,7 +2739,7 @@ impl ISClusResGroupResources_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrresourcename), ::core::mem::transmute(&bstrresourcetype), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2783,7 +2783,7 @@ impl ISClusResGroups_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2794,7 +2794,7 @@ impl ISClusResGroups_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2810,7 +2810,7 @@ impl ISClusResGroups_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusresgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusresgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2821,7 +2821,7 @@ impl ISClusResGroups_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrresourcegroupname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresourcegroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresourcegroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2866,7 +2866,7 @@ impl ISClusResPossibleOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2877,7 +2877,7 @@ impl ISClusResPossibleOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2893,7 +2893,7 @@ impl ISClusResPossibleOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2914,7 +2914,7 @@ impl ISClusResPossibleOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2958,7 +2958,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.CommonProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2969,7 +2969,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2980,7 +2980,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.CommonROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2991,7 +2991,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3002,7 +3002,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3018,7 +3018,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.Cluster() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcluster = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcluster, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3029,7 +3029,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.Resources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterrestyperesources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterrestyperesources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3040,7 +3040,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.PossibleOwnerNodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppownernodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppownernodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3051,7 +3051,7 @@ impl ISClusResType_Vtbl {
             let this = (*this).get_impl();
             match this.AvailableDisks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppavailabledisks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppavailabledisks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3092,7 +3092,7 @@ impl ISClusResTypePossibleOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3103,7 +3103,7 @@ impl ISClusResTypePossibleOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3119,7 +3119,7 @@ impl ISClusResTypePossibleOwnerNodes_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3156,7 +3156,7 @@ impl ISClusResTypeResources_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3167,7 +3167,7 @@ impl ISClusResTypeResources_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3183,7 +3183,7 @@ impl ISClusResTypeResources_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3194,7 +3194,7 @@ impl ISClusResTypeResources_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrresourcename), ::core::mem::transmute(&bstrgroupname), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3238,7 +3238,7 @@ impl ISClusResTypes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3249,7 +3249,7 @@ impl ISClusResTypes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3265,7 +3265,7 @@ impl ISClusResTypes_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusrestype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusrestype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3276,7 +3276,7 @@ impl ISClusResTypes_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrresourcetypename), ::core::mem::transmute(&bstrdisplayname), ::core::mem::transmute(&bstrresourcetypedll), ::core::mem::transmute_copy(&dwlooksalivepollinterval), ::core::mem::transmute_copy(&dwisalivepollinterval)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresourcetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresourcetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3346,7 +3346,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.CommonProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3357,7 +3357,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3368,7 +3368,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.CommonROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3379,7 +3379,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3390,7 +3390,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3401,7 +3401,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3417,7 +3417,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3428,7 +3428,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.CoreFlag() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwcoreflag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwcoreflag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3454,7 +3454,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Online(::core::mem::transmute_copy(&ntimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpending = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpending, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3465,7 +3465,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Offline(::core::mem::transmute_copy(&ntimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpending = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpending, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3491,7 +3491,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.CanResourceBeDependent(::core::mem::transmute(&presource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardependent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardependent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3502,7 +3502,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.PossibleOwnerNodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppownernodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppownernodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3513,7 +3513,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Dependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresdependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresdependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3524,7 +3524,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Dependents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresdependents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresdependents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3535,7 +3535,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Group() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3546,7 +3546,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppownernode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppownernode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3557,7 +3557,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Cluster() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcluster = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcluster, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3568,7 +3568,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.ClassInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prcclassinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prcclassinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3579,7 +3579,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Disk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3590,7 +3590,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.RegistryKeys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppregistrykeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppregistrykeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3601,7 +3601,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.CryptoKeys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcryptokeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcryptokeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3612,7 +3612,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.TypeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtypename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtypename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3623,7 +3623,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresourcetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresourcetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3634,7 +3634,7 @@ impl ISClusResource_Vtbl {
             let this = (*this).get_impl();
             match this.MaintenanceMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmaintenancemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmaintenancemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3704,7 +3704,7 @@ impl ISClusResources_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3715,7 +3715,7 @@ impl ISClusResources_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3731,7 +3731,7 @@ impl ISClusResources_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3742,7 +3742,7 @@ impl ISClusResources_Vtbl {
             let this = (*this).get_impl();
             match this.CreateItem(::core::mem::transmute(&bstrresourcename), ::core::mem::transmute(&bstrresourcetype), ::core::mem::transmute(&bstrgroupname), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3784,7 +3784,7 @@ impl ISClusScsiAddress_Vtbl {
             let this = (*this).get_impl();
             match this.PortNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarportnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarportnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3795,7 +3795,7 @@ impl ISClusScsiAddress_Vtbl {
             let this = (*this).get_impl();
             match this.PathId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpathid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpathid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3806,7 +3806,7 @@ impl ISClusScsiAddress_Vtbl {
             let this = (*this).get_impl();
             match this.TargetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvartargetid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvartargetid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3817,7 +3817,7 @@ impl ISClusScsiAddress_Vtbl {
             let this = (*this).get_impl();
             match this.Lun() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarlun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarlun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3858,7 +3858,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrclustername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrclustername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3869,7 +3869,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.MajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnmajorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnmajorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3880,7 +3880,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.MinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnminorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnminorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3891,7 +3891,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.BuildNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnbuildnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnbuildnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3902,7 +3902,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.VendorId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvendorid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvendorid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3913,7 +3913,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.CSDVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcsdversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcsdversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3924,7 +3924,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.ClusterHighestVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnclusterhighestversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnclusterhighestversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3935,7 +3935,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.ClusterLowestVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnclusterlowestversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnclusterlowestversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3946,7 +3946,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3957,7 +3957,7 @@ impl ISClusVersion_Vtbl {
             let this = (*this).get_impl();
             match this.MixedVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmixedversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmixedversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4015,7 +4015,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.CommonProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4026,7 +4026,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4037,7 +4037,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.CommonROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4048,7 +4048,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateROProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4059,7 +4059,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4075,7 +4075,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4091,7 +4091,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4107,7 +4107,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.QuorumResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclusterresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclusterresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4118,7 +4118,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.QuorumLogSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnlogsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnlogsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4134,7 +4134,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.QuorumPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4150,7 +4150,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.Nodes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4161,7 +4161,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.ResourceGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterresourcegroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterresourcegroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4172,7 +4172,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.Resources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclusterresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclusterresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4183,7 +4183,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.ResourceTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresourcetypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresourcetypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4194,7 +4194,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.Networks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetworks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetworks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4205,7 +4205,7 @@ impl ISCluster_Vtbl {
             let this = (*this).get_impl();
             match this.NetInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetinterfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetinterfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4258,7 +4258,7 @@ impl ISClusterNames_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4269,7 +4269,7 @@ impl ISClusterNames_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4285,7 +4285,7 @@ impl ISClusterNames_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrclustername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrclustername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4296,7 +4296,7 @@ impl ISClusterNames_Vtbl {
             let this = (*this).get_impl();
             match this.DomainName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdomainname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdomainname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4332,7 +4332,7 @@ impl ISDomainNames_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4343,7 +4343,7 @@ impl ISDomainNames_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4359,7 +4359,7 @@ impl ISDomainNames_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&varindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdomainname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdomainname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
@@ -16,7 +16,7 @@ impl IEnumNetworkConnections_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IEnumNetworkConnections_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -79,7 +79,7 @@ impl IEnumNetworks_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -105,7 +105,7 @@ impl IEnumNetworks_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -150,7 +150,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psznetworkname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psznetworkname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -166,7 +166,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -182,7 +182,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgdguidnetworkid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgdguidnetworkid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -193,7 +193,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetDomainType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnetworktype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnetworktype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumnetworkconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumnetworkconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -220,7 +220,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnectedToInternet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -231,7 +231,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -242,7 +242,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectivity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconnectivity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconnectivity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -253,7 +253,7 @@ impl INetwork_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcategory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcategory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl INetworkConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetwork() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl INetworkConnection_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnectedToInternet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -327,7 +327,7 @@ impl INetworkConnection_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -338,7 +338,7 @@ impl INetworkConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectivity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconnectivity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconnectivity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -349,7 +349,7 @@ impl INetworkConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgdconnectionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgdconnectionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -360,7 +360,7 @@ impl INetworkConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdapterId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgdadapterid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgdadapterid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -371,7 +371,7 @@ impl INetworkConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDomainType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdomaintype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdomaintype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -407,7 +407,7 @@ impl INetworkConnectionCost_Vtbl {
             let this = (*this).get_impl();
             match this.GetCost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcost = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcost, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -418,7 +418,7 @@ impl INetworkConnectionCost_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataPlanStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdataplanstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdataplanstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -615,7 +615,7 @@ impl INetworkListManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworks(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -626,7 +626,7 @@ impl INetworkListManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetwork(::core::mem::transmute(&gdnetworkid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -637,7 +637,7 @@ impl INetworkListManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl INetworkListManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkConnection(::core::mem::transmute(&gdnetworkconnectionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetworkconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetworkconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -659,7 +659,7 @@ impl INetworkListManager_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnectedToInternet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -670,7 +670,7 @@ impl INetworkListManager_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -681,7 +681,7 @@ impl INetworkListManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectivity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconnectivity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconnectivity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
@@ -10,7 +10,7 @@ impl IFindSimilarResults_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -67,7 +67,7 @@ impl IRdcFileReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -83,7 +83,7 @@ impl IRdcFileReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilePosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offsetfromstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offsetfromstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -116,7 +116,7 @@ impl IRdcFileWriter_Vtbl {
             let this = (*this).get_impl();
             match this.Write(::core::mem::transmute_copy(&offsetfilestart), ::core::mem::transmute_copy(&bytestowrite)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -158,7 +158,7 @@ impl IRdcGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeneratorParameters(::core::mem::transmute_copy(&level)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *igeneratorparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(igeneratorparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -193,7 +193,7 @@ impl IRdcGeneratorFilterMaxParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetHorizonSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *horizonsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(horizonsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -209,7 +209,7 @@ impl IRdcGeneratorFilterMaxParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetHashWindowSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hashwindowsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hashwindowsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -246,7 +246,7 @@ impl IRdcGeneratorParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeneratorParametersType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parameterstype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parameterstype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -262,7 +262,7 @@ impl IRdcGeneratorParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetSerializeSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -302,7 +302,7 @@ impl IRdcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeDefaultRecursionDepth(::core::mem::transmute_copy(&filesize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *depth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(depth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -313,7 +313,7 @@ impl IRdcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeneratorParameters(::core::mem::transmute_copy(&parameterstype), ::core::mem::transmute_copy(&level)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *igeneratorparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(igeneratorparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -324,7 +324,7 @@ impl IRdcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.OpenGeneratorParameters(::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&parametersblob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *igeneratorparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(igeneratorparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -335,7 +335,7 @@ impl IRdcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGenerator(::core::mem::transmute_copy(&depth), ::core::mem::transmute_copy(&igeneratorparametersarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *igenerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(igenerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -346,7 +346,7 @@ impl IRdcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateComparator(::core::mem::transmute(&iseedsignaturesfile), ::core::mem::transmute_copy(&comparatorbuffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *icomparator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icomparator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -357,7 +357,7 @@ impl IRdcLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSignatureReader(::core::mem::transmute(&ifilereader)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isignaturereader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isignaturereader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -398,7 +398,7 @@ impl IRdcSignatureReader_Vtbl {
             let this = (*this).get_impl();
             match this.ReadHeader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rdc_errorcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rdc_errorcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -436,7 +436,7 @@ impl IRdcSimilarityGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.Results() {
                 ::core::result::Result::Ok(ok__) => {
-                    *similaritydata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(similaritydata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -472,7 +472,7 @@ impl ISimilarity_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTable(::core::mem::transmute(&path), ::core::mem::transmute_copy(&truncate), ::core::mem::transmute_copy(&securitydescriptor), ::core::mem::transmute_copy(&recordsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -483,7 +483,7 @@ impl ISimilarity_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTableIndirect(::core::mem::transmute(&mapping), ::core::mem::transmute(&fileidfile), ::core::mem::transmute_copy(&truncate), ::core::mem::transmute_copy(&recordsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -504,7 +504,7 @@ impl ISimilarity_Vtbl {
             let this = (*this).get_impl();
             match this.FindSimilarFileId(::core::mem::transmute_copy(&similaritydata), ::core::mem::transmute_copy(&numberofmatchesrequired), ::core::mem::transmute_copy(&resultssize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *findsimilarresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(findsimilarresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -520,7 +520,7 @@ impl ISimilarity_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recordcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recordcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -561,7 +561,7 @@ impl ISimilarityFileIdTable_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTable(::core::mem::transmute(&path), ::core::mem::transmute_copy(&truncate), ::core::mem::transmute_copy(&securitydescriptor), ::core::mem::transmute_copy(&recordsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -572,7 +572,7 @@ impl ISimilarityFileIdTable_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTableIndirect(::core::mem::transmute(&fileidfile), ::core::mem::transmute_copy(&truncate), ::core::mem::transmute_copy(&recordsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -588,7 +588,7 @@ impl ISimilarityFileIdTable_Vtbl {
             let this = (*this).get_impl();
             match this.Append(::core::mem::transmute_copy(&similarityfileid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *similarityfileindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(similarityfileindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -599,7 +599,7 @@ impl ISimilarityFileIdTable_Vtbl {
             let this = (*this).get_impl();
             match this.Lookup(::core::mem::transmute_copy(&similarityfileindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *similarityfileid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(similarityfileid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -615,7 +615,7 @@ impl ISimilarityFileIdTable_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recordcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recordcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -700,7 +700,7 @@ impl ISimilarityTraitsMappedView_Vtbl {
             let this = (*this).get_impl();
             match this.Get(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&dirty), ::core::mem::transmute_copy(&numelements)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *viewinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(viewinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -750,7 +750,7 @@ impl ISimilarityTraitsMapping_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -761,7 +761,7 @@ impl ISimilarityTraitsMapping_Vtbl {
             let this = (*this).get_impl();
             match this.OpenMapping(::core::mem::transmute_copy(&accessmode), ::core::mem::transmute_copy(&begin), ::core::mem::transmute_copy(&end)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *actualend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actualend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -772,7 +772,7 @@ impl ISimilarityTraitsMapping_Vtbl {
             let this = (*this).get_impl();
             match this.ResizeMapping(::core::mem::transmute_copy(&accessmode), ::core::mem::transmute_copy(&begin), ::core::mem::transmute_copy(&end)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *actualend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actualend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -788,7 +788,7 @@ impl ISimilarityTraitsMapping_Vtbl {
             let this = (*this).get_impl();
             match this.CreateView(::core::mem::transmute_copy(&minimummappedpages), ::core::mem::transmute_copy(&accessmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mappedview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mappedview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -829,7 +829,7 @@ impl ISimilarityTraitsTable_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTable(::core::mem::transmute(&path), ::core::mem::transmute_copy(&truncate), ::core::mem::transmute_copy(&securitydescriptor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -840,7 +840,7 @@ impl ISimilarityTraitsTable_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTableIndirect(::core::mem::transmute(&mapping), ::core::mem::transmute_copy(&truncate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -866,7 +866,7 @@ impl ISimilarityTraitsTable_Vtbl {
             let this = (*this).get_impl();
             match this.BeginDump() {
                 ::core::result::Result::Ok(ok__) => {
-                    *similaritytabledumpstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(similaritytabledumpstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -877,7 +877,7 @@ impl ISimilarityTraitsTable_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fileindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fileindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
@@ -18,7 +18,7 @@ impl IDialBranding_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitmap(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -76,7 +76,7 @@ impl IDialEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectedState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -87,7 +87,7 @@ impl IDialEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/impl.rs
@@ -15,7 +15,7 @@ impl IContentPrefetcherTaskTrigger_Vtbl {
             let this = (*this).get_impl();
             match this.IsRegisteredForContentPrefetch(::core::mem::transmute(&packagefullname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isregistered = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isregistered, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
@@ -22,7 +22,7 @@ impl AsyncIAssociatedIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_AssociateIdentity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -110,7 +110,7 @@ impl AsyncIConnectedIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *connected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(connected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -136,7 +136,7 @@ impl AsyncIConnectedIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_GetAccountState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl AsyncIIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_GetIdentityEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidentityenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidentityenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -281,7 +281,7 @@ impl AsyncIIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_Create() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl AsyncIIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_FindByUniqueID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -333,7 +333,7 @@ impl AsyncIIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_GetProviderPropertyStore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -349,7 +349,7 @@ impl AsyncIIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_Advise() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -419,7 +419,7 @@ impl AsyncIIdentityStore_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwproviders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwproviders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -465,7 +465,7 @@ impl AsyncIIdentityStore_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_EnumerateIdentities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidentityenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidentityenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -558,7 +558,7 @@ impl IAssociatedIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.AssociateIdentity(::core::mem::transmute_copy(&hwndparent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -613,7 +613,7 @@ impl IConnectedIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *connected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(connected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -629,7 +629,7 @@ impl IConnectedIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccountState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -716,7 +716,7 @@ impl IIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetIdentityEnum(::core::mem::transmute_copy(&eidentitytype), ::core::mem::transmute_copy(&pfilterkey), ::core::mem::transmute_copy(&pfilterpropvarvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidentityenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidentityenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -742,7 +742,7 @@ impl IIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindByUniqueID(::core::mem::transmute(&lpszuniqueid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -753,7 +753,7 @@ impl IIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderPropertyStore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertystore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertystore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -764,7 +764,7 @@ impl IIdentityProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&pidentityadvise), ::core::mem::transmute_copy(&dwidentityupdateevents)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -810,7 +810,7 @@ impl IIdentityStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwproviders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwproviders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -836,7 +836,7 @@ impl IIdentityStore_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateIdentities(::core::mem::transmute_copy(&eidentitytype), ::core::mem::transmute_copy(&pfilterkey), ::core::mem::transmute_copy(&pfilterpropvarvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidentityenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidentityenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
@@ -199,7 +199,7 @@ impl ISecurityInformation3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullResourceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszresourcename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszresourcename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/impl.rs
@@ -72,7 +72,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -88,7 +88,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -104,7 +104,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplicationdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplicationdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -120,7 +120,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.AuthzInterfaceClsid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -136,7 +136,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -152,7 +152,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateAudits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -168,7 +168,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.ApplyStoreSacl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -184,7 +184,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Writable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -195,7 +195,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -211,7 +211,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyAdministrators() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaradmins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaradmins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -222,7 +222,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyReaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -253,7 +253,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Scopes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscopecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscopecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -264,7 +264,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.OpenScope(::core::mem::transmute(&bstrscopename), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -275,7 +275,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.CreateScope(::core::mem::transmute(&bstrscopename), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -291,7 +291,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Operations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoperationcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoperationcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -302,7 +302,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.OpenOperation(::core::mem::transmute(&bstroperationname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoperation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoperation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -313,7 +313,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.CreateOperation(::core::mem::transmute(&bstroperationname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoperation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoperation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -329,7 +329,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Tasks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptaskcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptaskcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -340,7 +340,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.OpenTask(::core::mem::transmute(&bstrtaskname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -351,7 +351,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTask(::core::mem::transmute(&bstrtaskname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -367,7 +367,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroupcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroupcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -378,7 +378,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.OpenApplicationGroup(::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -389,7 +389,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplicationGroup(::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -405,7 +405,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Roles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprolecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprolecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -416,7 +416,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.OpenRole(::core::mem::transmute(&bstrrolename), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -427,7 +427,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRole(::core::mem::transmute(&bstrrolename), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -443,7 +443,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.InitializeClientContextFromToken(::core::mem::transmute_copy(&ulltokenhandle), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclientcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclientcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -469,7 +469,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.InitializeClientContextFromName(::core::mem::transmute(&clientname), ::core::mem::transmute(&domainname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclientcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclientcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -480,7 +480,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.DelegatedPolicyUsers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardelegatedpolicyusers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardelegatedpolicyusers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -501,7 +501,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.InitializeClientContextFromStringSid(::core::mem::transmute(&sidstring), ::core::mem::transmute_copy(&loptions), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclientcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclientcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -512,7 +512,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyAdministratorsName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaradmins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaradmins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -523,7 +523,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyReadersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -554,7 +554,7 @@ impl IAzApplication_Vtbl {
             let this = (*this).get_impl();
             match this.DelegatedPolicyUsersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardelegatedpolicyusers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardelegatedpolicyusers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -654,7 +654,7 @@ impl IAzApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.InitializeClientContextFromToken2(::core::mem::transmute_copy(&ultokenhandlelowpart), ::core::mem::transmute_copy(&ultokenhandlehighpart), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclientcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclientcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -665,7 +665,7 @@ impl IAzApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.InitializeClientContext2(::core::mem::transmute(&identifyingstring), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclientcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclientcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -708,7 +708,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.ScopeExists(::core::mem::transmute(&bstrscopename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbexist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbexist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -719,7 +719,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.OpenScope2(::core::mem::transmute(&bstrscopename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscope2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscope2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -730,7 +730,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateScope2(::core::mem::transmute(&bstrscopename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscope2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscope2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -746,7 +746,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.RoleDefinitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -757,7 +757,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRoleDefinition(::core::mem::transmute(&bstrroledefinitionname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -768,7 +768,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.OpenRoleDefinition(::core::mem::transmute(&bstrroledefinitionname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -784,7 +784,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.RoleAssignments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -795,7 +795,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRoleAssignment(::core::mem::transmute(&bstrroleassignmentname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -806,7 +806,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.OpenRoleAssignment(::core::mem::transmute(&bstrroleassignmentname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -822,7 +822,7 @@ impl IAzApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.BizRulesEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -900,7 +900,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -916,7 +916,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -932,7 +932,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.LdapQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -948,7 +948,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.AppMembers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -959,7 +959,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.AppNonMembers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -970,7 +970,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Members() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -981,7 +981,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.NonMembers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -992,7 +992,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1048,7 +1048,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Writable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1059,7 +1059,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1110,7 +1110,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.MembersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1121,7 +1121,7 @@ impl IAzApplicationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.NonMembersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1187,7 +1187,7 @@ impl IAzApplicationGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.BizRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1203,7 +1203,7 @@ impl IAzApplicationGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.BizRuleLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1219,7 +1219,7 @@ impl IAzApplicationGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.BizRuleImportedPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1235,7 +1235,7 @@ impl IAzApplicationGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.RoleAssignments(::core::mem::transmute(&bstrscopename), ::core::mem::transmute_copy(&brecursive)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1272,7 +1272,7 @@ impl IAzApplicationGroups_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1283,7 +1283,7 @@ impl IAzApplicationGroups_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1294,7 +1294,7 @@ impl IAzApplicationGroups_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1327,7 +1327,7 @@ impl IAzApplications_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1338,7 +1338,7 @@ impl IAzApplications_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1349,7 +1349,7 @@ impl IAzApplications_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1430,7 +1430,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1446,7 +1446,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplicationdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplicationdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1462,7 +1462,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.DomainTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1478,7 +1478,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.ScriptEngineTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1494,7 +1494,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.MaxScriptEngines() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1510,7 +1510,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateAudits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1526,7 +1526,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.Writable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1537,7 +1537,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1563,7 +1563,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyAdministrators() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaradmins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaradmins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1574,7 +1574,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyReaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1620,7 +1620,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.Applications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppappcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppappcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1631,7 +1631,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.OpenApplication(::core::mem::transmute(&bstrapplicationname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppapplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppapplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1642,7 +1642,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplication(::core::mem::transmute(&bstrapplicationname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppapplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppapplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1658,7 +1658,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroupcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroupcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1669,7 +1669,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplicationGroup(::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1680,7 +1680,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.OpenApplicationGroup(::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1701,7 +1701,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.DelegatedPolicyUsers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardelegatedpolicyusers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardelegatedpolicyusers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1722,7 +1722,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.TargetMachine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtargetmachine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtargetmachine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1733,7 +1733,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.ApplyStoreSacl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbapplystoresacl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbapplystoresacl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1749,7 +1749,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyAdministratorsName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaradmins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaradmins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1760,7 +1760,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyReadersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1791,7 +1791,7 @@ impl IAzAuthorizationStore_Vtbl {
             let this = (*this).get_impl();
             match this.DelegatedPolicyUsersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardelegatedpolicyusers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardelegatedpolicyusers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1886,7 +1886,7 @@ impl IAzAuthorizationStore2_Vtbl {
             let this = (*this).get_impl();
             match this.OpenApplication2(::core::mem::transmute(&bstrapplicationname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppapplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppapplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1897,7 +1897,7 @@ impl IAzAuthorizationStore2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplication2(::core::mem::transmute(&bstrapplicationname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppapplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppapplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1931,7 +1931,7 @@ impl IAzAuthorizationStore3_Vtbl {
             let this = (*this).get_impl();
             match this.IsUpdateNeeded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisupdateneeded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisupdateneeded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1942,7 +1942,7 @@ impl IAzAuthorizationStore3_Vtbl {
             let this = (*this).get_impl();
             match this.BizruleGroupSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1958,7 +1958,7 @@ impl IAzAuthorizationStore3_Vtbl {
             let this = (*this).get_impl();
             match this.IsFunctionalLevelUpgradeSupported(::core::mem::transmute_copy(&lfunctionallevel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2009,7 +2009,7 @@ impl IAzBizRuleContext_Vtbl {
             let this = (*this).get_impl();
             match this.BusinessRuleString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbusinessrulestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbusinessrulestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2020,7 +2020,7 @@ impl IAzBizRuleContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameter(::core::mem::transmute(&bstrparametername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarparametervalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarparametervalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2082,7 +2082,7 @@ impl IAzBizRuleInterfaces_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2131,7 +2131,7 @@ impl IAzBizRuleParameters_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameterValue(::core::mem::transmute(&bstrparametername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarparametervalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarparametervalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2152,7 +2152,7 @@ impl IAzBizRuleParameters_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2209,7 +2209,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.AccessCheck(::core::mem::transmute(&bstrobjectname), ::core::mem::transmute(&varscopenames), ::core::mem::transmute(&varoperations), ::core::mem::transmute(&varparameternames), ::core::mem::transmute(&varparametervalues), ::core::mem::transmute(&varinterfacenames), ::core::mem::transmute(&varinterfaceflags), ::core::mem::transmute(&varinterfaces)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2220,7 +2220,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetBusinessRuleString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbusinessrulestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbusinessrulestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2231,7 +2231,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserDn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2242,7 +2242,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserSamCompat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2253,7 +2253,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserDisplay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2264,7 +2264,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2275,7 +2275,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserCanonical() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2286,7 +2286,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserUpn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2297,7 +2297,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.UserDnsSamCompat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2308,7 +2308,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2319,7 +2319,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetRoles(::core::mem::transmute(&bstrscopename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarrolenames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarrolenames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2330,7 +2330,7 @@ impl IAzClientContext_Vtbl {
             let this = (*this).get_impl();
             match this.RoleForAccessCheck() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2406,7 +2406,7 @@ impl IAzClientContext2_Vtbl {
             let this = (*this).get_impl();
             match this.LDAPQueryDN() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrldapquerydn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrldapquerydn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2447,7 +2447,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.AccessCheck2(::core::mem::transmute(&bstrobjectname), ::core::mem::transmute(&bstrscopename), ::core::mem::transmute_copy(&loperation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2458,7 +2458,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.IsInRoleAssignment(::core::mem::transmute(&bstrscopename), ::core::mem::transmute(&bstrrolename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisinrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisinrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2469,7 +2469,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOperations(::core::mem::transmute(&bstrscopename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoperationcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoperationcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2480,7 +2480,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTasks(::core::mem::transmute(&bstrscopename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptaskcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptaskcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2491,7 +2491,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.BizRuleParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbizruleparam = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbizruleparam, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2502,7 +2502,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.BizRuleInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbizruleinterfaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbizruleinterfaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2513,7 +2513,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroups(::core::mem::transmute(&bstrscopename), ::core::mem::transmute_copy(&uloptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgrouparray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgrouparray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2524,7 +2524,7 @@ impl IAzClientContext3_Vtbl {
             let this = (*this).get_impl();
             match this.Sids() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstringsidarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstringsidarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2596,7 +2596,7 @@ impl IAzObjectPicker_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2637,7 +2637,7 @@ impl IAzOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2653,7 +2653,7 @@ impl IAzOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2669,7 +2669,7 @@ impl IAzOperation_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplicationdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplicationdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2685,7 +2685,7 @@ impl IAzOperation_Vtbl {
             let this = (*this).get_impl();
             match this.OperationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2701,7 +2701,7 @@ impl IAzOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Writable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2712,7 +2712,7 @@ impl IAzOperation_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2762,7 +2762,7 @@ impl IAzOperation2_Vtbl {
             let this = (*this).get_impl();
             match this.RoleAssignments(::core::mem::transmute(&bstrscopename), ::core::mem::transmute_copy(&brecursive)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2790,7 +2790,7 @@ impl IAzOperations_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2801,7 +2801,7 @@ impl IAzOperations_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2812,7 +2812,7 @@ impl IAzOperations_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2844,7 +2844,7 @@ impl IAzPrincipalLocator_Vtbl {
             let this = (*this).get_impl();
             match this.NameResolver() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnameresolver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnameresolver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2855,7 +2855,7 @@ impl IAzPrincipalLocator_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectPicker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjectpicker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjectpicker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2911,7 +2911,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2927,7 +2927,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2943,7 +2943,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplicationdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplicationdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2999,7 +2999,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.Writable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3010,7 +3010,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3026,7 +3026,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.AppMembers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3037,7 +3037,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.Members() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3048,7 +3048,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.Operations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3059,7 +3059,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.Tasks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3095,7 +3095,7 @@ impl IAzRole_Vtbl {
             let this = (*this).get_impl();
             match this.MembersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3163,7 +3163,7 @@ impl IAzRoleAssignment_Vtbl {
             let this = (*this).get_impl();
             match this.RoleDefinitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3174,7 +3174,7 @@ impl IAzRoleAssignment_Vtbl {
             let this = (*this).get_impl();
             match this.Scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3208,7 +3208,7 @@ impl IAzRoleAssignments_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3219,7 +3219,7 @@ impl IAzRoleAssignments_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3230,7 +3230,7 @@ impl IAzRoleAssignments_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3264,7 +3264,7 @@ impl IAzRoleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.RoleAssignments(::core::mem::transmute(&bstrscopename), ::core::mem::transmute_copy(&brecursive)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3285,7 +3285,7 @@ impl IAzRoleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.RoleDefinitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3319,7 +3319,7 @@ impl IAzRoleDefinitions_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3330,7 +3330,7 @@ impl IAzRoleDefinitions_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3341,7 +3341,7 @@ impl IAzRoleDefinitions_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3374,7 +3374,7 @@ impl IAzRoles_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3385,7 +3385,7 @@ impl IAzRoles_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3396,7 +3396,7 @@ impl IAzRoles_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3464,7 +3464,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3480,7 +3480,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3496,7 +3496,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplicationdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplicationdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.Writable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3549,7 +3549,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyAdministrators() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaradmins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaradmins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3560,7 +3560,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyReaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3591,7 +3591,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroupcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroupcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3602,7 +3602,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.OpenApplicationGroup(::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3613,7 +3613,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplicationGroup(::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3629,7 +3629,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.Roles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprolecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprolecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3640,7 +3640,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.OpenRole(::core::mem::transmute(&bstrrolename), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3651,7 +3651,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRole(::core::mem::transmute(&bstrrolename), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3667,7 +3667,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.Tasks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptaskcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptaskcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3678,7 +3678,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.OpenTask(::core::mem::transmute(&bstrtaskname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3689,7 +3689,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTask(::core::mem::transmute(&bstrtaskname), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3710,7 +3710,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.CanBeDelegated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3721,7 +3721,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.BizrulesWritable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3732,7 +3732,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyAdministratorsName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaradmins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaradmins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3743,7 +3743,7 @@ impl IAzScope_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyReadersName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarreaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarreaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3836,7 +3836,7 @@ impl IAzScope2_Vtbl {
             let this = (*this).get_impl();
             match this.RoleDefinitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3847,7 +3847,7 @@ impl IAzScope2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRoleDefinition(::core::mem::transmute(&bstrroledefinitionname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3858,7 +3858,7 @@ impl IAzScope2_Vtbl {
             let this = (*this).get_impl();
             match this.OpenRoleDefinition(::core::mem::transmute(&bstrroledefinitionname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3874,7 +3874,7 @@ impl IAzScope2_Vtbl {
             let this = (*this).get_impl();
             match this.RoleAssignments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3885,7 +3885,7 @@ impl IAzScope2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRoleAssignment(::core::mem::transmute(&bstrroleassignmentname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3896,7 +3896,7 @@ impl IAzScope2_Vtbl {
             let this = (*this).get_impl();
             match this.OpenRoleAssignment(::core::mem::transmute(&bstrroleassignmentname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3939,7 +3939,7 @@ impl IAzScopes_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3950,7 +3950,7 @@ impl IAzScopes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3961,7 +3961,7 @@ impl IAzScopes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4017,7 +4017,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4033,7 +4033,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4049,7 +4049,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplicationdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplicationdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4065,7 +4065,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.BizRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4081,7 +4081,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.BizRuleLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4097,7 +4097,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.BizRuleImportedPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4113,7 +4113,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.IsRoleDefinition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4129,7 +4129,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.Operations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4140,7 +4140,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.Tasks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4171,7 +4171,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.Writable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4182,7 +4182,7 @@ impl IAzTask_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lpropid), ::core::mem::transmute(&varreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4256,7 +4256,7 @@ impl IAzTask2_Vtbl {
             let this = (*this).get_impl();
             match this.RoleAssignments(::core::mem::transmute(&bstrscopename), ::core::mem::transmute_copy(&brecursive)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproleassignments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproleassignments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4284,7 +4284,7 @@ impl IAzTasks_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarobtptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarobtptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4295,7 +4295,7 @@ impl IAzTasks_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4306,7 +4306,7 @@ impl IAzTasks_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumptr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumptr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
@@ -33,7 +33,7 @@ impl IAlternativeName_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -44,7 +44,7 @@ impl IAlternativeName_Vtbl {
             let this = (*this).get_impl();
             match this.StrValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -55,7 +55,7 @@ impl IAlternativeName_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -66,7 +66,7 @@ impl IAlternativeName_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawData(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -106,7 +106,7 @@ impl IAlternativeNames_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -117,7 +117,7 @@ impl IAlternativeNames_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -128,7 +128,7 @@ impl IAlternativeNames_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -179,7 +179,7 @@ impl IBinaryConverter_Vtbl {
             let this = (*this).get_impl();
             match this.StringToString(::core::mem::transmute(&strencodedin), ::core::mem::transmute_copy(&encodingin), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencoded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencoded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl IBinaryConverter_Vtbl {
             let this = (*this).get_impl();
             match this.VariantByteArrayToString(::core::mem::transmute_copy(&pvarbytearray), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencoded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencoded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IBinaryConverter_Vtbl {
             let this = (*this).get_impl();
             match this.StringToVariantByteArray(::core::mem::transmute(&strencoded), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbytearray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbytearray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -233,7 +233,7 @@ impl IBinaryConverter2_Vtbl {
             let this = (*this).get_impl();
             match this.StringArrayToVariantArray(::core::mem::transmute_copy(&pvarstringarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvariantarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvariantarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -244,7 +244,7 @@ impl IBinaryConverter2_Vtbl {
             let this = (*this).get_impl();
             match this.VariantArrayToStringArray(::core::mem::transmute_copy(&pvarvariantarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarstringarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarstringarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -339,7 +339,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.createPKCS10(::core::mem::transmute(&dnname), ::core::mem::transmute(&usage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkcs10 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkcs10, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -355,7 +355,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.getCertFromPKCS7(::core::mem::transmute(&wszpkcs7)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -366,7 +366,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.enumProviders(::core::mem::transmute_copy(&dwindex), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprovname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprovname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -377,7 +377,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.enumContainers(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -393,7 +393,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.MyStoreName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -409,7 +409,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.MyStoreType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -425,7 +425,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.MyStoreFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -441,7 +441,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.CAStoreName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -457,7 +457,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.CAStoreType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -473,7 +473,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.CAStoreFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -489,7 +489,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.RootStoreName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -505,7 +505,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.RootStoreType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -521,7 +521,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.RootStoreFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -537,7 +537,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.RequestStoreName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -553,7 +553,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.RequestStoreType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -569,7 +569,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.RequestStoreFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -585,7 +585,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.ContainerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcontainer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcontainer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -601,7 +601,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -617,7 +617,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -633,7 +633,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.KeySpec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -649,7 +649,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -665,7 +665,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.UseExistingKeySet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fuseexistingkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fuseexistingkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -681,7 +681,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.GenKeyFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -697,7 +697,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.DeleteRequestCert() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fdelete = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fdelete, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -713,7 +713,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.WriteCertToCSP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -729,7 +729,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.SPCFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -745,7 +745,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.PVKFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -761,7 +761,7 @@ impl ICEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -865,7 +865,7 @@ impl ICEnroll2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteCertToUserDS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -881,7 +881,7 @@ impl ICEnroll2_Vtbl {
             let this = (*this).get_impl();
             match this.EnableT61DNEncoding() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedKeySpec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwkeyspec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwkeyspec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyLen(::core::mem::transmute_copy(&fmin), ::core::mem::transmute_copy(&fexchange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwkeysize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwkeysize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -965,7 +965,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAlgs(::core::mem::transmute_copy(&dwindex), ::core::mem::transmute_copy(&algclass)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwalgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwalgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -976,7 +976,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlgName(::core::mem::transmute_copy(&algid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -992,7 +992,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.ReuseHardwareKeyIfUnableToGenNew() {
                 ::core::result::Result::Ok(ok__) => {
-                    *freusehardwarekeyifunabletogennew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(freusehardwarekeyifunabletogennew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1008,7 +1008,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hashalgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hashalgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1024,7 +1024,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.LimitExchangeKeyToEncipherment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flimitexchangekeytoencipherment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flimitexchangekeytoencipherment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1040,7 +1040,7 @@ impl ICEnroll3_Vtbl {
             let this = (*this).get_impl();
             match this.EnableSMIMECapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fenablesmimecapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fenablesmimecapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1119,7 +1119,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateKeyArchiveCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1135,7 +1135,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.ThumbPrint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrthumbprint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrthumbprint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1146,7 +1146,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.binaryToString(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&strbinary)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencoded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencoded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1157,7 +1157,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.stringToBinary(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&strencoded)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbinary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbinary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1193,7 +1193,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.createRequest(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&strdnname), ::core::mem::transmute(&usage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrrequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrrequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1219,7 +1219,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.getCertFromResponse(::core::mem::transmute(&strresponse)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrcert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrcert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1230,7 +1230,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.getCertFromFileResponse(::core::mem::transmute(&strresponsefilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrcert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrcert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1241,7 +1241,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.createPFX(::core::mem::transmute(&strpassword)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrpfx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrpfx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1262,7 +1262,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.enumPendingRequest(::core::mem::transmute_copy(&lindex), ::core::mem::transmute_copy(&ldesiredproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1278,7 +1278,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyLenEx(::core::mem::transmute_copy(&lsizespec), ::core::mem::transmute_copy(&lkeyspec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwkeysize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwkeysize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1289,7 +1289,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.InstallPKCS7Ex(::core::mem::transmute(&pkcs7)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcertinstalled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcertinstalled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1305,7 +1305,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.getProviderType(::core::mem::transmute(&strprovname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprovtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprovtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1326,7 +1326,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.ClientId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plclientid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plclientid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1352,7 +1352,7 @@ impl ICEnroll4_Vtbl {
             let this = (*this).get_impl();
             match this.IncludeSubjectKeyID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinclude = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinclude, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1422,7 +1422,7 @@ impl ICertAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.IsValidCertificate(::core::mem::transmute(&strconfig), ::core::mem::transmute(&strserialnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1433,7 +1433,7 @@ impl ICertAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetRevocationReason() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preason = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preason, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1464,7 +1464,7 @@ impl ICertAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.ResubmitRequest(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&requestid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1480,7 +1480,7 @@ impl ICertAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetCRL(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrcrl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrcrl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1491,7 +1491,7 @@ impl ICertAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.ImportCertificate(::core::mem::transmute(&strconfig), ::core::mem::transmute(&strcertificate), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1544,7 +1544,7 @@ impl ICertAdmin2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAProperty(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&propid), ::core::mem::transmute_copy(&propindex), ::core::mem::transmute_copy(&proptype), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1560,7 +1560,7 @@ impl ICertAdmin2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAPropertyFlags(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&propid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1571,7 +1571,7 @@ impl ICertAdmin2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAPropertyDisplayName(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&propid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1582,7 +1582,7 @@ impl ICertAdmin2_Vtbl {
             let this = (*this).get_impl();
             match this.GetArchivedKey(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrarchivedkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrarchivedkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1593,7 +1593,7 @@ impl ICertAdmin2_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfigEntry(::core::mem::transmute(&strconfig), ::core::mem::transmute(&strnodepath), ::core::mem::transmute(&strentryname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1614,7 +1614,7 @@ impl ICertAdmin2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMyRoles(::core::mem::transmute(&strconfig)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *proles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(proles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1625,7 +1625,7 @@ impl ICertAdmin2_Vtbl {
             let this = (*this).get_impl();
             match this.DeleteRow(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&date), ::core::mem::transmute_copy(&table), ::core::mem::transmute_copy(&rowid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcdeleted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcdeleted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1667,7 +1667,7 @@ impl ICertConfig_Vtbl {
             let this = (*this).get_impl();
             match this.Reset(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1678,7 +1678,7 @@ impl ICertConfig_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1689,7 +1689,7 @@ impl ICertConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetField(::core::mem::transmute(&strfieldname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1700,7 +1700,7 @@ impl ICertConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfig(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1763,7 +1763,7 @@ impl ICertEncodeAltName_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnamecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnamecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1774,7 +1774,7 @@ impl ICertEncodeAltName_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameChoice(::core::mem::transmute_copy(&nameindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnamechoice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnamechoice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1785,7 +1785,7 @@ impl ICertEncodeAltName_Vtbl {
             let this = (*this).get_impl();
             match this.GetName(::core::mem::transmute_copy(&nameindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1806,7 +1806,7 @@ impl ICertEncodeAltName_Vtbl {
             let this = (*this).get_impl();
             match this.Encode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbinary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbinary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1849,7 +1849,7 @@ impl ICertEncodeAltName2_Vtbl {
             let this = (*this).get_impl();
             match this.EncodeBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencodeddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencodeddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1860,7 +1860,7 @@ impl ICertEncodeAltName2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameBlob(::core::mem::transmute_copy(&nameindex), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1905,7 +1905,7 @@ impl ICertEncodeBitString_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbitcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbitcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1916,7 +1916,7 @@ impl ICertEncodeBitString_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbitstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbitstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1927,7 +1927,7 @@ impl ICertEncodeBitString_Vtbl {
             let this = (*this).get_impl();
             match this.Encode(::core::mem::transmute_copy(&bitcount), ::core::mem::transmute(&strbitstring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbinary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbinary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1966,7 +1966,7 @@ impl ICertEncodeBitString2_Vtbl {
             let this = (*this).get_impl();
             match this.EncodeBlob(::core::mem::transmute_copy(&bitcount), ::core::mem::transmute(&strbitstring), ::core::mem::transmute_copy(&encodingin), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencodeddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencodeddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1977,7 +1977,7 @@ impl ICertEncodeBitString2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitStringBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbitstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbitstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2021,7 +2021,7 @@ impl ICertEncodeCRLDistInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDistPointCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdistpointcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdistpointcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2032,7 +2032,7 @@ impl ICertEncodeCRLDistInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameCount(::core::mem::transmute_copy(&distpointindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnamecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnamecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2043,7 +2043,7 @@ impl ICertEncodeCRLDistInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameChoice(::core::mem::transmute_copy(&distpointindex), ::core::mem::transmute_copy(&nameindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnamechoice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnamechoice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2054,7 +2054,7 @@ impl ICertEncodeCRLDistInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetName(::core::mem::transmute_copy(&distpointindex), ::core::mem::transmute_copy(&nameindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2080,7 +2080,7 @@ impl ICertEncodeCRLDistInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Encode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbinary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbinary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2123,7 +2123,7 @@ impl ICertEncodeCRLDistInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.EncodeBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencodeddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencodeddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2163,7 +2163,7 @@ impl ICertEncodeDateArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2174,7 +2174,7 @@ impl ICertEncodeDateArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2195,7 +2195,7 @@ impl ICertEncodeDateArray_Vtbl {
             let this = (*this).get_impl();
             match this.Encode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbinary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbinary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2235,7 +2235,7 @@ impl ICertEncodeDateArray2_Vtbl {
             let this = (*this).get_impl();
             match this.EncodeBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencodeddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencodeddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2275,7 +2275,7 @@ impl ICertEncodeLongArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2286,7 +2286,7 @@ impl ICertEncodeLongArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2307,7 +2307,7 @@ impl ICertEncodeLongArray_Vtbl {
             let this = (*this).get_impl();
             match this.Encode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbinary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbinary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2347,7 +2347,7 @@ impl ICertEncodeLongArray2_Vtbl {
             let this = (*this).get_impl();
             match this.EncodeBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencodeddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencodeddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2388,7 +2388,7 @@ impl ICertEncodeStringArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstringtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstringtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2399,7 +2399,7 @@ impl ICertEncodeStringArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2410,7 +2410,7 @@ impl ICertEncodeStringArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2431,7 +2431,7 @@ impl ICertEncodeStringArray_Vtbl {
             let this = (*this).get_impl();
             match this.Encode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrbinary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrbinary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2472,7 +2472,7 @@ impl ICertEncodeStringArray2_Vtbl {
             let this = (*this).get_impl();
             match this.EncodeBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencodeddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencodeddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2504,7 +2504,7 @@ impl ICertExit_Vtbl {
             let this = (*this).get_impl();
             match this.Initialize(::core::mem::transmute(&strconfig)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2520,7 +2520,7 @@ impl ICertExit_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2551,7 +2551,7 @@ impl ICertExit2_Vtbl {
             let this = (*this).get_impl();
             match this.GetManageModule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmanagemodule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmanagemodule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2577,7 +2577,7 @@ impl ICertGetConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfig(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2605,7 +2605,7 @@ impl ICertManageModule_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&strconfig), ::core::mem::transmute(&strstoragelocation), ::core::mem::transmute(&strpropertyname), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2654,7 +2654,7 @@ impl ICertPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.VerifyRequest(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&context), ::core::mem::transmute_copy(&bnewrequest), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2665,7 +2665,7 @@ impl ICertPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2702,7 +2702,7 @@ impl ICertPolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.GetManageModule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmanagemodule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmanagemodule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2734,7 +2734,7 @@ impl ICertProperties_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2745,7 +2745,7 @@ impl ICertProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2756,7 +2756,7 @@ impl ICertProperties_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2827,7 +2827,7 @@ impl ICertProperty_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2843,7 +2843,7 @@ impl ICertProperty_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawData(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2894,7 +2894,7 @@ impl ICertPropertyArchived_Vtbl {
             let this = (*this).get_impl();
             match this.Archived() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2930,7 +2930,7 @@ impl ICertPropertyArchivedKeyHash_Vtbl {
             let this = (*this).get_impl();
             match this.get_ArchivedKeyHash(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2966,7 +2966,7 @@ impl ICertPropertyAutoEnroll_Vtbl {
             let this = (*this).get_impl();
             match this.TemplateName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3009,7 +3009,7 @@ impl ICertPropertyBackedUp_Vtbl {
             let this = (*this).get_impl();
             match this.BackedUpValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3020,7 +3020,7 @@ impl ICertPropertyBackedUp_Vtbl {
             let this = (*this).get_impl();
             match this.BackedUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3058,7 +3058,7 @@ impl ICertPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3097,7 +3097,7 @@ impl ICertPropertyEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.RequestId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3108,7 +3108,7 @@ impl ICertPropertyEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CADnsName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3119,7 +3119,7 @@ impl ICertPropertyEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CAName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3130,7 +3130,7 @@ impl ICertPropertyEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3176,7 +3176,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicyServerUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3187,7 +3187,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicyServerId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3198,7 +3198,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnrollmentServerUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3209,7 +3209,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestIdString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3220,7 +3220,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3231,7 +3231,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetUrlFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3242,7 +3242,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAuthentication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3253,7 +3253,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnrollmentServerAuthentication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3296,7 +3296,7 @@ impl ICertPropertyFriendlyName_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3332,7 +3332,7 @@ impl ICertPropertyKeyProvInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3374,7 +3374,7 @@ impl ICertPropertyRenewal_Vtbl {
             let this = (*this).get_impl();
             match this.get_Renewal(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3417,7 +3417,7 @@ impl ICertPropertyRequestOriginator_Vtbl {
             let this = (*this).get_impl();
             match this.RequestOriginator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3454,7 +3454,7 @@ impl ICertPropertySHA1Hash_Vtbl {
             let this = (*this).get_impl();
             match this.get_SHA1Hash(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3490,7 +3490,7 @@ impl ICertRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Submit(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&strrequest), ::core::mem::transmute(&strattributes), ::core::mem::transmute(&strconfig)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3501,7 +3501,7 @@ impl ICertRequest_Vtbl {
             let this = (*this).get_impl();
             match this.RetrievePending(::core::mem::transmute_copy(&requestid), ::core::mem::transmute(&strconfig)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl ICertRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl ICertRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3534,7 +3534,7 @@ impl ICertRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetDispositionMessage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrdispositionmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrdispositionmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3545,7 +3545,7 @@ impl ICertRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetCACertificate(::core::mem::transmute_copy(&fexchangecertificate), ::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrcertificate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrcertificate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3556,7 +3556,7 @@ impl ICertRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificate(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrcertificate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrcertificate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3596,7 +3596,7 @@ impl ICertRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIssuedCertificate(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute(&strserialnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3607,7 +3607,7 @@ impl ICertRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorMessageText(::core::mem::transmute_copy(&hrmessage), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrerrormessagetext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrerrormessagetext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3618,7 +3618,7 @@ impl ICertRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAProperty(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&propid), ::core::mem::transmute_copy(&propindex), ::core::mem::transmute_copy(&proptype), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3629,7 +3629,7 @@ impl ICertRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAPropertyFlags(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&propid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3640,7 +3640,7 @@ impl ICertRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAPropertyDisplayName(::core::mem::transmute(&strconfig), ::core::mem::transmute_copy(&propid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3651,7 +3651,7 @@ impl ICertRequest2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFullResponseProperty(::core::mem::transmute_copy(&propid), ::core::mem::transmute_copy(&propindex), ::core::mem::transmute_copy(&proptype), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3693,7 +3693,7 @@ impl ICertRequest3_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestIdString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrrequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrrequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3704,7 +3704,7 @@ impl ICertRequest3_Vtbl {
             let this = (*this).get_impl();
             match this.GetIssuedCertificate2(::core::mem::transmute(&strconfig), ::core::mem::transmute(&strrequestid), ::core::mem::transmute(&strserialnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3715,7 +3715,7 @@ impl ICertRequest3_Vtbl {
             let this = (*this).get_impl();
             match this.GetRefreshPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3751,7 +3751,7 @@ impl ICertRequestD_Vtbl {
             let this = (*this).get_impl();
             match this.GetCACert(::core::mem::transmute_copy(&fchain), ::core::mem::transmute(&pwszauthority)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pctbout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pctbout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3792,7 +3792,7 @@ impl ICertRequestD2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAProperty(::core::mem::transmute(&pwszauthority), ::core::mem::transmute_copy(&propid), ::core::mem::transmute_copy(&propindex), ::core::mem::transmute_copy(&proptype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pctbpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pctbpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3850,7 +3850,7 @@ impl ICertServerExit_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestProperty(::core::mem::transmute(&strpropertyname), ::core::mem::transmute_copy(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3861,7 +3861,7 @@ impl ICertServerExit_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestAttribute(::core::mem::transmute(&strattributename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrattributevalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrattributevalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3872,7 +3872,7 @@ impl ICertServerExit_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateProperty(::core::mem::transmute(&strpropertyname), ::core::mem::transmute_copy(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3883,7 +3883,7 @@ impl ICertServerExit_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateExtension(::core::mem::transmute(&strextensionname), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3894,7 +3894,7 @@ impl ICertServerExit_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateExtensionFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3910,7 +3910,7 @@ impl ICertServerExit_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrextensionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrextensionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3931,7 +3931,7 @@ impl ICertServerExit_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrattributename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrattributename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3994,7 +3994,7 @@ impl ICertServerPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestProperty(::core::mem::transmute(&strpropertyname), ::core::mem::transmute_copy(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4005,7 +4005,7 @@ impl ICertServerPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestAttribute(::core::mem::transmute(&strattributename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrattributevalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrattributevalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4016,7 +4016,7 @@ impl ICertServerPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateProperty(::core::mem::transmute(&strpropertyname), ::core::mem::transmute_copy(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarpropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarpropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4032,7 +4032,7 @@ impl ICertServerPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateExtension(::core::mem::transmute(&strextensionname), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4043,7 +4043,7 @@ impl ICertServerPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateExtensionFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4064,7 +4064,7 @@ impl ICertServerPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrextensionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrextensionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4085,7 +4085,7 @@ impl ICertServerPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrattributename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrattributename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4144,7 +4144,7 @@ impl ICertView_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCertViewColumn(::core::mem::transmute_copy(&fresultcolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4180,7 +4180,7 @@ impl ICertView_Vtbl {
             let this = (*this).get_impl();
             match this.OpenView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4243,7 +4243,7 @@ impl ICertificateAttestationChallenge_Vtbl {
             let this = (*this).get_impl();
             match this.DecryptChallenge(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrenvelopedpkcs7reencryptedtoca = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrenvelopedpkcs7reencryptedtoca, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4254,7 +4254,7 @@ impl ICertificateAttestationChallenge_Vtbl {
             let this = (*this).get_impl();
             match this.RequestID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrrequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrrequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4320,7 +4320,7 @@ impl ICertificatePolicies_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4331,7 +4331,7 @@ impl ICertificatePolicies_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4342,7 +4342,7 @@ impl ICertificatePolicies_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4398,7 +4398,7 @@ impl ICertificatePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4409,7 +4409,7 @@ impl ICertificatePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyQualifiers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4447,7 +4447,7 @@ impl ICertificationAuthorities_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4458,7 +4458,7 @@ impl ICertificationAuthorities_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4469,7 +4469,7 @@ impl ICertificationAuthorities_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4500,7 +4500,7 @@ impl ICertificationAuthorities_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByName(::core::mem::transmute(&strname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4536,7 +4536,7 @@ impl ICertificationAuthority_Vtbl {
             let this = (*this).get_impl();
             match this.get_Property(::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4575,7 +4575,7 @@ impl ICryptAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4586,7 +4586,7 @@ impl ICryptAttribute_Vtbl {
             let this = (*this).get_impl();
             match this.Values() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4625,7 +4625,7 @@ impl ICryptAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4636,7 +4636,7 @@ impl ICryptAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4647,7 +4647,7 @@ impl ICryptAttributes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4673,7 +4673,7 @@ impl ICryptAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.get_IndexByObjectId(::core::mem::transmute(&pobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4723,7 +4723,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlgorithmOid(::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&algflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4734,7 +4734,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4745,7 +4745,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.IncrementLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4756,7 +4756,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.LongName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4767,7 +4767,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.Valid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4778,7 +4778,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.MaxLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4789,7 +4789,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.MinLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4800,7 +4800,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4811,7 +4811,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4822,7 +4822,7 @@ impl ICspAlgorithm_Vtbl {
             let this = (*this).get_impl();
             match this.Operations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4867,7 +4867,7 @@ impl ICspAlgorithms_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4878,7 +4878,7 @@ impl ICspAlgorithms_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4889,7 +4889,7 @@ impl ICspAlgorithms_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4915,7 +4915,7 @@ impl ICspAlgorithms_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByName(::core::mem::transmute(&strname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4926,7 +4926,7 @@ impl ICspAlgorithms_Vtbl {
             let this = (*this).get_impl();
             match this.get_IndexByObjectId(::core::mem::transmute(&pobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4988,7 +4988,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.CspAlgorithms() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4999,7 +4999,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.HasHardwareRandomNumberGenerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5010,7 +5010,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.IsHardwareDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5021,7 +5021,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.IsRemovable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5032,7 +5032,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.IsSoftwareDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5043,7 +5043,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Valid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5054,7 +5054,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.MaxKeyContainerNameLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5065,7 +5065,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5076,7 +5076,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5087,7 +5087,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5098,7 +5098,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.KeySpec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5109,7 +5109,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.IsSmartCard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5120,7 +5120,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultSecurityDescriptor(::core::mem::transmute_copy(&machinecontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5131,7 +5131,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.LegacyCsp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5142,7 +5142,7 @@ impl ICspInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetCspStatusFromOperations(::core::mem::transmute(&palgorithm), ::core::mem::transmute_copy(&operations)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5198,7 +5198,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5209,7 +5209,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5220,7 +5220,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5251,7 +5251,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByName(::core::mem::transmute(&strname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcspinformation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcspinformation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5262,7 +5262,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this.GetCspStatusFromProviderName(::core::mem::transmute(&strprovidername), ::core::mem::transmute_copy(&legacykeyspec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5273,7 +5273,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this.GetCspStatusesFromOperations(::core::mem::transmute_copy(&operations), ::core::mem::transmute(&pcspinformation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5284,7 +5284,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this.GetEncryptionCspAlgorithms(::core::mem::transmute(&pcspinformation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5295,7 +5295,7 @@ impl ICspInformations_Vtbl {
             let this = (*this).get_impl();
             match this.GetHashAlgorithms(::core::mem::transmute(&pcspinformation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5346,7 +5346,7 @@ impl ICspStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Ordinal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5362,7 +5362,7 @@ impl ICspStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CspAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5373,7 +5373,7 @@ impl ICspStatus_Vtbl {
             let this = (*this).get_impl();
             match this.CspInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5384,7 +5384,7 @@ impl ICspStatus_Vtbl {
             let this = (*this).get_impl();
             match this.EnrollmentStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5395,7 +5395,7 @@ impl ICspStatus_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5439,7 +5439,7 @@ impl ICspStatuses_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5450,7 +5450,7 @@ impl ICspStatuses_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5461,7 +5461,7 @@ impl ICspStatuses_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5487,7 +5487,7 @@ impl ICspStatuses_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByName(::core::mem::transmute(&strcspname), ::core::mem::transmute(&stralgorithmname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5498,7 +5498,7 @@ impl ICspStatuses_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByOrdinal(::core::mem::transmute_copy(&ordinal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5509,7 +5509,7 @@ impl ICspStatuses_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByOperations(::core::mem::transmute(&strcspname), ::core::mem::transmute(&stralgorithmname), ::core::mem::transmute_copy(&operations)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5520,7 +5520,7 @@ impl ICspStatuses_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByProvider(::core::mem::transmute(&pcspstatus)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6476,7 +6476,7 @@ impl IEnumCERTVIEWATTRIBUTE_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6564,7 +6564,7 @@ impl IEnumCERTVIEWCOLUMN_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6638,7 +6638,7 @@ impl IEnumCERTVIEWEXTENSION_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6685,7 +6685,7 @@ impl IEnumCERTVIEWROW_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCertViewColumn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6696,7 +6696,7 @@ impl IEnumCERTVIEWROW_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCertViewAttribute(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6707,7 +6707,7 @@ impl IEnumCERTVIEWROW_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCertViewExtension(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6728,7 +6728,7 @@ impl IEnumCERTVIEWROW_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6783,7 +6783,7 @@ impl INDESPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateChallenge(::core::mem::transmute(&pwsztemplate), ::core::mem::transmute(&pwszparams)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6835,7 +6835,7 @@ impl IOCSPAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.OCSPServiceProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6846,7 +6846,7 @@ impl IOCSPAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.OCSPCAConfigurationCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6867,7 +6867,7 @@ impl IOCSPAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetMyRoles(::core::mem::transmute(&bstrservername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *proles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(proles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6888,7 +6888,7 @@ impl IOCSPAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurity(::core::mem::transmute(&bstrservername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6899,7 +6899,7 @@ impl IOCSPAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetSigningCertificates(::core::mem::transmute(&bstrservername), ::core::mem::transmute_copy(&pcacertvar)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6910,7 +6910,7 @@ impl IOCSPAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetHashAlgorithms(::core::mem::transmute(&bstrservername), ::core::mem::transmute(&bstrcaid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6971,7 +6971,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.Identifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6982,7 +6982,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.CACertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6993,7 +6993,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7009,7 +7009,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SigningFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7025,7 +7025,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SigningCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7041,7 +7041,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ReminderDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7057,7 +7057,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7068,7 +7068,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.CSPName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7079,7 +7079,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.KeySpec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7090,7 +7090,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7106,7 +7106,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7122,7 +7122,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7133,7 +7133,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.LocalRevocationInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7149,7 +7149,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.SigningCertificateTemplate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7165,7 +7165,7 @@ impl IOCSPCAConfiguration_Vtbl {
             let this = (*this).get_impl();
             match this.CAConfig() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7227,7 +7227,7 @@ impl IOCSPCAConfigurationCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7238,7 +7238,7 @@ impl IOCSPCAConfigurationCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7249,7 +7249,7 @@ impl IOCSPCAConfigurationCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7260,7 +7260,7 @@ impl IOCSPCAConfigurationCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByName(::core::mem::transmute(&bstridentifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7271,7 +7271,7 @@ impl IOCSPCAConfigurationCollection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCAConfiguration(::core::mem::transmute(&bstridentifier), ::core::mem::transmute(&varcacert)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7313,7 +7313,7 @@ impl IOCSPProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7324,7 +7324,7 @@ impl IOCSPProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7340,7 +7340,7 @@ impl IOCSPProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Modified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7379,7 +7379,7 @@ impl IOCSPPropertyCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7390,7 +7390,7 @@ impl IOCSPPropertyCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7401,7 +7401,7 @@ impl IOCSPPropertyCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7412,7 +7412,7 @@ impl IOCSPPropertyCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByName(::core::mem::transmute(&bstrpropname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7423,7 +7423,7 @@ impl IOCSPPropertyCollection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProperty(::core::mem::transmute(&bstrpropname), ::core::mem::transmute_copy(&pvarpropvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7444,7 +7444,7 @@ impl IOCSPPropertyCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7502,7 +7502,7 @@ impl IObjectId_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7513,7 +7513,7 @@ impl IObjectId_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7529,7 +7529,7 @@ impl IObjectId_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7540,7 +7540,7 @@ impl IObjectId_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlgorithmName(::core::mem::transmute_copy(&groupid), ::core::mem::transmute_copy(&keyflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstralgorithmname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstralgorithmname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7582,7 +7582,7 @@ impl IObjectIds_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7593,7 +7593,7 @@ impl IObjectIds_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7604,7 +7604,7 @@ impl IObjectIds_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7668,7 +7668,7 @@ impl IPolicyQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7679,7 +7679,7 @@ impl IPolicyQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.Qualifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7690,7 +7690,7 @@ impl IPolicyQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7701,7 +7701,7 @@ impl IPolicyQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawData(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7739,7 +7739,7 @@ impl IPolicyQualifiers_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7750,7 +7750,7 @@ impl IPolicyQualifiers_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7761,7 +7761,7 @@ impl IPolicyQualifiers_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7825,7 +7825,7 @@ impl ISignerCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.get_Certificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7836,7 +7836,7 @@ impl ISignerCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7847,7 +7847,7 @@ impl ISignerCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.Silent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7863,7 +7863,7 @@ impl ISignerCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.ParentWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7879,7 +7879,7 @@ impl ISignerCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.UIContextMessage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7900,7 +7900,7 @@ impl ISignerCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.SignatureInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7945,7 +7945,7 @@ impl ISignerCertificates_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7956,7 +7956,7 @@ impl ISignerCertificates_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7967,7 +7967,7 @@ impl ISignerCertificates_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7993,7 +7993,7 @@ impl ISignerCertificates_Vtbl {
             let this = (*this).get_impl();
             match this.Find(::core::mem::transmute(&psignercert)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisignercert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisignercert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8035,7 +8035,7 @@ impl ISmimeCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8046,7 +8046,7 @@ impl ISmimeCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8057,7 +8057,7 @@ impl ISmimeCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8125,7 +8125,7 @@ impl ISmimeCapability_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8136,7 +8136,7 @@ impl ISmimeCapability_Vtbl {
             let this = (*this).get_impl();
             match this.BitCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8180,7 +8180,7 @@ impl IX500DistinguishedName_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8191,7 +8191,7 @@ impl IX500DistinguishedName_Vtbl {
             let this = (*this).get_impl();
             match this.get_EncodedName(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8230,7 +8230,7 @@ impl IX509Attribute_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8241,7 +8241,7 @@ impl IX509Attribute_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawData(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8286,7 +8286,7 @@ impl IX509AttributeArchiveKey_Vtbl {
             let this = (*this).get_impl();
             match this.get_EncryptedKeyBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8297,7 +8297,7 @@ impl IX509AttributeArchiveKey_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptionAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8308,7 +8308,7 @@ impl IX509AttributeArchiveKey_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptionStrength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8353,7 +8353,7 @@ impl IX509AttributeArchiveKeyHash_Vtbl {
             let this = (*this).get_impl();
             match this.get_EncryptedKeyHashBlob(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8399,7 +8399,7 @@ impl IX509AttributeClientId_Vtbl {
             let this = (*this).get_impl();
             match this.ClientId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8410,7 +8410,7 @@ impl IX509AttributeClientId_Vtbl {
             let this = (*this).get_impl();
             match this.MachineDnsName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8421,7 +8421,7 @@ impl IX509AttributeClientId_Vtbl {
             let this = (*this).get_impl();
             match this.UserSamName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8432,7 +8432,7 @@ impl IX509AttributeClientId_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8480,7 +8480,7 @@ impl IX509AttributeCspProvider_Vtbl {
             let this = (*this).get_impl();
             match this.KeySpec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8491,7 +8491,7 @@ impl IX509AttributeCspProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8502,7 +8502,7 @@ impl IX509AttributeCspProvider_Vtbl {
             let this = (*this).get_impl();
             match this.get_Signature(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8547,7 +8547,7 @@ impl IX509AttributeExtensions_Vtbl {
             let this = (*this).get_impl();
             match this.X509Extensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8590,7 +8590,7 @@ impl IX509AttributeOSVersion_Vtbl {
             let this = (*this).get_impl();
             match this.OSVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8633,7 +8633,7 @@ impl IX509AttributeRenewalCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.get_RenewalCertificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8669,7 +8669,7 @@ impl IX509Attributes_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8680,7 +8680,7 @@ impl IX509Attributes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8691,7 +8691,7 @@ impl IX509Attributes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8779,7 +8779,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetInnerRequest(::core::mem::transmute_copy(&level)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8790,7 +8790,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8801,7 +8801,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.EnrollmentContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8812,7 +8812,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Silent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8828,7 +8828,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ParentWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8844,7 +8844,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.UIContextMessage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8860,7 +8860,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.SuppressDefaults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8876,7 +8876,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.get_RenewalCertificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8892,7 +8892,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.ClientId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8908,7 +8908,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.CspInformations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8924,7 +8924,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8940,7 +8940,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.AlternateSignatureAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8956,7 +8956,7 @@ impl IX509CertificateRequest_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawData(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9024,7 +9024,7 @@ impl IX509CertificateRequestCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.Issuer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9040,7 +9040,7 @@ impl IX509CertificateRequestCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.NotBefore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9056,7 +9056,7 @@ impl IX509CertificateRequestCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.NotAfter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9072,7 +9072,7 @@ impl IX509CertificateRequestCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.get_SerialNumber(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9088,7 +9088,7 @@ impl IX509CertificateRequestCertificate_Vtbl {
             let this = (*this).get_impl();
             match this.SignerCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9145,7 +9145,7 @@ impl IX509CertificateRequestCertificate2_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppolicyserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppolicyserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9156,7 +9156,7 @@ impl IX509CertificateRequestCertificate2_Vtbl {
             let this = (*this).get_impl();
             match this.Template() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9215,7 +9215,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.TemplateObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9226,7 +9226,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.NullSigned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9237,7 +9237,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.CryptAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9248,7 +9248,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.NameValuePairs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9259,7 +9259,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.X509Extensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9270,7 +9270,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.CriticalExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9281,7 +9281,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.SuppressOids() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9292,7 +9292,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9308,7 +9308,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.get_SenderNonce(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9324,7 +9324,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.SignatureInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9335,7 +9335,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.ArchivePrivateKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9351,7 +9351,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.get_KeyArchivalCertificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9367,7 +9367,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptionAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9383,7 +9383,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptionStrength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9399,7 +9399,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.get_EncryptedKeyHash(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9410,7 +9410,7 @@ impl IX509CertificateRequestCmc_Vtbl {
             let this = (*this).get_impl();
             match this.SignerCertificates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9476,7 +9476,7 @@ impl IX509CertificateRequestCmc2_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppolicyserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppolicyserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9487,7 +9487,7 @@ impl IX509CertificateRequestCmc2_Vtbl {
             let this = (*this).get_impl();
             match this.Template() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9588,7 +9588,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.IsSmartCard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9599,7 +9599,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.TemplateObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9610,7 +9610,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.PublicKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9621,7 +9621,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9632,7 +9632,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.NullSigned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9643,7 +9643,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.ReuseKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9654,7 +9654,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.get_OldCertificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9665,7 +9665,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.Subject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9681,7 +9681,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.CspStatuses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9692,7 +9692,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.SmimeCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9708,7 +9708,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.SignatureInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9719,7 +9719,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.KeyContainerNamePrefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9735,7 +9735,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.CryptAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9746,7 +9746,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.X509Extensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9757,7 +9757,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.CriticalExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9768,7 +9768,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.SuppressOids() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9779,7 +9779,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawDataToBeSigned(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9790,7 +9790,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.get_Signature(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9801,7 +9801,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
             let this = (*this).get_impl();
             match this.GetCspStatuses(::core::mem::transmute_copy(&keyspec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcspstatuses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcspstatuses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9876,7 +9876,7 @@ impl IX509CertificateRequestPkcs10V2_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppolicyserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppolicyserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9887,7 +9887,7 @@ impl IX509CertificateRequestPkcs10V2_Vtbl {
             let this = (*this).get_impl();
             match this.Template() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9930,7 +9930,7 @@ impl IX509CertificateRequestPkcs10V3_Vtbl {
             let this = (*this).get_impl();
             match this.AttestPrivateKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9946,7 +9946,7 @@ impl IX509CertificateRequestPkcs10V3_Vtbl {
             let this = (*this).get_impl();
             match this.get_AttestationEncryptionCertificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9962,7 +9962,7 @@ impl IX509CertificateRequestPkcs10V3_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptionAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9978,7 +9978,7 @@ impl IX509CertificateRequestPkcs10V3_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptionStrength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9994,7 +9994,7 @@ impl IX509CertificateRequestPkcs10V3_Vtbl {
             let this = (*this).get_impl();
             match this.ChallengePassword() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10010,7 +10010,7 @@ impl IX509CertificateRequestPkcs10V3_Vtbl {
             let this = (*this).get_impl();
             match this.NameValuePairs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10052,7 +10052,7 @@ impl IX509CertificateRequestPkcs10V4_Vtbl {
             let this = (*this).get_impl();
             match this.ClaimType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10068,7 +10068,7 @@ impl IX509CertificateRequestPkcs10V4_Vtbl {
             let this = (*this).get_impl();
             match this.AttestPrivateKeyPreferred() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10132,7 +10132,7 @@ impl IX509CertificateRequestPkcs7_Vtbl {
             let this = (*this).get_impl();
             match this.RequesterName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10148,7 +10148,7 @@ impl IX509CertificateRequestPkcs7_Vtbl {
             let this = (*this).get_impl();
             match this.SignerCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10197,7 +10197,7 @@ impl IX509CertificateRequestPkcs7V2_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppolicyserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppolicyserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10208,7 +10208,7 @@ impl IX509CertificateRequestPkcs7V2_Vtbl {
             let this = (*this).get_impl();
             match this.Template() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10305,7 +10305,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.Issuer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10321,7 +10321,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.ThisUpdate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10337,7 +10337,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.NextUpdate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10353,7 +10353,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.X509CRLEntries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10364,7 +10364,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.X509Extensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10375,7 +10375,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.CriticalExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10386,7 +10386,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.SignerCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10402,7 +10402,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.get_CRLNumber(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10418,7 +10418,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.CAVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10434,7 +10434,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.BaseCRL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10445,7 +10445,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.NullSigned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10456,7 +10456,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10472,7 +10472,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.AlternateSignatureAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10488,7 +10488,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.SignatureInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10499,7 +10499,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawData(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10510,7 +10510,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawDataToBeSigned(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10521,7 +10521,7 @@ impl IX509CertificateRevocationList_Vtbl {
             let this = (*this).get_impl();
             match this.get_Signature(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10587,7 +10587,7 @@ impl IX509CertificateRevocationListEntries_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10598,7 +10598,7 @@ impl IX509CertificateRevocationListEntries_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10609,7 +10609,7 @@ impl IX509CertificateRevocationListEntries_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10635,7 +10635,7 @@ impl IX509CertificateRevocationListEntries_Vtbl {
             let this = (*this).get_impl();
             match this.get_IndexBySerialNumber(::core::mem::transmute_copy(&encoding), ::core::mem::transmute(&serialnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10687,7 +10687,7 @@ impl IX509CertificateRevocationListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.get_SerialNumber(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10698,7 +10698,7 @@ impl IX509CertificateRevocationListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.RevocationDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10709,7 +10709,7 @@ impl IX509CertificateRevocationListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.RevocationReason() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10725,7 +10725,7 @@ impl IX509CertificateRevocationListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.X509Extensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10736,7 +10736,7 @@ impl IX509CertificateRevocationListEntry_Vtbl {
             let this = (*this).get_impl();
             match this.CriticalExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10771,7 +10771,7 @@ impl IX509CertificateTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.get_Property(::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10811,7 +10811,7 @@ impl IX509CertificateTemplateWritable_Vtbl {
             let this = (*this).get_impl();
             match this.get_Property(::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10827,7 +10827,7 @@ impl IX509CertificateTemplateWritable_Vtbl {
             let this = (*this).get_impl();
             match this.Template() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10867,7 +10867,7 @@ impl IX509CertificateTemplates_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10878,7 +10878,7 @@ impl IX509CertificateTemplates_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10889,7 +10889,7 @@ impl IX509CertificateTemplates_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10915,7 +10915,7 @@ impl IX509CertificateTemplates_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByName(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10926,7 +10926,7 @@ impl IX509CertificateTemplates_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByOid(::core::mem::transmute(&poid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10972,7 +10972,7 @@ impl IX509EndorsementKey_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10988,7 +10988,7 @@ impl IX509EndorsementKey_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10999,7 +10999,7 @@ impl IX509EndorsementKey_Vtbl {
             let this = (*this).get_impl();
             match this.Opened() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11020,7 +11020,7 @@ impl IX509EndorsementKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateByIndex(::core::mem::transmute_copy(&manufactureronly), ::core::mem::transmute_copy(&dwindex), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11031,7 +11031,7 @@ impl IX509EndorsementKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateCount(::core::mem::transmute_copy(&manufactureronly)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11042,7 +11042,7 @@ impl IX509EndorsementKey_Vtbl {
             let this = (*this).get_impl();
             match this.ExportPublicKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppublickey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppublickey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11128,7 +11128,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRequest(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11149,7 +11149,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePFX(::core::mem::transmute(&strpassword), ::core::mem::transmute_copy(&exportoptions), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11160,7 +11160,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.Request() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11171,7 +11171,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.Silent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11187,7 +11187,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.ParentWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11203,7 +11203,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.NameValuePairs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11214,7 +11214,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.EnrollmentContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11225,7 +11225,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11236,7 +11236,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.get_Certificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11247,7 +11247,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.get_Response(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11258,7 +11258,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CertificateFriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11274,7 +11274,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CertificateDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11290,7 +11290,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.RequestId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11301,7 +11301,7 @@ impl IX509Enrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CAConfigString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11366,7 +11366,7 @@ impl IX509Enrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.PolicyServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppolicyserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppolicyserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11377,7 +11377,7 @@ impl IX509Enrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.Template() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11388,7 +11388,7 @@ impl IX509Enrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.RequestIdString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11434,7 +11434,7 @@ impl IX509EnrollmentHelper_Vtbl {
             let this = (*this).get_impl();
             match this.Enroll(::core::mem::transmute(&strenrollmentpolicyserveruri), ::core::mem::transmute(&strtemplatename), ::core::mem::transmute_copy(&encoding), ::core::mem::transmute_copy(&enrollflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrcertificate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrcertificate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11504,7 +11504,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetTemplates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11515,7 +11515,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAsForTemplate(::core::mem::transmute(&ptemplate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11526,7 +11526,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCAs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11542,7 +11542,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomOids() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjectids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjectids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11553,7 +11553,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextUpdateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11564,7 +11564,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastUpdateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11575,7 +11575,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicyServerUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11586,7 +11586,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicyServerId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11597,7 +11597,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetFriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11608,7 +11608,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsDefaultCEP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11619,7 +11619,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetUseClientId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11630,7 +11630,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllowUnTrustedCA() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11641,7 +11641,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11652,7 +11652,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCacheDir() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11663,7 +11663,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.GetAuthFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11679,7 +11679,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.QueryChanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11695,7 +11695,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.Export(::core::mem::transmute_copy(&exportflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11706,7 +11706,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
             let this = (*this).get_impl();
             match this.Cost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11779,7 +11779,7 @@ impl IX509EnrollmentStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11795,7 +11795,7 @@ impl IX509EnrollmentStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Selected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11811,7 +11811,7 @@ impl IX509EnrollmentStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Display() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11827,7 +11827,7 @@ impl IX509EnrollmentStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11843,7 +11843,7 @@ impl IX509EnrollmentStatus_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11859,7 +11859,7 @@ impl IX509EnrollmentStatus_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11899,7 +11899,7 @@ impl IX509EnrollmentWebClassFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateObject(::core::mem::transmute(&strprogid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11934,7 +11934,7 @@ impl IX509Extension_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11945,7 +11945,7 @@ impl IX509Extension_Vtbl {
             let this = (*this).get_impl();
             match this.get_RawData(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11956,7 +11956,7 @@ impl IX509Extension_Vtbl {
             let this = (*this).get_impl();
             match this.Critical() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12006,7 +12006,7 @@ impl IX509ExtensionAlternativeNames_Vtbl {
             let this = (*this).get_impl();
             match this.AlternativeNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12049,7 +12049,7 @@ impl IX509ExtensionAuthorityKeyIdentifier_Vtbl {
             let this = (*this).get_impl();
             match this.get_AuthorityKeyIdentifier(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12093,7 +12093,7 @@ impl IX509ExtensionBasicConstraints_Vtbl {
             let this = (*this).get_impl();
             match this.IsCA() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12104,7 +12104,7 @@ impl IX509ExtensionBasicConstraints_Vtbl {
             let this = (*this).get_impl();
             match this.PathLenConstraint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12148,7 +12148,7 @@ impl IX509ExtensionCertificatePolicies_Vtbl {
             let this = (*this).get_impl();
             match this.Policies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12191,7 +12191,7 @@ impl IX509ExtensionEnhancedKeyUsage_Vtbl {
             let this = (*this).get_impl();
             match this.EnhancedKeyUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12234,7 +12234,7 @@ impl IX509ExtensionKeyUsage_Vtbl {
             let this = (*this).get_impl();
             match this.KeyUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12277,7 +12277,7 @@ impl IX509ExtensionMSApplicationPolicies_Vtbl {
             let this = (*this).get_impl();
             match this.Policies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12320,7 +12320,7 @@ impl IX509ExtensionSmimeCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.SmimeCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12363,7 +12363,7 @@ impl IX509ExtensionSubjectKeyIdentifier_Vtbl {
             let this = (*this).get_impl();
             match this.get_SubjectKeyIdentifier(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12408,7 +12408,7 @@ impl IX509ExtensionTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.TemplateOid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12419,7 +12419,7 @@ impl IX509ExtensionTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.MajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12430,7 +12430,7 @@ impl IX509ExtensionTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.MinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12475,7 +12475,7 @@ impl IX509ExtensionTemplateName_Vtbl {
             let this = (*this).get_impl();
             match this.TemplateName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12513,7 +12513,7 @@ impl IX509Extensions_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12524,7 +12524,7 @@ impl IX509Extensions_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12535,7 +12535,7 @@ impl IX509Extensions_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12561,7 +12561,7 @@ impl IX509Extensions_Vtbl {
             let this = (*this).get_impl();
             match this.get_IndexByObjectId(::core::mem::transmute(&pobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12602,7 +12602,7 @@ impl IX509MachineEnrollmentFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateObject(::core::mem::transmute(&strprogid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppihelper = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppihelper, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12635,7 +12635,7 @@ impl IX509NameValuePair_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12646,7 +12646,7 @@ impl IX509NameValuePair_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12682,7 +12682,7 @@ impl IX509NameValuePairs_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12693,7 +12693,7 @@ impl IX509NameValuePairs_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12704,7 +12704,7 @@ impl IX509NameValuePairs_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12759,7 +12759,7 @@ impl IX509PolicyServerListManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_ItemByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12770,7 +12770,7 @@ impl IX509PolicyServerListManager_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12781,7 +12781,7 @@ impl IX509PolicyServerListManager_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12855,7 +12855,7 @@ impl IX509PolicyServerUrl_Vtbl {
             let this = (*this).get_impl();
             match this.Url() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12871,7 +12871,7 @@ impl IX509PolicyServerUrl_Vtbl {
             let this = (*this).get_impl();
             match this.Default() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12887,7 +12887,7 @@ impl IX509PolicyServerUrl_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12903,7 +12903,7 @@ impl IX509PolicyServerUrl_Vtbl {
             let this = (*this).get_impl();
             match this.AuthFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12919,7 +12919,7 @@ impl IX509PolicyServerUrl_Vtbl {
             let this = (*this).get_impl();
             match this.Cost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12935,7 +12935,7 @@ impl IX509PolicyServerUrl_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringProperty(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13080,7 +13080,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.Export(::core::mem::transmute(&strexporttype), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrencodedkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrencodedkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13091,7 +13091,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ExportPublicKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppublickey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppublickey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13102,7 +13102,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ContainerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13118,7 +13118,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ContainerNamePrefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13134,7 +13134,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ReaderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13150,7 +13150,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.CspInformations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13166,7 +13166,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.CspStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13182,7 +13182,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13198,7 +13198,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13214,7 +13214,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.LegacyCsp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13230,7 +13230,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.Algorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13246,7 +13246,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.KeySpec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13262,7 +13262,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13278,7 +13278,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ExportPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13294,7 +13294,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.KeyUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13310,7 +13310,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.KeyProtection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13326,7 +13326,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.MachineContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13342,7 +13342,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.SecurityDescriptor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13358,7 +13358,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.get_Certificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13374,7 +13374,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.UniqueContainerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13385,7 +13385,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.Opened() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13396,7 +13396,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13407,7 +13407,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.Existing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13423,7 +13423,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.Silent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13439,7 +13439,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.ParentWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13455,7 +13455,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.UIContextMessage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13476,7 +13476,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13492,7 +13492,7 @@ impl IX509PrivateKey_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13592,7 +13592,7 @@ impl IX509PrivateKey2_Vtbl {
             let this = (*this).get_impl();
             match this.HardwareKeyUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13608,7 +13608,7 @@ impl IX509PrivateKey2_Vtbl {
             let this = (*this).get_impl();
             match this.AlternateStorageLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13624,7 +13624,7 @@ impl IX509PrivateKey2_Vtbl {
             let this = (*this).get_impl();
             match this.AlgorithmName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13640,7 +13640,7 @@ impl IX509PrivateKey2_Vtbl {
             let this = (*this).get_impl();
             match this.get_AlgorithmParameters(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13656,7 +13656,7 @@ impl IX509PrivateKey2_Vtbl {
             let this = (*this).get_impl();
             match this.ParametersExportType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13715,7 +13715,7 @@ impl IX509PublicKey_Vtbl {
             let this = (*this).get_impl();
             match this.Algorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13726,7 +13726,7 @@ impl IX509PublicKey_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13737,7 +13737,7 @@ impl IX509PublicKey_Vtbl {
             let this = (*this).get_impl();
             match this.get_EncodedKey(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13748,7 +13748,7 @@ impl IX509PublicKey_Vtbl {
             let this = (*this).get_impl();
             match this.get_EncodedParameters(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13759,7 +13759,7 @@ impl IX509PublicKey_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeKeyIdentifier(::core::mem::transmute_copy(&algorithm), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13825,7 +13825,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRequestMessage(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13836,7 +13836,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRetrievePendingMessage(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13847,7 +13847,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRetrieveCertificateMessage(::core::mem::transmute_copy(&context), ::core::mem::transmute(&strissuer), ::core::mem::transmute_copy(&issuerencoding), ::core::mem::transmute(&strserialnumber), ::core::mem::transmute_copy(&serialnumberencoding), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13858,7 +13858,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessResponseMessage(::core::mem::transmute(&strresponse), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13874,7 +13874,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.FailInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13885,7 +13885,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.SignerCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13901,7 +13901,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.OldCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13917,7 +13917,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.get_TransactionId(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13933,7 +13933,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.Request() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13944,7 +13944,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.CertificateFriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13960,7 +13960,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13971,7 +13971,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.get_Certificate(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13982,7 +13982,7 @@ impl IX509SCEPEnrollment_Vtbl {
             let this = (*this).get_impl();
             match this.Silent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14047,7 +14047,7 @@ impl IX509SCEPEnrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateChallengeAnswerMessage(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14058,7 +14058,7 @@ impl IX509SCEPEnrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessResponseMessage2(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&strresponse), ::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14069,7 +14069,7 @@ impl IX509SCEPEnrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.ResultMessageText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14080,7 +14080,7 @@ impl IX509SCEPEnrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.DelayRetry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14091,7 +14091,7 @@ impl IX509SCEPEnrollment2_Vtbl {
             let this = (*this).get_impl();
             match this.ActivityId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14145,7 +14145,7 @@ impl IX509SCEPEnrollmentHelper_Vtbl {
             let this = (*this).get_impl();
             match this.Enroll(::core::mem::transmute_copy(&processflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14156,7 +14156,7 @@ impl IX509SCEPEnrollmentHelper_Vtbl {
             let this = (*this).get_impl();
             match this.FetchPending(::core::mem::transmute_copy(&processflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14167,7 +14167,7 @@ impl IX509SCEPEnrollmentHelper_Vtbl {
             let this = (*this).get_impl();
             match this.X509SCEPEnrollment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14178,7 +14178,7 @@ impl IX509SCEPEnrollmentHelper_Vtbl {
             let this = (*this).get_impl();
             match this.ResultMessageText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14224,7 +14224,7 @@ impl IX509SignatureInformation_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14240,7 +14240,7 @@ impl IX509SignatureInformation_Vtbl {
             let this = (*this).get_impl();
             match this.PublicKeyAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14256,7 +14256,7 @@ impl IX509SignatureInformation_Vtbl {
             let this = (*this).get_impl();
             match this.get_Parameters(::core::mem::transmute_copy(&encoding)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14272,7 +14272,7 @@ impl IX509SignatureInformation_Vtbl {
             let this = (*this).get_impl();
             match this.AlternateSignatureAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14288,7 +14288,7 @@ impl IX509SignatureInformation_Vtbl {
             let this = (*this).get_impl();
             match this.AlternateSignatureAlgorithmSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14299,7 +14299,7 @@ impl IX509SignatureInformation_Vtbl {
             let this = (*this).get_impl();
             match this.NullSigned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14315,7 +14315,7 @@ impl IX509SignatureInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureAlgorithm(::core::mem::transmute_copy(&pkcs7signature), ::core::mem::transmute_copy(&signaturekey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/impl.rs
@@ -31,7 +31,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.CAErrorId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.CAErrorString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -58,7 +58,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetCASetupProperty(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -74,7 +74,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.IsPropertyEditable(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbeditable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbeditable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -85,7 +85,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedCATypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -96,7 +96,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderNameList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -107,7 +107,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyLengthList(::core::mem::transmute(&bstrprovidername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -118,7 +118,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetHashAlgorithmList(::core::mem::transmute(&bstrprovidername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -129,7 +129,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrivateKeyContainerList(::core::mem::transmute(&bstrprovidername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -140,7 +140,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetExistingCACertificates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -151,7 +151,7 @@ impl ICertSrvSetup_Vtbl {
             let this = (*this).get_impl();
             match this.CAImportPFX(::core::mem::transmute(&bstrfilename), ::core::mem::transmute(&bstrpasswd), ::core::mem::transmute_copy(&boverwriteexistingkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl ICertSrvSetupKeyInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -261,7 +261,7 @@ impl ICertSrvSetupKeyInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -277,7 +277,7 @@ impl ICertSrvSetupKeyInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Existing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -293,7 +293,7 @@ impl ICertSrvSetupKeyInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ContainerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -309,7 +309,7 @@ impl ICertSrvSetupKeyInformation_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -325,7 +325,7 @@ impl ICertSrvSetupKeyInformation_Vtbl {
             let this = (*this).get_impl();
             match this.ExistingCACertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -373,7 +373,7 @@ impl ICertSrvSetupKeyInformationCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -384,7 +384,7 @@ impl ICertSrvSetupKeyInformationCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -395,7 +395,7 @@ impl ICertSrvSetupKeyInformationCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -437,7 +437,7 @@ impl ICertificateEnrollmentPolicyServerSetup_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -453,7 +453,7 @@ impl ICertificateEnrollmentPolicyServerSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -508,7 +508,7 @@ impl ICertificateEnrollmentServerSetup_Vtbl {
             let this = (*this).get_impl();
             match this.ErrorString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -524,7 +524,7 @@ impl ICertificateEnrollmentServerSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -590,7 +590,7 @@ impl IMSCEPSetup_Vtbl {
             let this = (*this).get_impl();
             match this.MSCEPErrorId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -601,7 +601,7 @@ impl IMSCEPSetup_Vtbl {
             let this = (*this).get_impl();
             match this.MSCEPErrorString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -617,7 +617,7 @@ impl IMSCEPSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetMSCEPSetupProperty(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -638,7 +638,7 @@ impl IMSCEPSetup_Vtbl {
             let this = (*this).get_impl();
             match this.IsMSCEPStoreEmpty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbempty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbempty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -649,7 +649,7 @@ impl IMSCEPSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderNameList(::core::mem::transmute_copy(&bexchange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -660,7 +660,7 @@ impl IMSCEPSetup_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyLengthList(::core::mem::transmute_copy(&bexchange), ::core::mem::transmute(&bstrprovidername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
@@ -16,7 +16,7 @@ impl IAccountingProviderConfig_Vtbl {
             let this = (*this).get_impl();
             match this.Initialize(::core::mem::transmute(&pszmachinename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puconnectionparam = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puconnectionparam, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -73,7 +73,7 @@ impl IAuthenticationProviderConfig_Vtbl {
             let this = (*this).get_impl();
             match this.Initialize(::core::mem::transmute(&pszmachinename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puconnectionparam = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puconnectionparam, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -130,7 +130,7 @@ impl IEAPProviderConfig_Vtbl {
             let this = (*this).get_impl();
             match this.Initialize(::core::mem::transmute(&pszmachinename), ::core::mem::transmute_copy(&dweaptypeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puconnectionparam = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puconnectionparam, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
@@ -34,7 +34,7 @@ impl ITpmVirtualSmartCardManager_Vtbl {
             let this = (*this).get_impl();
             match this.DestroyVirtualSmartCard(::core::mem::transmute(&pszinstanceid), ::core::mem::transmute(&pstatuscallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfneedreboot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfneedreboot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -121,7 +121,7 @@ impl ITpmVirtualSmartCardManager3_Vtbl {
                 ::core::mem::transmute(&pstatuscallback),
             ) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszinstanceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszinstanceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
@@ -50,7 +50,7 @@ impl IDedupChunkLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.StartChunking(::core::mem::transmute(&iiditeratorinterfaceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchunksenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchunksenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.LookupChunks(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&phashes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -109,7 +109,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.InsertChunks(::core::mem::transmute_copy(&chunkcount), ::core::mem::transmute_copy(&pchunkmetadata), ::core::mem::transmute_copy(&databytecount), ::core::mem::transmute_copy(&pchunkdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -120,7 +120,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.InsertChunksWithStream(::core::mem::transmute_copy(&chunkcount), ::core::mem::transmute_copy(&pchunkmetadata), ::core::mem::transmute_copy(&databytecount), ::core::mem::transmute(&pchunkdatastream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -131,7 +131,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.CommitStreams(::core::mem::transmute_copy(&streamcount), ::core::mem::transmute_copy(&pstreams), ::core::mem::transmute_copy(&entrycount), ::core::mem::transmute_copy(&pentries)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -142,7 +142,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.CommitStreamsWithStream(::core::mem::transmute_copy(&streamcount), ::core::mem::transmute_copy(&pstreams), ::core::mem::transmute_copy(&entrycount), ::core::mem::transmute(&pentriesstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -153,7 +153,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.GetStreams(::core::mem::transmute_copy(&streamcount), ::core::mem::transmute_copy(&pstreampaths)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -169,7 +169,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.GetChunks(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&phashes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prequestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prequestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -185,7 +185,7 @@ impl IDedupDataPort_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestStatus(::core::mem::transmute(&requestid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -237,7 +237,7 @@ impl IDedupDataPortManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetVolumeStatus(::core::mem::transmute_copy(&options), ::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -248,7 +248,7 @@ impl IDedupDataPortManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetVolumeDataPort(::core::mem::transmute_copy(&options), ::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
@@ -24,7 +24,7 @@ impl IEnhancedStorageACT_Vtbl {
             let this = (*this).get_impl();
             match this.GetAuthorizationState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35,7 +35,7 @@ impl IEnhancedStorageACT_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingVolume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -46,7 +46,7 @@ impl IEnhancedStorageACT_Vtbl {
             let this = (*this).get_impl();
             match this.GetUniqueIdentity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszidentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszidentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -86,7 +86,7 @@ impl IEnhancedStorageACT2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -97,7 +97,7 @@ impl IEnhancedStorageACT2_Vtbl {
             let this = (*this).get_impl();
             match this.IsDeviceRemovable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisdeviceremovable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisdeviceremovable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -134,7 +134,7 @@ impl IEnhancedStorageACT3_Vtbl {
             let this = (*this).get_impl();
             match this.IsQueueFrozen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisqueuefrozen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisqueuefrozen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -145,7 +145,7 @@ impl IEnhancedStorageACT3_Vtbl {
             let this = (*this).get_impl();
             match this.GetShellExtSupport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pshellextsupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pshellextsupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -180,7 +180,7 @@ impl IEnhancedStorageSilo_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psiloinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psiloinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IEnhancedStorageSilo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPortableDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiportabledevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiportabledevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -212,7 +212,7 @@ impl IEnhancedStorageSilo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDevicePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszsilodevicepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszsilodevicepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -244,7 +244,7 @@ impl IEnhancedStorageSiloAction_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszactionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszactionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -255,7 +255,7 @@ impl IEnhancedStorageSiloAction_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszactiondescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszactiondescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -294,7 +294,7 @@ impl IEnumEnhancedStorageACT_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchingACT(::core::mem::transmute(&szvolume)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienhancedstorageact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienhancedstorageact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
@@ -45,7 +45,7 @@ impl IFhConfigMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetIncludeExcludeRules(::core::mem::transmute_copy(&include), ::core::mem::transmute_copy(&category)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *iterator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iterator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -56,7 +56,7 @@ impl IFhConfigMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalPolicy(::core::mem::transmute_copy(&localpolicytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *policyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(policyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -72,7 +72,7 @@ impl IFhConfigMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackupStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *backupstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(backupstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -88,7 +88,7 @@ impl IFhConfigMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *defaulttarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(defaulttarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -99,7 +99,7 @@ impl IFhConfigMgr_Vtbl {
             let this = (*this).get_impl();
             match this.ValidateTarget(::core::mem::transmute(&targeturl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *validationresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(validationresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -160,7 +160,7 @@ impl IFhReassociation_Vtbl {
             let this = (*this).get_impl();
             match this.ValidateTarget(::core::mem::transmute(&targeturl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *validationresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(validationresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -219,7 +219,7 @@ impl IFhScopeIterator_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -250,7 +250,7 @@ impl IFhTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringProperty(::core::mem::transmute_copy(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -261,7 +261,7 @@ impl IFhTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumericalProperty(::core::mem::transmute_copy(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/impl.rs
@@ -25,7 +25,7 @@ impl IFsrmAccessDeniedRemediationClient_Vtbl {
             let this = (*this).get_impl();
             match this.Show(::core::mem::transmute_copy(&parentwnd), ::core::mem::transmute(&accesspath), ::core::mem::transmute_copy(&errortype), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&windowtitle), ::core::mem::transmute(&windowmessage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -55,7 +55,7 @@ impl IFsrmAction_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -66,7 +66,7 @@ impl IFsrmAction_Vtbl {
             let this = (*this).get_impl();
             match this.ActionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *actiontype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actiontype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -77,7 +77,7 @@ impl IFsrmAction_Vtbl {
             let this = (*this).get_impl();
             match this.RunLimitInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minutes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minutes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl IFsrmActionCommand_Vtbl {
             let this = (*this).get_impl();
             match this.ExecutablePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *executablepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(executablepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -149,7 +149,7 @@ impl IFsrmActionCommand_Vtbl {
             let this = (*this).get_impl();
             match this.Arguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *arguments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(arguments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -165,7 +165,7 @@ impl IFsrmActionCommand_Vtbl {
             let this = (*this).get_impl();
             match this.Account() {
                 ::core::result::Result::Ok(ok__) => {
-                    *account = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(account, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -181,7 +181,7 @@ impl IFsrmActionCommand_Vtbl {
             let this = (*this).get_impl();
             match this.WorkingDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *workingdirectory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(workingdirectory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -197,7 +197,7 @@ impl IFsrmActionCommand_Vtbl {
             let this = (*this).get_impl();
             match this.MonitorCommand() {
                 ::core::result::Result::Ok(ok__) => {
-                    *monitorcommand = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(monitorcommand, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -213,7 +213,7 @@ impl IFsrmActionCommand_Vtbl {
             let this = (*this).get_impl();
             match this.KillTimeOut() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minutes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minutes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -229,7 +229,7 @@ impl IFsrmActionCommand_Vtbl {
             let this = (*this).get_impl();
             match this.LogResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *logresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(logresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -289,7 +289,7 @@ impl IFsrmActionEmail_Vtbl {
             let this = (*this).get_impl();
             match this.MailFrom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailfrom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailfrom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl IFsrmActionEmail_Vtbl {
             let this = (*this).get_impl();
             match this.MailReplyTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailreplyto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailreplyto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -321,7 +321,7 @@ impl IFsrmActionEmail_Vtbl {
             let this = (*this).get_impl();
             match this.MailTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -337,7 +337,7 @@ impl IFsrmActionEmail_Vtbl {
             let this = (*this).get_impl();
             match this.MailCc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -353,7 +353,7 @@ impl IFsrmActionEmail_Vtbl {
             let this = (*this).get_impl();
             match this.MailBcc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailbcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailbcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -369,7 +369,7 @@ impl IFsrmActionEmail_Vtbl {
             let this = (*this).get_impl();
             match this.MailSubject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailsubject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailsubject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -385,7 +385,7 @@ impl IFsrmActionEmail_Vtbl {
             let this = (*this).get_impl();
             match this.MessageText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *messagetext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(messagetext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -433,7 +433,7 @@ impl IFsrmActionEmail2_Vtbl {
             let this = (*this).get_impl();
             match this.AttachmentFileListSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attachmentfilelistsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attachmentfilelistsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -471,7 +471,7 @@ impl IFsrmActionEventLog_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -487,7 +487,7 @@ impl IFsrmActionEventLog_Vtbl {
             let this = (*this).get_impl();
             match this.MessageText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *messagetext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(messagetext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -527,7 +527,7 @@ impl IFsrmActionReport_Vtbl {
             let this = (*this).get_impl();
             match this.ReportTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reporttypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reporttypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -543,7 +543,7 @@ impl IFsrmActionReport_Vtbl {
             let this = (*this).get_impl();
             match this.MailTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -582,7 +582,7 @@ impl IFsrmAutoApplyQuota_Vtbl {
             let this = (*this).get_impl();
             match this.ExcludeFolders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *folders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(folders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -598,7 +598,7 @@ impl IFsrmAutoApplyQuota_Vtbl {
             let this = (*this).get_impl();
             match this.CommitAndUpdateDerived(::core::mem::transmute_copy(&commitoptions), ::core::mem::transmute_copy(&applyoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *derivedobjectsresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(derivedobjectsresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -655,7 +655,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ClassificationReportFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -671,7 +671,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.Logging() {
                 ::core::result::Result::Ok(ok__) => {
-                    *logging = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(logging, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -687,7 +687,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ClassificationReportMailTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -703,7 +703,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ClassificationReportEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reportenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reportenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -719,7 +719,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ClassificationLastReportPathWithoutExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastreportpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastreportpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -730,7 +730,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ClassificationLastError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lasterror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lasterror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -741,7 +741,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ClassificationRunningStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *runningstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(runningstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -752,7 +752,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumPropertyDefinitions(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertydefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertydefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -763,7 +763,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyDefinition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertydefinition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertydefinition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -774,7 +774,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyDefinition(::core::mem::transmute(&propertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertydefinition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertydefinition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -785,7 +785,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRules(::core::mem::transmute_copy(&ruletype), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -796,7 +796,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRule(::core::mem::transmute_copy(&ruletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -807,7 +807,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetRule(::core::mem::transmute(&rulename), ::core::mem::transmute_copy(&ruletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -818,7 +818,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumModuleDefinitions(::core::mem::transmute_copy(&moduletype), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduledefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduledefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -829,7 +829,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateModuleDefinition(::core::mem::transmute_copy(&moduletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduledefinition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduledefinition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -840,7 +840,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetModuleDefinition(::core::mem::transmute(&modulename), ::core::mem::transmute_copy(&moduletype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduledefinition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduledefinition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -856,7 +856,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForClassificationCompletion(::core::mem::transmute_copy(&waitseconds)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *completed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(completed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -872,7 +872,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFileProperties(::core::mem::transmute(&filepath), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fileproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fileproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -883,7 +883,7 @@ impl IFsrmClassificationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileProperty(::core::mem::transmute(&filepath), ::core::mem::transmute(&propertyname), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *property = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(property, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -973,7 +973,7 @@ impl IFsrmClassificationRule_Vtbl {
             let this = (*this).get_impl();
             match this.ExecutionOption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *executionoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(executionoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -989,7 +989,7 @@ impl IFsrmClassificationRule_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyAffected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *property = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(property, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1005,7 +1005,7 @@ impl IFsrmClassificationRule_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1049,7 +1049,7 @@ impl IFsrmClassifierModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertiesAffected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertiesaffected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertiesaffected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1065,7 +1065,7 @@ impl IFsrmClassifierModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertiesUsed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertiesused = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertiesused, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1081,7 +1081,7 @@ impl IFsrmClassifierModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.NeedsExplicitValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *needsexplicitvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(needsexplicitvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1125,7 +1125,7 @@ impl IFsrmClassifierModuleImplementation_Vtbl {
             let this = (*this).get_impl();
             match this.LastModified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1190,7 +1190,7 @@ impl IFsrmCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *unknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(unknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1201,7 +1201,7 @@ impl IFsrmCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1212,7 +1212,7 @@ impl IFsrmCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1223,7 +1223,7 @@ impl IFsrmCollection_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1239,7 +1239,7 @@ impl IFsrmCollection_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForCompletion(::core::mem::transmute_copy(&waitseconds)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *completed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(completed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1250,7 +1250,7 @@ impl IFsrmCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetById(::core::mem::transmute(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *entry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(entry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1285,7 +1285,7 @@ impl IFsrmCommittableCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Commit(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *results = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(results, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1312,7 +1312,7 @@ impl IFsrmDerivedObjectsResult_Vtbl {
             let this = (*this).get_impl();
             match this.DerivedObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *derivedobjects = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(derivedobjects, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1323,7 +1323,7 @@ impl IFsrmDerivedObjectsResult_Vtbl {
             let this = (*this).get_impl();
             match this.Results() {
                 ::core::result::Result::Ok(ok__) => {
-                    *results = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(results, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1363,7 +1363,7 @@ impl IFsrmExportImport_Vtbl {
             let this = (*this).get_impl();
             match this.ImportFileGroups(::core::mem::transmute(&filepath), ::core::mem::transmute_copy(&filegroupnamessafearray), ::core::mem::transmute(&remotehost)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filegroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filegroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1379,7 +1379,7 @@ impl IFsrmExportImport_Vtbl {
             let this = (*this).get_impl();
             match this.ImportFileScreenTemplates(::core::mem::transmute(&filepath), ::core::mem::transmute_copy(&templatenamessafearray), ::core::mem::transmute(&remotehost)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *templates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(templates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1395,7 +1395,7 @@ impl IFsrmExportImport_Vtbl {
             let this = (*this).get_impl();
             match this.ImportQuotaTemplates(::core::mem::transmute(&filepath), ::core::mem::transmute_copy(&templatenamessafearray), ::core::mem::transmute(&remotehost)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *templates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(templates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1430,7 +1430,7 @@ impl IFsrmFileCondition_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1474,7 +1474,7 @@ impl IFsrmFileConditionProperty_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1490,7 +1490,7 @@ impl IFsrmFileConditionProperty_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1506,7 +1506,7 @@ impl IFsrmFileConditionProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Operator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1522,7 +1522,7 @@ impl IFsrmFileConditionProperty_Vtbl {
             let this = (*this).get_impl();
             match this.ValueType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1538,7 +1538,7 @@ impl IFsrmFileConditionProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1586,7 +1586,7 @@ impl IFsrmFileGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1602,7 +1602,7 @@ impl IFsrmFileGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Members() {
                 ::core::result::Result::Ok(ok__) => {
-                    *members = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(members, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1618,7 +1618,7 @@ impl IFsrmFileGroup_Vtbl {
             let this = (*this).get_impl();
             match this.NonMembers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nonmembers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nonmembers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1658,7 +1658,7 @@ impl IFsrmFileGroupImported_Vtbl {
             let this = (*this).get_impl();
             match this.OverwriteOnCommit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *overwrite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(overwrite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1697,7 +1697,7 @@ impl IFsrmFileGroupManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filegroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filegroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1708,7 +1708,7 @@ impl IFsrmFileGroupManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileGroup(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filegroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filegroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1719,7 +1719,7 @@ impl IFsrmFileGroupManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFileGroups(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filegroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filegroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1730,7 +1730,7 @@ impl IFsrmFileGroupManager_Vtbl {
             let this = (*this).get_impl();
             match this.ExportFileGroups(::core::mem::transmute_copy(&filegroupnamesarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *serializedfilegroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(serializedfilegroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1741,7 +1741,7 @@ impl IFsrmFileGroupManager_Vtbl {
             let this = (*this).get_impl();
             match this.ImportFileGroups(::core::mem::transmute(&serializedfilegroups), ::core::mem::transmute_copy(&filegroupnamesarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filegroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filegroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1822,7 +1822,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1838,7 +1838,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.NamespaceRoots() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaceroots = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaceroots, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1854,7 +1854,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1870,7 +1870,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.OperationType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *operationtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(operationtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1886,7 +1886,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.ExpirationDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *expirationdirectory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expirationdirectory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1902,7 +1902,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.CustomAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1913,7 +1913,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.Notifications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *notifications = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(notifications, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1924,7 +1924,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.Logging() {
                 ::core::result::Result::Ok(ok__) => {
-                    *loggingflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(loggingflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1940,7 +1940,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.ReportEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reportenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reportenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1956,7 +1956,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.Formats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1972,7 +1972,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.MailTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1988,7 +1988,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.DaysSinceFileCreated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dayssincecreation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dayssincecreation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2004,7 +2004,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.DaysSinceFileLastAccessed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dayssinceaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dayssinceaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2020,7 +2020,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.DaysSinceFileLastModified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dayssincemodify = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dayssincemodify, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2036,7 +2036,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyConditions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyconditions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyconditions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2047,7 +2047,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.FromDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fromdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fromdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2063,7 +2063,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.Task() {
                 ::core::result::Result::Ok(ok__) => {
-                    *taskname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(taskname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2079,7 +2079,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.Parameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2095,7 +2095,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.RunningStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *runningstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(runningstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2106,7 +2106,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.LastError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lasterror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lasterror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2117,7 +2117,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.LastReportPathWithoutExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2128,7 +2128,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.LastRun() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastrun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastrun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2139,7 +2139,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.FileNamePattern() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filenamepattern = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filenamepattern, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2160,7 +2160,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForCompletion(::core::mem::transmute_copy(&waitseconds)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *completed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(completed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2191,7 +2191,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNotificationAction(::core::mem::transmute_copy(&days), ::core::mem::transmute_copy(&actiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2202,7 +2202,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.EnumNotificationActions(::core::mem::transmute_copy(&days)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *actions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2213,7 +2213,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyCondition(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertycondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertycondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2224,7 +2224,7 @@ impl IFsrmFileManagementJob_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCustomAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2305,7 +2305,7 @@ impl IFsrmFileManagementJobManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActionVariables() {
                 ::core::result::Result::Ok(ok__) => {
-                    *variables = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variables, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2316,7 +2316,7 @@ impl IFsrmFileManagementJobManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActionVariableDescriptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *descriptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descriptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2327,7 +2327,7 @@ impl IFsrmFileManagementJobManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFileManagementJobs(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filemanagementjobs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filemanagementjobs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2338,7 +2338,7 @@ impl IFsrmFileManagementJobManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileManagementJob() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filemanagementjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filemanagementjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2349,7 +2349,7 @@ impl IFsrmFileManagementJobManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileManagementJob(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filemanagementjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filemanagementjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2387,7 +2387,7 @@ impl IFsrmFileScreen_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2398,7 +2398,7 @@ impl IFsrmFileScreen_Vtbl {
             let this = (*this).get_impl();
             match this.SourceTemplateName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreentemplatename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreentemplatename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2409,7 +2409,7 @@ impl IFsrmFileScreen_Vtbl {
             let this = (*this).get_impl();
             match this.MatchesSourceTemplate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2420,7 +2420,7 @@ impl IFsrmFileScreen_Vtbl {
             let this = (*this).get_impl();
             match this.UserSid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usersid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usersid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2431,7 +2431,7 @@ impl IFsrmFileScreen_Vtbl {
             let this = (*this).get_impl();
             match this.UserAccount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *useraccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(useraccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2475,7 +2475,7 @@ impl IFsrmFileScreenBase_Vtbl {
             let this = (*this).get_impl();
             match this.BlockedFileGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blocklist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blocklist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2491,7 +2491,7 @@ impl IFsrmFileScreenBase_Vtbl {
             let this = (*this).get_impl();
             match this.FileScreenFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreenflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreenflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2507,7 +2507,7 @@ impl IFsrmFileScreenBase_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAction(::core::mem::transmute_copy(&actiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2518,7 +2518,7 @@ impl IFsrmFileScreenBase_Vtbl {
             let this = (*this).get_impl();
             match this.EnumActions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *actions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2554,7 +2554,7 @@ impl IFsrmFileScreenException_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2565,7 +2565,7 @@ impl IFsrmFileScreenException_Vtbl {
             let this = (*this).get_impl();
             match this.AllowedFileGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allowlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allowlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2609,7 +2609,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActionVariables() {
                 ::core::result::Result::Ok(ok__) => {
-                    *variables = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variables, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2620,7 +2620,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActionVariableDescriptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *descriptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descriptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2631,7 +2631,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileScreen(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2642,7 +2642,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileScreen(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2653,7 +2653,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFileScreens(::core::mem::transmute(&path), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreens = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreens, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2664,7 +2664,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileScreenException(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreenexception = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreenexception, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2675,7 +2675,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileScreenException(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreenexception = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreenexception, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2686,7 +2686,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFileScreenExceptions(::core::mem::transmute(&path), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreenexceptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreenexceptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2697,7 +2697,7 @@ impl IFsrmFileScreenManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileScreenCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2737,7 +2737,7 @@ impl IFsrmFileScreenTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2758,7 +2758,7 @@ impl IFsrmFileScreenTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.CommitAndUpdateDerived(::core::mem::transmute_copy(&commitoptions), ::core::mem::transmute_copy(&applyoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *derivedobjectsresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(derivedobjectsresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2791,7 +2791,7 @@ impl IFsrmFileScreenTemplateImported_Vtbl {
             let this = (*this).get_impl();
             match this.OverwriteOnCommit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *overwrite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(overwrite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2830,7 +2830,7 @@ impl IFsrmFileScreenTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTemplate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreentemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreentemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2841,7 +2841,7 @@ impl IFsrmFileScreenTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetTemplate(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreentemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreentemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2852,7 +2852,7 @@ impl IFsrmFileScreenTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTemplates(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreentemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreentemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2863,7 +2863,7 @@ impl IFsrmFileScreenTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.ExportTemplates(::core::mem::transmute_copy(&filescreentemplatenamesarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *serializedfilescreentemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(serializedfilescreentemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2874,7 +2874,7 @@ impl IFsrmFileScreenTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.ImportTemplates(::core::mem::transmute(&serializedfilescreentemplates), ::core::mem::transmute_copy(&filescreentemplatenamesarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filescreentemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filescreentemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2925,7 +2925,7 @@ impl IFsrmMutableCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2961,7 +2961,7 @@ impl IFsrmObject_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2972,7 +2972,7 @@ impl IFsrmObject_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3020,7 +3020,7 @@ impl IFsrmPathMapper_Vtbl {
             let this = (*this).get_impl();
             match this.GetSharePathsForLocalPath(::core::mem::transmute(&localpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sharepaths = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sharepaths, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3053,7 +3053,7 @@ impl IFsrmPipelineModuleConnector_Vtbl {
             let this = (*this).get_impl();
             match this.ModuleImplementation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pipelinemoduleimplementation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pipelinemoduleimplementation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3064,7 +3064,7 @@ impl IFsrmPipelineModuleConnector_Vtbl {
             let this = (*this).get_impl();
             match this.ModuleName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *username = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(username, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3075,7 +3075,7 @@ impl IFsrmPipelineModuleConnector_Vtbl {
             let this = (*this).get_impl();
             match this.HostingUserAccount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *useraccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(useraccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3086,7 +3086,7 @@ impl IFsrmPipelineModuleConnector_Vtbl {
             let this = (*this).get_impl();
             match this.HostingProcessPid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3142,7 +3142,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.ModuleClsid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduleclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduleclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3158,7 +3158,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3174,7 +3174,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Company() {
                 ::core::result::Result::Ok(ok__) => {
-                    *company = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(company, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3190,7 +3190,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *version = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(version, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3206,7 +3206,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.ModuleType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3217,7 +3217,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3233,7 +3233,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.NeedsFileContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *needsfilecontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(needsfilecontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3249,7 +3249,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Account() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retrievalaccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retrievalaccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3265,7 +3265,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedextensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedextensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3281,7 +3281,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Parameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3334,7 +3334,7 @@ impl IFsrmPipelineModuleImplementation_Vtbl {
             let this = (*this).get_impl();
             match this.OnLoad(::core::mem::transmute(&moduledefinition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduleconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduleconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3372,7 +3372,7 @@ impl IFsrmProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3383,7 +3383,7 @@ impl IFsrmProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3394,7 +3394,7 @@ impl IFsrmProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Sources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3405,7 +3405,7 @@ impl IFsrmProperty_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3457,7 +3457,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3468,7 +3468,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.RelativePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3479,7 +3479,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *volumename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(volumename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3490,7 +3490,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.RelativeNamespaceRoot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relativenamespaceroot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relativenamespaceroot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3501,7 +3501,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *volumeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(volumeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.FileId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fileid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fileid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.ParentDirectoryId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parentdirectoryid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parentdirectoryid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3534,7 +3534,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3545,7 +3545,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.SizeAllocated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sizeallocated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sizeallocated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3556,7 +3556,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.CreationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *creationtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(creationtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3567,7 +3567,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.LastAccessTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastaccesstime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastaccesstime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3578,7 +3578,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.LastModificationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastmodificationtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastmodificationtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3589,7 +3589,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.Attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3600,7 +3600,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerSid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ownersid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ownersid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3611,7 +3611,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.FilePropertyNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filepropertynames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filepropertynames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3622,7 +3622,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.Messages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *messages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(messages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3633,7 +3633,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyBagFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3644,7 +3644,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileProperty(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fileproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fileproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3665,7 +3665,7 @@ impl IFsrmPropertyBag_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileStreamInterface(::core::mem::transmute_copy(&accessmode), ::core::mem::transmute_copy(&interfacetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstreaminterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstreaminterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3715,7 +3715,7 @@ impl IFsrmPropertyBag2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldValue(::core::mem::transmute_copy(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3726,7 +3726,7 @@ impl IFsrmPropertyBag2_Vtbl {
             let this = (*this).get_impl();
             match this.GetUntrustedInFileProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *props = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(props, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3762,7 +3762,7 @@ impl IFsrmPropertyCondition_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3778,7 +3778,7 @@ impl IFsrmPropertyCondition_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3794,7 +3794,7 @@ impl IFsrmPropertyCondition_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3848,7 +3848,7 @@ impl IFsrmPropertyDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3864,7 +3864,7 @@ impl IFsrmPropertyDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3880,7 +3880,7 @@ impl IFsrmPropertyDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.PossibleValues() {
                 ::core::result::Result::Ok(ok__) => {
-                    *possiblevalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(possiblevalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3896,7 +3896,7 @@ impl IFsrmPropertyDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.ValueDescriptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *valuedescriptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(valuedescriptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3912,7 +3912,7 @@ impl IFsrmPropertyDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Parameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3959,7 +3959,7 @@ impl IFsrmPropertyDefinition2_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyDefinitionFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertydefinitionflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertydefinitionflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3970,7 +3970,7 @@ impl IFsrmPropertyDefinition2_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3986,7 +3986,7 @@ impl IFsrmPropertyDefinition2_Vtbl {
             let this = (*this).get_impl();
             match this.AppliesTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *appliesto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(appliesto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3997,7 +3997,7 @@ impl IFsrmPropertyDefinition2_Vtbl {
             let this = (*this).get_impl();
             match this.ValueDefinitions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *valuedefinitions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(valuedefinitions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4033,7 +4033,7 @@ impl IFsrmPropertyDefinitionValue_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4044,7 +4044,7 @@ impl IFsrmPropertyDefinitionValue_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4055,7 +4055,7 @@ impl IFsrmPropertyDefinitionValue_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4066,7 +4066,7 @@ impl IFsrmPropertyDefinitionValue_Vtbl {
             let this = (*this).get_impl();
             match this.UniqueID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uniqueid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uniqueid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4102,7 +4102,7 @@ impl IFsrmQuota_Vtbl {
             let this = (*this).get_impl();
             match this.QuotaUsed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *used = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(used, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4113,7 +4113,7 @@ impl IFsrmQuota_Vtbl {
             let this = (*this).get_impl();
             match this.QuotaPeakUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peakusage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peakusage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4124,7 +4124,7 @@ impl IFsrmQuota_Vtbl {
             let this = (*this).get_impl();
             match this.QuotaPeakUsageTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peakusagedatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peakusagedatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4176,7 +4176,7 @@ impl IFsrmQuotaBase_Vtbl {
             let this = (*this).get_impl();
             match this.QuotaLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotalimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotalimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4192,7 +4192,7 @@ impl IFsrmQuotaBase_Vtbl {
             let this = (*this).get_impl();
             match this.QuotaFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotaflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotaflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4208,7 +4208,7 @@ impl IFsrmQuotaBase_Vtbl {
             let this = (*this).get_impl();
             match this.Thresholds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *thresholds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(thresholds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4234,7 +4234,7 @@ impl IFsrmQuotaBase_Vtbl {
             let this = (*this).get_impl();
             match this.CreateThresholdAction(::core::mem::transmute_copy(&threshold), ::core::mem::transmute_copy(&actiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4245,7 +4245,7 @@ impl IFsrmQuotaBase_Vtbl {
             let this = (*this).get_impl();
             match this.EnumThresholdActions(::core::mem::transmute_copy(&threshold)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *actions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4294,7 +4294,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActionVariables() {
                 ::core::result::Result::Ok(ok__) => {
-                    *variables = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variables, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4305,7 +4305,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActionVariableDescriptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *descriptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descriptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4316,7 +4316,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQuota(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4327,7 +4327,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAutoApplyQuota(::core::mem::transmute(&quotatemplatename), ::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4338,7 +4338,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetQuota(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4349,7 +4349,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutoApplyQuota(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4360,7 +4360,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictiveQuota(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4371,7 +4371,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumQuotas(::core::mem::transmute(&path), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4382,7 +4382,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAutoApplyQuotas(::core::mem::transmute(&path), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4393,7 +4393,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumEffectiveQuotas(::core::mem::transmute(&path), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4409,7 +4409,7 @@ impl IFsrmQuotaManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQuotaCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4449,7 +4449,7 @@ impl IFsrmQuotaManagerEx_Vtbl {
             let this = (*this).get_impl();
             match this.IsAffectedByQuota(::core::mem::transmute(&path), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *affected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(affected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4480,7 +4480,7 @@ impl IFsrmQuotaObject_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4491,7 +4491,7 @@ impl IFsrmQuotaObject_Vtbl {
             let this = (*this).get_impl();
             match this.UserSid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usersid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usersid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4502,7 +4502,7 @@ impl IFsrmQuotaObject_Vtbl {
             let this = (*this).get_impl();
             match this.UserAccount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *useraccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(useraccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4513,7 +4513,7 @@ impl IFsrmQuotaObject_Vtbl {
             let this = (*this).get_impl();
             match this.SourceTemplateName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotatemplatename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotatemplatename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4524,7 +4524,7 @@ impl IFsrmQuotaObject_Vtbl {
             let this = (*this).get_impl();
             match this.MatchesSourceTemplate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4566,7 +4566,7 @@ impl IFsrmQuotaTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4587,7 +4587,7 @@ impl IFsrmQuotaTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.CommitAndUpdateDerived(::core::mem::transmute_copy(&commitoptions), ::core::mem::transmute_copy(&applyoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *derivedobjectsresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(derivedobjectsresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4620,7 +4620,7 @@ impl IFsrmQuotaTemplateImported_Vtbl {
             let this = (*this).get_impl();
             match this.OverwriteOnCommit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *overwrite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(overwrite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4659,7 +4659,7 @@ impl IFsrmQuotaTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTemplate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotatemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotatemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4670,7 +4670,7 @@ impl IFsrmQuotaTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetTemplate(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotatemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotatemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4681,7 +4681,7 @@ impl IFsrmQuotaTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTemplates(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotatemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotatemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4692,7 +4692,7 @@ impl IFsrmQuotaTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.ExportTemplates(::core::mem::transmute_copy(&quotatemplatenamesarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *serializedquotatemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(serializedquotatemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4703,7 +4703,7 @@ impl IFsrmQuotaTemplateManager_Vtbl {
             let this = (*this).get_impl();
             match this.ImportTemplates(::core::mem::transmute(&serializedquotatemplates), ::core::mem::transmute_copy(&quotatemplatenamesarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *quotatemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quotatemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4744,7 +4744,7 @@ impl IFsrmReport_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reporttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reporttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4755,7 +4755,7 @@ impl IFsrmReport_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4771,7 +4771,7 @@ impl IFsrmReport_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4787,7 +4787,7 @@ impl IFsrmReport_Vtbl {
             let this = (*this).get_impl();
             match this.LastGeneratedFileNamePrefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prefix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prefix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4798,7 +4798,7 @@ impl IFsrmReport_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilter(::core::mem::transmute_copy(&filter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filtervalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filtervalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4861,7 +4861,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.Task() {
                 ::core::result::Result::Ok(ok__) => {
-                    *taskname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(taskname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4877,7 +4877,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.NamespaceRoots() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaceroots = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaceroots, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4893,7 +4893,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.Formats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4909,7 +4909,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.MailTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4925,7 +4925,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.RunningStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *runningstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(runningstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4936,7 +4936,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.LastRun() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastrun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastrun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4947,7 +4947,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.LastError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lasterror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lasterror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4958,7 +4958,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.LastGeneratedInDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4969,7 +4969,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.EnumReports() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reports = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reports, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4980,7 +4980,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.CreateReport(::core::mem::transmute_copy(&reporttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *report = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(report, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4996,7 +4996,7 @@ impl IFsrmReportJob_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForCompletion(::core::mem::transmute_copy(&waitseconds)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *completed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(completed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5055,7 +5055,7 @@ impl IFsrmReportManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumReportJobs(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *reportjobs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reportjobs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5066,7 +5066,7 @@ impl IFsrmReportManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateReportJob() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reportjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reportjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5077,7 +5077,7 @@ impl IFsrmReportManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetReportJob(::core::mem::transmute(&taskname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *reportjob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reportjob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5088,7 +5088,7 @@ impl IFsrmReportManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputDirectory(::core::mem::transmute_copy(&context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5104,7 +5104,7 @@ impl IFsrmReportManager_Vtbl {
             let this = (*this).get_impl();
             match this.IsFilterValidForReportType(::core::mem::transmute_copy(&reporttype), ::core::mem::transmute_copy(&filter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *valid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(valid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5115,7 +5115,7 @@ impl IFsrmReportManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultFilter(::core::mem::transmute_copy(&reporttype), ::core::mem::transmute_copy(&filter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filtervalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filtervalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5131,7 +5131,7 @@ impl IFsrmReportManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetReportSizeLimit(::core::mem::transmute_copy(&limit)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *limitvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(limitvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5229,7 +5229,7 @@ impl IFsrmRule_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5245,7 +5245,7 @@ impl IFsrmRule_Vtbl {
             let this = (*this).get_impl();
             match this.RuleType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ruletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ruletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5256,7 +5256,7 @@ impl IFsrmRule_Vtbl {
             let this = (*this).get_impl();
             match this.ModuleDefinitionName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduledefinitionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduledefinitionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5272,7 +5272,7 @@ impl IFsrmRule_Vtbl {
             let this = (*this).get_impl();
             match this.NamespaceRoots() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaceroots = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaceroots, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5288,7 +5288,7 @@ impl IFsrmRule_Vtbl {
             let this = (*this).get_impl();
             match this.RuleFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ruleflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ruleflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5304,7 +5304,7 @@ impl IFsrmRule_Vtbl {
             let this = (*this).get_impl();
             match this.Parameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5320,7 +5320,7 @@ impl IFsrmRule_Vtbl {
             let this = (*this).get_impl();
             match this.LastModified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5372,7 +5372,7 @@ impl IFsrmSetting_Vtbl {
             let this = (*this).get_impl();
             match this.SmtpServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *smtpserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(smtpserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5388,7 +5388,7 @@ impl IFsrmSetting_Vtbl {
             let this = (*this).get_impl();
             match this.MailFrom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mailfrom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mailfrom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5404,7 +5404,7 @@ impl IFsrmSetting_Vtbl {
             let this = (*this).get_impl();
             match this.AdminEmail() {
                 ::core::result::Result::Ok(ok__) => {
-                    *adminemail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(adminemail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5420,7 +5420,7 @@ impl IFsrmSetting_Vtbl {
             let this = (*this).get_impl();
             match this.DisableCommandLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *disablecommandline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(disablecommandline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5436,7 +5436,7 @@ impl IFsrmSetting_Vtbl {
             let this = (*this).get_impl();
             match this.EnableScreeningAudit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enablescreeningaudit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enablescreeningaudit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5462,7 +5462,7 @@ impl IFsrmSetting_Vtbl {
             let this = (*this).get_impl();
             match this.GetActionRunLimitInterval(::core::mem::transmute_copy(&actiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *delaytimeminutes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(delaytimeminutes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5508,7 +5508,7 @@ impl IFsrmStorageModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Capabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *capabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(capabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5524,7 +5524,7 @@ impl IFsrmStorageModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.StorageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *storagetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storagetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5540,7 +5540,7 @@ impl IFsrmStorageModuleDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.UpdatesFileContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *updatesfilecontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(updatesfilecontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
@@ -87,7 +87,7 @@ impl IDiskQuotaControl_Vtbl {
             let this = (*this).get_impl();
             match this.AddUserSid(::core::mem::transmute_copy(&pusersid), ::core::mem::transmute_copy(&fnameresolution)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl IDiskQuotaControl_Vtbl {
             let this = (*this).get_impl();
             match this.AddUserName(::core::mem::transmute(&pszlogonname), ::core::mem::transmute_copy(&fnameresolution)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -114,7 +114,7 @@ impl IDiskQuotaControl_Vtbl {
             let this = (*this).get_impl();
             match this.FindUserSid(::core::mem::transmute_copy(&pusersid), ::core::mem::transmute_copy(&fnameresolution)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -125,7 +125,7 @@ impl IDiskQuotaControl_Vtbl {
             let this = (*this).get_impl();
             match this.FindUserName(::core::mem::transmute(&pszlogonname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -141,7 +141,7 @@ impl IDiskQuotaControl_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUserBatch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -399,7 +399,7 @@ impl IEnumDiskQuotaUsers_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
@@ -183,7 +183,7 @@ impl IBlockRange_Vtbl {
             let this = (*this).get_impl();
             match this.StartLba() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -194,7 +194,7 @@ impl IBlockRange_Vtbl {
             let this = (*this).get_impl();
             match this.EndLba() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -224,7 +224,7 @@ impl IBlockRangeList_Vtbl {
             let this = (*this).get_impl();
             match this.BlockRanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -258,7 +258,7 @@ impl IBootOptions_Vtbl {
             let this = (*this).get_impl();
             match this.BootImage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -269,7 +269,7 @@ impl IBootOptions_Vtbl {
             let this = (*this).get_impl();
             match this.Manufacturer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -285,7 +285,7 @@ impl IBootOptions_Vtbl {
             let this = (*this).get_impl();
             match this.PlatformId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -301,7 +301,7 @@ impl IBootOptions_Vtbl {
             let this = (*this).get_impl();
             match this.Emulation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl IBootOptions_Vtbl {
             let this = (*this).get_impl();
             match this.ImageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -362,7 +362,7 @@ impl IBurnVerification_Vtbl {
             let this = (*this).get_impl();
             match this.BurnVerificationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -396,7 +396,7 @@ impl IDiscFormat2_Vtbl {
             let this = (*this).get_impl();
             match this.IsRecorderSupported(::core::mem::transmute(&recorder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -407,7 +407,7 @@ impl IDiscFormat2_Vtbl {
             let this = (*this).get_impl();
             match this.IsCurrentMediaSupported(::core::mem::transmute(&recorder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -418,7 +418,7 @@ impl IDiscFormat2_Vtbl {
             let this = (*this).get_impl();
             match this.MediaPhysicallyBlank() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl IDiscFormat2_Vtbl {
             let this = (*this).get_impl();
             match this.MediaHeuristicallyBlank() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl IDiscFormat2_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedMediaTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -509,7 +509,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.Recorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -525,7 +525,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.BufferUnderrunFreeDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -541,7 +541,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.PostgapAlreadyInImage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -552,7 +552,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentMediaStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -563,7 +563,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.WriteProtectStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -574,7 +574,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.TotalSectorsOnMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -585,7 +585,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.FreeSectorsOnMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -596,7 +596,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.NextWritableAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -607,7 +607,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.StartAddressOfPreviousSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -618,7 +618,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.LastWrittenAddressOfPreviousSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -634,7 +634,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.ForceMediaToBeClosed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -650,7 +650,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.DisableConsumerDvdCompatibilityMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -661,7 +661,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPhysicalMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -677,7 +677,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.ClientName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -688,7 +688,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedWriteSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -699,7 +699,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedRotationTypeIsPureCAV() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -710,7 +710,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentWriteSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -721,7 +721,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRotationTypeIsPureCAV() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -732,7 +732,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedWriteSpeeds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedspeeds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedspeeds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -743,7 +743,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedWriteSpeedDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedspeeddescriptors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedspeeddescriptors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -759,7 +759,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.ForceOverwrite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -770,7 +770,7 @@ impl IDiscFormat2Data_Vtbl {
             let this = (*this).get_impl();
             match this.MultisessionInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -848,7 +848,7 @@ impl IDiscFormat2DataEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ElapsedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -859,7 +859,7 @@ impl IDiscFormat2DataEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.RemainingTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -870,7 +870,7 @@ impl IDiscFormat2DataEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TotalTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -881,7 +881,7 @@ impl IDiscFormat2DataEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -925,7 +925,7 @@ impl IDiscFormat2Erase_Vtbl {
             let this = (*this).get_impl();
             match this.Recorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -941,7 +941,7 @@ impl IDiscFormat2Erase_Vtbl {
             let this = (*this).get_impl();
             match this.FullErase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -952,7 +952,7 @@ impl IDiscFormat2Erase_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPhysicalMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -968,7 +968,7 @@ impl IDiscFormat2Erase_Vtbl {
             let this = (*this).get_impl();
             match this.ClientName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1067,7 +1067,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.Recorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1083,7 +1083,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.BufferUnderrunFreeDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1094,7 +1094,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.StartOfNextSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1105,7 +1105,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.LastPossibleStartOfLeadout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1116,7 +1116,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPhysicalMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1127,7 +1127,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedSectorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1143,7 +1143,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedSectorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1159,7 +1159,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.ClientName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1170,7 +1170,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedWriteSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1181,7 +1181,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedRotationTypeIsPureCAV() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1192,7 +1192,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentWriteSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1203,7 +1203,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRotationTypeIsPureCAV() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1214,7 +1214,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedWriteSpeeds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedspeeds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedspeeds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1225,7 +1225,7 @@ impl IDiscFormat2RawCD_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedWriteSpeedDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedspeeddescriptors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedspeeddescriptors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1279,7 +1279,7 @@ impl IDiscFormat2RawCDEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1290,7 +1290,7 @@ impl IDiscFormat2RawCDEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ElapsedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1301,7 +1301,7 @@ impl IDiscFormat2RawCDEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.RemainingTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1386,7 +1386,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.Recorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1402,7 +1402,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.BufferUnderrunFreeDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1413,7 +1413,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfExistingTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1424,7 +1424,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.TotalSectorsOnMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1435,7 +1435,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.FreeSectorsOnMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1446,7 +1446,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.UsedSectorsOnMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1462,7 +1462,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.DoNotFinalizeMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1473,7 +1473,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.ExpectedTableOfContents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1484,7 +1484,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPhysicalMediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1500,7 +1500,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.ClientName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1511,7 +1511,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedWriteSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1522,7 +1522,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.RequestedRotationTypeIsPureCAV() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1533,7 +1533,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentWriteSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1544,7 +1544,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRotationTypeIsPureCAV() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1555,7 +1555,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedWriteSpeeds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedspeeds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedspeeds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1566,7 +1566,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedWriteSpeedDescriptors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedspeeddescriptors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedspeeddescriptors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1622,7 +1622,7 @@ impl IDiscFormat2TrackAtOnceEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentTrackNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1633,7 +1633,7 @@ impl IDiscFormat2TrackAtOnceEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1644,7 +1644,7 @@ impl IDiscFormat2TrackAtOnceEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.ElapsedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1655,7 +1655,7 @@ impl IDiscFormat2TrackAtOnceEventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.RemainingTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1700,7 +1700,7 @@ impl IDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDiscMasterFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1711,7 +1711,7 @@ impl IDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveDiscMasterFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpiid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpiid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1727,7 +1727,7 @@ impl IDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDiscRecorders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1738,7 +1738,7 @@ impl IDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveDiscRecorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprecorder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprecorder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1759,7 +1759,7 @@ impl IDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.ProgressAdvise(::core::mem::transmute(&pevents)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1817,7 +1817,7 @@ impl IDiscMaster2_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1828,7 +1828,7 @@ impl IDiscMaster2_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1839,7 +1839,7 @@ impl IDiscMaster2_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1850,7 +1850,7 @@ impl IDiscMaster2_Vtbl {
             let this = (*this).get_impl();
             match this.IsSupportedEnvironment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1887,7 +1887,7 @@ impl IDiscMasterProgressEvents_Vtbl {
             let this = (*this).get_impl();
             match this.QueryCancel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbcancel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbcancel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1988,7 +1988,7 @@ impl IDiscRecorder_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecorderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ftypecode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ftypecode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2004,7 +2004,7 @@ impl IDiscRecorder_Vtbl {
             let this = (*this).get_impl();
             match this.GetBasePnPID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbasepnpid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbasepnpid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2015,7 +2015,7 @@ impl IDiscRecorder_Vtbl {
             let this = (*this).get_impl();
             match this.GetPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2026,7 +2026,7 @@ impl IDiscRecorder_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecorderProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2042,7 +2042,7 @@ impl IDiscRecorder_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecorderState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puldevstateflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puldevstateflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2170,7 +2170,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.ActiveDiscRecorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2181,7 +2181,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.VendorId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2192,7 +2192,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.ProductId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2203,7 +2203,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.ProductRevision() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2214,7 +2214,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2225,7 +2225,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.VolumePathNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2236,7 +2236,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceCanLoadMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2247,7 +2247,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.LegacyDeviceNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *legacydevicenumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(legacydevicenumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2258,7 +2258,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedFeaturePages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2269,7 +2269,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFeaturePages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2280,7 +2280,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedProfiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2291,7 +2291,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentProfiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2302,7 +2302,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedModePages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2313,7 +2313,7 @@ impl IDiscRecorder2_Vtbl {
             let this = (*this).get_impl();
             match this.ExclusiveAccessOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2454,7 +2454,7 @@ impl IDiscRecorder2Ex_Vtbl {
             let this = (*this).get_impl();
             match this.GetByteAlignmentMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2465,7 +2465,7 @@ impl IDiscRecorder2Ex_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumNonPageAlignedTransferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2476,7 +2476,7 @@ impl IDiscRecorder2Ex_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaximumPageAlignedTransferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2537,7 +2537,7 @@ impl IEnumDiscMasterFormats_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2584,7 +2584,7 @@ impl IEnumDiscRecorders_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2634,7 +2634,7 @@ impl IEnumFsiItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2684,7 +2684,7 @@ impl IEnumProgressItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2765,7 +2765,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.Root() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2776,7 +2776,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.SessionStartBlock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2792,7 +2792,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.FreeMediaBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2813,7 +2813,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.UsedBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2824,7 +2824,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2840,7 +2840,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.ImportedVolumeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2851,7 +2851,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.BootImageOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2867,7 +2867,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.FileCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2878,7 +2878,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.DirectoryCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2889,7 +2889,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.WorkingDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2905,7 +2905,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.ChangePoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2916,7 +2916,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.StrictFileSystemCompliance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2932,7 +2932,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.UseRestrictedCharacterSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2948,7 +2948,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.FileSystemsToCreate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2964,7 +2964,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.FileSystemsSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2980,7 +2980,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.UDFRevision() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2991,7 +2991,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.UDFRevisionsSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3017,7 +3017,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.ISO9660InterchangeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3028,7 +3028,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.ISO9660InterchangeLevelsSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3039,7 +3039,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateResultImage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3050,7 +3050,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.Exists(::core::mem::transmute(&fullpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3061,7 +3061,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.CalculateDiscIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *discidentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(discidentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3072,7 +3072,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.IdentifyFileSystemsOnDisc(::core::mem::transmute(&discrecorder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filesystems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filesystems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3083,7 +3083,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultFileSystemForImport(::core::mem::transmute_copy(&filesystems)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *importdefault = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(importdefault, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3094,7 +3094,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.ImportFileSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *importedfilesystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(importedfilesystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3120,7 +3120,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDirectoryItem(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3131,7 +3131,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFileItem(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3142,7 +3142,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeNameUDF() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3153,7 +3153,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeNameJoliet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3164,7 +3164,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.VolumeNameISO9660() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3175,7 +3175,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.StageFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3191,7 +3191,7 @@ impl IFileSystemImage_Vtbl {
             let this = (*this).get_impl();
             match this.MultisessionInterfaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3275,7 +3275,7 @@ impl IFileSystemImage2_Vtbl {
             let this = (*this).get_impl();
             match this.BootImageOptionsArray() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3312,7 +3312,7 @@ impl IFileSystemImage3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRedundantUdfMetadataFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3328,7 +3328,7 @@ impl IFileSystemImage3_Vtbl {
             let this = (*this).get_impl();
             match this.ProbeSpecificFileSystem(::core::mem::transmute_copy(&filesystemtoprobe)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isappendable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isappendable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3363,7 +3363,7 @@ impl IFileSystemImageResult_Vtbl {
             let this = (*this).get_impl();
             match this.ImageStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3374,7 +3374,7 @@ impl IFileSystemImageResult_Vtbl {
             let this = (*this).get_impl();
             match this.ProgressItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3385,7 +3385,7 @@ impl IFileSystemImageResult_Vtbl {
             let this = (*this).get_impl();
             match this.TotalBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3396,7 +3396,7 @@ impl IFileSystemImageResult_Vtbl {
             let this = (*this).get_impl();
             match this.BlockSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3407,7 +3407,7 @@ impl IFileSystemImageResult_Vtbl {
             let this = (*this).get_impl();
             match this.DiscId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3440,7 +3440,7 @@ impl IFileSystemImageResult2_Vtbl {
             let this = (*this).get_impl();
             match this.ModifiedBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3475,7 +3475,7 @@ impl IFsiDirectoryItem_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3486,7 +3486,7 @@ impl IFsiDirectoryItem_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3497,7 +3497,7 @@ impl IFsiDirectoryItem_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3508,7 +3508,7 @@ impl IFsiDirectoryItem_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFsiItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3600,7 +3600,7 @@ impl IFsiFileItem_Vtbl {
             let this = (*this).get_impl();
             match this.DataSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3611,7 +3611,7 @@ impl IFsiFileItem_Vtbl {
             let this = (*this).get_impl();
             match this.DataSize32BitLow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3622,7 +3622,7 @@ impl IFsiFileItem_Vtbl {
             let this = (*this).get_impl();
             match this.DataSize32BitHigh() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3633,7 +3633,7 @@ impl IFsiFileItem_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3676,7 +3676,7 @@ impl IFsiFileItem2_Vtbl {
             let this = (*this).get_impl();
             match this.FsiNamedStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *streams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(streams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3687,7 +3687,7 @@ impl IFsiFileItem2_Vtbl {
             let this = (*this).get_impl();
             match this.IsNamedStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3708,7 +3708,7 @@ impl IFsiFileItem2_Vtbl {
             let this = (*this).get_impl();
             match this.IsRealTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3758,7 +3758,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3769,7 +3769,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.FullPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3780,7 +3780,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.CreationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3796,7 +3796,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.LastAccessedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3812,7 +3812,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.LastModifiedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3828,7 +3828,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsHidden() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3844,7 +3844,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.FileSystemName(::core::mem::transmute_copy(&filesystem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3855,7 +3855,7 @@ impl IFsiItem_Vtbl {
             let this = (*this).get_impl();
             match this.FileSystemPath(::core::mem::transmute_copy(&filesystem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3898,7 +3898,7 @@ impl IFsiNamedStreams_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3909,7 +3909,7 @@ impl IFsiNamedStreams_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3920,7 +3920,7 @@ impl IFsiNamedStreams_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3931,7 +3931,7 @@ impl IFsiNamedStreams_Vtbl {
             let this = (*this).get_impl();
             match this.EnumNamedStreams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3967,7 +3967,7 @@ impl IIsoImageManager_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3978,7 +3978,7 @@ impl IIsoImageManager_Vtbl {
             let this = (*this).get_impl();
             match this.Stream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *data = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(data, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4031,7 +4031,7 @@ impl IJolietDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalDataBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnblocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnblocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4042,7 +4042,7 @@ impl IJolietDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetUsedDataBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnblocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnblocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4053,7 +4053,7 @@ impl IJolietDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataBlockSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnblockbytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnblockbytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4069,7 +4069,7 @@ impl IJolietDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetJolietProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4111,7 +4111,7 @@ impl IMultisession_Vtbl {
             let this = (*this).get_impl();
             match this.IsSupportedOnCurrentMediaState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4127,7 +4127,7 @@ impl IMultisession_Vtbl {
             let this = (*this).get_impl();
             match this.InUse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4138,7 +4138,7 @@ impl IMultisession_Vtbl {
             let this = (*this).get_impl();
             match this.ImportRecorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4172,7 +4172,7 @@ impl IMultisessionRandomWrite_Vtbl {
             let this = (*this).get_impl();
             match this.WriteUnitSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4183,7 +4183,7 @@ impl IMultisessionRandomWrite_Vtbl {
             let this = (*this).get_impl();
             match this.LastWrittenAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4194,7 +4194,7 @@ impl IMultisessionRandomWrite_Vtbl {
             let this = (*this).get_impl();
             match this.TotalSectorsOnMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4229,7 +4229,7 @@ impl IMultisessionSequential_Vtbl {
             let this = (*this).get_impl();
             match this.IsFirstDataSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4240,7 +4240,7 @@ impl IMultisessionSequential_Vtbl {
             let this = (*this).get_impl();
             match this.StartAddressOfPreviousSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4251,7 +4251,7 @@ impl IMultisessionSequential_Vtbl {
             let this = (*this).get_impl();
             match this.LastWrittenAddressOfPreviousSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4262,7 +4262,7 @@ impl IMultisessionSequential_Vtbl {
             let this = (*this).get_impl();
             match this.NextWritableAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4273,7 +4273,7 @@ impl IMultisessionSequential_Vtbl {
             let this = (*this).get_impl();
             match this.FreeSectorsOnMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4306,7 +4306,7 @@ impl IMultisessionSequential2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteUnitSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4335,7 +4335,7 @@ impl IProgressItem_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *desc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(desc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4346,7 +4346,7 @@ impl IProgressItem_Vtbl {
             let this = (*this).get_impl();
             match this.FirstBlock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *block = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(block, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4357,7 +4357,7 @@ impl IProgressItem_Vtbl {
             let this = (*this).get_impl();
             match this.LastBlock() {
                 ::core::result::Result::Ok(ok__) => {
-                    *block = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(block, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4368,7 +4368,7 @@ impl IProgressItem_Vtbl {
             let this = (*this).get_impl();
             match this.BlockCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4405,7 +4405,7 @@ impl IProgressItems_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4416,7 +4416,7 @@ impl IProgressItems_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4427,7 +4427,7 @@ impl IProgressItems_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4438,7 +4438,7 @@ impl IProgressItems_Vtbl {
             let this = (*this).get_impl();
             match this.ProgressItemFromBlock(::core::mem::transmute_copy(&block)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4449,7 +4449,7 @@ impl IProgressItems_Vtbl {
             let this = (*this).get_impl();
             match this.ProgressItemFromDescription(::core::mem::transmute(&description)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4460,7 +4460,7 @@ impl IProgressItems_Vtbl {
             let this = (*this).get_impl();
             match this.EnumProgressItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4512,7 +4512,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.CreateResultImage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4523,7 +4523,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.AddTrack(::core::mem::transmute_copy(&datatype), ::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *trackindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(trackindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4549,7 +4549,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.ResultingImageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4560,7 +4560,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.StartOfLeadout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4576,7 +4576,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.StartOfLeadoutLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4592,7 +4592,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.DisableGaplessAudio() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4608,7 +4608,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.MediaCatalogNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4624,7 +4624,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.StartingTrackNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4635,7 +4635,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.get_TrackInfo(::core::mem::transmute_copy(&trackindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4646,7 +4646,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfExistingTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4657,7 +4657,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.LastUsedUserSectorInImage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4668,7 +4668,7 @@ impl IRawCDImageCreator_Vtbl {
             let this = (*this).get_impl();
             match this.ExpectedTableOfContents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4727,7 +4727,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.StartingLba() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4738,7 +4738,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SectorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4749,7 +4749,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TrackNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4760,7 +4760,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SectorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4771,7 +4771,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ISRC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4787,7 +4787,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DigitalAudioCopySetting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4803,7 +4803,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AudioHasPreemphasis() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4819,7 +4819,7 @@ impl IRawCDImageTrackInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TrackIndexes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4874,7 +4874,7 @@ impl IRedbookDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalAudioTracks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pntracks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pntracks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4885,7 +4885,7 @@ impl IRedbookDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalAudioBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnblocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnblocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4896,7 +4896,7 @@ impl IRedbookDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetUsedAudioBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnblocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnblocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4907,7 +4907,7 @@ impl IRedbookDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetAvailableAudioTrackBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnblocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnblocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4918,7 +4918,7 @@ impl IRedbookDiscMaster_Vtbl {
             let this = (*this).get_impl();
             match this.GetAudioBlockSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnblockbytes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnblockbytes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5041,7 +5041,7 @@ impl IStreamPseudoRandomBased_Vtbl {
             let this = (*this).get_impl();
             match this.Seed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5110,7 +5110,7 @@ impl IWriteEngine2_Vtbl {
             let this = (*this).get_impl();
             match this.Recorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5126,7 +5126,7 @@ impl IWriteEngine2_Vtbl {
             let this = (*this).get_impl();
             match this.UseStreamingWrite12() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5142,7 +5142,7 @@ impl IWriteEngine2_Vtbl {
             let this = (*this).get_impl();
             match this.StartingSectorsPerSecond() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5158,7 +5158,7 @@ impl IWriteEngine2_Vtbl {
             let this = (*this).get_impl();
             match this.EndingSectorsPerSecond() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5174,7 +5174,7 @@ impl IWriteEngine2_Vtbl {
             let this = (*this).get_impl();
             match this.BytesPerSector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5185,7 +5185,7 @@ impl IWriteEngine2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteInProgress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5232,7 +5232,7 @@ impl IWriteEngine2EventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.StartLba() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5243,7 +5243,7 @@ impl IWriteEngine2EventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.SectorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5254,7 +5254,7 @@ impl IWriteEngine2EventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.LastReadLba() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5265,7 +5265,7 @@ impl IWriteEngine2EventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.LastWrittenLba() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5276,7 +5276,7 @@ impl IWriteEngine2EventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.TotalSystemBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5287,7 +5287,7 @@ impl IWriteEngine2EventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.UsedSystemBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5298,7 +5298,7 @@ impl IWriteEngine2EventArgs_Vtbl {
             let this = (*this).get_impl();
             match this.FreeSystemBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5335,7 +5335,7 @@ impl IWriteSpeedDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5346,7 +5346,7 @@ impl IWriteSpeedDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.RotationTypeIsPureCAV() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5357,7 +5357,7 @@ impl IWriteSpeedDescriptor_Vtbl {
             let this = (*this).get_impl();
             match this.WriteSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
@@ -27,7 +27,7 @@ impl IEnumOfflineFilesItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -74,7 +74,7 @@ impl IEnumOfflineFilesSettings_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -157,7 +157,7 @@ impl IOfflineFilesCache_Vtbl {
             let this = (*this).get_impl();
             match this.FindItem(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&dwqueryflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -168,7 +168,7 @@ impl IOfflineFilesCache_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemEx(::core::mem::transmute(&pszpath), ::core::mem::transmute(&pincludefilefilter), ::core::mem::transmute(&pincludedirfilter), ::core::mem::transmute(&pexcludefilefilter), ::core::mem::transmute(&pexcludedirfilter), ::core::mem::transmute_copy(&dwqueryflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -184,7 +184,7 @@ impl IOfflineFilesCache_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -210,7 +210,7 @@ impl IOfflineFilesCache_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettingObject(::core::mem::transmute(&pszsettingname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsetting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsetting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -221,7 +221,7 @@ impl IOfflineFilesCache_Vtbl {
             let this = (*this).get_impl();
             match this.EnumSettingObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -301,7 +301,7 @@ impl IOfflineFilesChangeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsDeletedOffline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdeletedoffline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdeletedoffline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -312,7 +312,7 @@ impl IOfflineFilesChangeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsCreatedOffline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbcreatedoffline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbcreatedoffline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -323,7 +323,7 @@ impl IOfflineFilesChangeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsLocallyModifiedData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblocallymodifieddata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblocallymodifieddata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -334,7 +334,7 @@ impl IOfflineFilesChangeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsLocallyModifiedAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblocallymodifiedattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblocallymodifiedattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -345,7 +345,7 @@ impl IOfflineFilesChangeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsLocallyModifiedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pblocallymodifiedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pblocallymodifiedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -397,7 +397,7 @@ impl IOfflineFilesConnectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TransitionOffline(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&bforceopenfilesclosed)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbopenfilespreventedtransition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbopenfilespreventedtransition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl IOfflineFilesDirtyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LocalDirtyByteCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdirtybytecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdirtybytecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -451,7 +451,7 @@ impl IOfflineFilesDirtyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteDirtyByteCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdirtybytecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdirtybytecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -482,7 +482,7 @@ impl IOfflineFilesErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppblob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppblob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -493,7 +493,7 @@ impl IOfflineFilesErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -895,7 +895,7 @@ impl IOfflineFilesFileItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsSparse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbissparse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbissparse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -906,7 +906,7 @@ impl IOfflineFilesFileItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsEncrypted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisencrypted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisencrypted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -938,7 +938,7 @@ impl IOfflineFilesFileSysInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributes(::core::mem::transmute_copy(&copy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl IOfflineFilesFileSysInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileSize(::core::mem::transmute_copy(&copy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -985,7 +985,7 @@ impl IOfflineFilesGhostInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsGhosted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbghosted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbghosted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1015,7 +1015,7 @@ impl IOfflineFilesItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitemtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitemtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1026,7 +1026,7 @@ impl IOfflineFilesItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1037,7 +1037,7 @@ impl IOfflineFilesItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1053,7 +1053,7 @@ impl IOfflineFilesItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsMarkedForDeletion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmarkedfordeletion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmarkedfordeletion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1084,7 +1084,7 @@ impl IOfflineFilesItemContainer_Vtbl {
             let this = (*this).get_impl();
             match this.EnumItems(::core::mem::transmute_copy(&dwqueryflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1095,7 +1095,7 @@ impl IOfflineFilesItemContainer_Vtbl {
             let this = (*this).get_impl();
             match this.EnumItemsEx(::core::mem::transmute(&pincludefilefilter), ::core::mem::transmute(&pincludedirfilter), ::core::mem::transmute(&pexcludefilefilter), ::core::mem::transmute(&pexcludedirfilter), ::core::mem::transmute_copy(&dwenumflags), ::core::mem::transmute_copy(&dwqueryflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1166,7 +1166,7 @@ impl IOfflineFilesPinInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsPinned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbpinned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbpinned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1219,7 +1219,7 @@ impl IOfflineFilesPinInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.IsPartlyPinned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbpartlypinned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbpartlypinned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1247,7 +1247,7 @@ impl IOfflineFilesProgress_Vtbl {
             let this = (*this).get_impl();
             match this.Begin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbabort = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbabort, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1258,7 +1258,7 @@ impl IOfflineFilesProgress_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAbort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbabort = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbabort, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1315,7 +1315,7 @@ impl IOfflineFilesSetting_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1326,7 +1326,7 @@ impl IOfflineFilesSetting_Vtbl {
             let this = (*this).get_impl();
             match this.GetValueType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1342,7 +1342,7 @@ impl IOfflineFilesSetting_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferenceScope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1368,7 +1368,7 @@ impl IOfflineFilesSetting_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicyScope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1412,7 +1412,7 @@ impl IOfflineFilesShareInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetShareItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshareitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshareitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1423,7 +1423,7 @@ impl IOfflineFilesShareInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetShareCachingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcachingmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcachingmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1434,7 +1434,7 @@ impl IOfflineFilesShareInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsShareDfsJunction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisdfsjunction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisdfsjunction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1479,7 +1479,7 @@ impl IOfflineFilesSimpleProgress_Vtbl {
             let this = (*this).get_impl();
             match this.ItemBegin(::core::mem::transmute(&pszfile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1490,7 +1490,7 @@ impl IOfflineFilesSimpleProgress_Vtbl {
             let this = (*this).get_impl();
             match this.ItemResult(::core::mem::transmute(&pszfile), ::core::mem::transmute_copy(&hrresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1583,7 +1583,7 @@ impl IOfflineFilesSyncErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psyncop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psyncop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1594,7 +1594,7 @@ impl IOfflineFilesSyncErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemChangeFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwitemchangeflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwitemchangeflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1615,7 +1615,7 @@ impl IOfflineFilesSyncErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1626,7 +1626,7 @@ impl IOfflineFilesSyncErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetRemoteInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1637,7 +1637,7 @@ impl IOfflineFilesSyncErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1674,7 +1674,7 @@ impl IOfflineFilesSyncErrorItemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1690,7 +1690,7 @@ impl IOfflineFilesSyncErrorItemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1722,7 +1722,7 @@ impl IOfflineFilesSyncProgress_Vtbl {
             let this = (*this).get_impl();
             match this.SyncItemBegin(::core::mem::transmute(&pszfile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1733,7 +1733,7 @@ impl IOfflineFilesSyncProgress_Vtbl {
             let this = (*this).get_impl();
             match this.SyncItemResult(::core::mem::transmute(&pszfile), ::core::mem::transmute_copy(&hrresult), ::core::mem::transmute(&perrorinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1763,7 +1763,7 @@ impl IOfflineFilesTransparentCacheInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransparentlyCached() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbtransparentlycached = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbtransparentlycached, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
@@ -15,7 +15,7 @@ impl IAppxBlockMapBlock_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompressedSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -47,7 +47,7 @@ impl IAppxBlockMapBlocksEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *block = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(block, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -58,7 +58,7 @@ impl IAppxBlockMapBlocksEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -69,7 +69,7 @@ impl IAppxBlockMapBlocksEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -104,7 +104,7 @@ impl IAppxBlockMapFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -115,7 +115,7 @@ impl IAppxBlockMapFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalFileHeaderSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lfhsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lfhsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -126,7 +126,7 @@ impl IAppxBlockMapFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -137,7 +137,7 @@ impl IAppxBlockMapFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetUncompressedSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -148,7 +148,7 @@ impl IAppxBlockMapFile_Vtbl {
             let this = (*this).get_impl();
             match this.ValidateFileHash(::core::mem::transmute(&filestream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isvalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isvalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -183,7 +183,7 @@ impl IAppxBlockMapFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *file = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(file, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -194,7 +194,7 @@ impl IAppxBlockMapFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -205,7 +205,7 @@ impl IAppxBlockMapFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -239,7 +239,7 @@ impl IAppxBlockMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetFile(::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *file = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(file, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -250,7 +250,7 @@ impl IAppxBlockMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -261,7 +261,7 @@ impl IAppxBlockMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetHashMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hashmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hashmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -272,7 +272,7 @@ impl IAppxBlockMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blockmapstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blockmapstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -306,7 +306,7 @@ impl IAppxBundleFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBundleWriter(::core::mem::transmute(&outputstream), ::core::mem::transmute_copy(&bundleversion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bundlewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bundlewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl IAppxBundleFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBundleReader(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bundlereader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bundlereader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -328,7 +328,7 @@ impl IAppxBundleFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBundleManifestReader(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *manifestreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(manifestreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl IAppxBundleManifestOptionalBundleInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -369,7 +369,7 @@ impl IAppxBundleManifestOptionalBundleInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -380,7 +380,7 @@ impl IAppxBundleManifestOptionalBundleInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageInfoItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageinfoitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageinfoitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -413,7 +413,7 @@ impl IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *optionalbundle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(optionalbundle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -424,7 +424,7 @@ impl IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -435,7 +435,7 @@ impl IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -468,7 +468,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -479,7 +479,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -490,7 +490,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -501,7 +501,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -512,7 +512,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -523,7 +523,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -559,7 +559,7 @@ impl IAppxBundleManifestPackageInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsPackageReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ispackagereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ispackagereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -570,7 +570,7 @@ impl IAppxBundleManifestPackageInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsNonQualifiedResourcePackage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnonqualifiedresourcepackage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnonqualifiedresourcepackage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -581,7 +581,7 @@ impl IAppxBundleManifestPackageInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsDefaultApplicablePackage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isdefaultapplicablepackage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isdefaultapplicablepackage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -609,7 +609,7 @@ impl IAppxBundleManifestPackageInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetDeviceFamilies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetdevicefamilies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetdevicefamilies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -635,7 +635,7 @@ impl IAppxBundleManifestPackageInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsStub() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isstub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isstub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -663,7 +663,7 @@ impl IAppxBundleManifestPackageInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -674,7 +674,7 @@ impl IAppxBundleManifestPackageInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -685,7 +685,7 @@ impl IAppxBundleManifestPackageInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -718,7 +718,7 @@ impl IAppxBundleManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -729,7 +729,7 @@ impl IAppxBundleManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageInfoItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageinfoitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageinfoitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -740,7 +740,7 @@ impl IAppxBundleManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *manifeststream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(manifeststream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -768,7 +768,7 @@ impl IAppxBundleManifestReader2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionalBundles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *optionalbundles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(optionalbundles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -795,7 +795,7 @@ impl IAppxBundleReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetFootprintFile(::core::mem::transmute_copy(&filetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *footprintfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(footprintfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -806,7 +806,7 @@ impl IAppxBundleReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlockMap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blockmapreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blockmapreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -817,7 +817,7 @@ impl IAppxBundleReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetManifest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *manifestreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(manifestreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -828,7 +828,7 @@ impl IAppxBundleReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPayloadPackages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *payloadpackages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(payloadpackages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -839,7 +839,7 @@ impl IAppxBundleReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPayloadPackage(::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *payloadpackage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(payloadpackage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -990,7 +990,7 @@ impl IAppxContentGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *groupname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(groupname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1001,7 +1001,7 @@ impl IAppxContentGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1033,7 +1033,7 @@ impl IAppxContentGroupFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *file = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(file, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1044,7 +1044,7 @@ impl IAppxContentGroupFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1055,7 +1055,7 @@ impl IAppxContentGroupFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1084,7 +1084,7 @@ impl IAppxContentGroupMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequiredGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requiredgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requiredgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1095,7 +1095,7 @@ impl IAppxContentGroupMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutomaticGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *automaticgroupsenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(automaticgroupsenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1161,7 +1161,7 @@ impl IAppxContentGroupsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1172,7 +1172,7 @@ impl IAppxContentGroupsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1183,7 +1183,7 @@ impl IAppxContentGroupsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1364,7 +1364,7 @@ impl IAppxEncryptionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncryptedPackageWriter(::core::mem::transmute(&outputstream), ::core::mem::transmute(&manifeststream), ::core::mem::transmute_copy(&settings), ::core::mem::transmute_copy(&keyinfo), ::core::mem::transmute_copy(&exemptedfiles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1375,7 +1375,7 @@ impl IAppxEncryptionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncryptedPackageReader(::core::mem::transmute(&inputstream), ::core::mem::transmute_copy(&keyinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagereader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagereader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1396,7 +1396,7 @@ impl IAppxEncryptionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncryptedBundleWriter(::core::mem::transmute(&outputstream), ::core::mem::transmute_copy(&bundleversion), ::core::mem::transmute_copy(&settings), ::core::mem::transmute_copy(&keyinfo), ::core::mem::transmute_copy(&exemptedfiles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bundlewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bundlewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1407,7 +1407,7 @@ impl IAppxEncryptionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncryptedBundleReader(::core::mem::transmute(&inputstream), ::core::mem::transmute_copy(&keyinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bundlereader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bundlereader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1443,7 +1443,7 @@ impl IAppxEncryptionFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncryptedPackageWriter(::core::mem::transmute(&outputstream), ::core::mem::transmute(&manifeststream), ::core::mem::transmute(&contentgroupmapstream), ::core::mem::transmute_copy(&settings), ::core::mem::transmute_copy(&keyinfo), ::core::mem::transmute_copy(&exemptedfiles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1480,7 +1480,7 @@ impl IAppxEncryptionFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncryptedPackageWriter(::core::mem::transmute(&outputstream), ::core::mem::transmute(&manifeststream), ::core::mem::transmute(&contentgroupmapstream), ::core::mem::transmute_copy(&settings), ::core::mem::transmute_copy(&keyinfo), ::core::mem::transmute_copy(&exemptedfiles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1496,7 +1496,7 @@ impl IAppxEncryptionFactory3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEncryptedBundleWriter(::core::mem::transmute(&outputstream), ::core::mem::transmute_copy(&bundleversion), ::core::mem::transmute_copy(&settings), ::core::mem::transmute_copy(&keyinfo), ::core::mem::transmute_copy(&exemptedfiles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bundlewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bundlewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1552,7 +1552,7 @@ impl IAppxFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageWriter(::core::mem::transmute(&outputstream), ::core::mem::transmute_copy(&settings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1563,7 +1563,7 @@ impl IAppxFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageReader(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagereader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagereader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1574,7 +1574,7 @@ impl IAppxFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateManifestReader(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *manifestreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(manifestreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1585,7 +1585,7 @@ impl IAppxFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBlockMapReader(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *blockmapreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blockmapreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1596,7 +1596,7 @@ impl IAppxFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateValidatedBlockMapReader(::core::mem::transmute(&blockmapstream), ::core::mem::transmute(&signaturefilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *blockmapreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blockmapreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1631,7 +1631,7 @@ impl IAppxFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContentGroupMapReader(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentgroupmapreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentgroupmapreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1642,7 +1642,7 @@ impl IAppxFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSourceContentGroupMapReader(::core::mem::transmute(&inputstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *reader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1653,7 +1653,7 @@ impl IAppxFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContentGroupMapWriter(::core::mem::transmute(&stream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentgroupmapwriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentgroupmapwriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1688,7 +1688,7 @@ impl IAppxFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompressionOption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *compressionoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(compressionoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1699,7 +1699,7 @@ impl IAppxFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1710,7 +1710,7 @@ impl IAppxFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1721,7 +1721,7 @@ impl IAppxFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1732,7 +1732,7 @@ impl IAppxFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1767,7 +1767,7 @@ impl IAppxFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *file = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(file, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1778,7 +1778,7 @@ impl IAppxFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1789,7 +1789,7 @@ impl IAppxFilesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1818,7 +1818,7 @@ impl IAppxManifestApplication_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1829,7 +1829,7 @@ impl IAppxManifestApplication_Vtbl {
             let this = (*this).get_impl();
             match this.GetAppUserModelId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *appusermodelid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(appusermodelid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1861,7 +1861,7 @@ impl IAppxManifestApplicationsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *application = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(application, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1872,7 +1872,7 @@ impl IAppxManifestApplicationsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1883,7 +1883,7 @@ impl IAppxManifestApplicationsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1916,7 +1916,7 @@ impl IAppxManifestCapabilitiesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *capability = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(capability, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1927,7 +1927,7 @@ impl IAppxManifestCapabilitiesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1938,7 +1938,7 @@ impl IAppxManifestCapabilitiesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1971,7 +1971,7 @@ impl IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecapability = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecapability, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1982,7 +1982,7 @@ impl IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1993,7 +1993,7 @@ impl IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2023,7 +2023,7 @@ impl IAppxManifestDriverConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2034,7 +2034,7 @@ impl IAppxManifestDriverConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2045,7 +2045,7 @@ impl IAppxManifestDriverConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mindate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mindate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2078,7 +2078,7 @@ impl IAppxManifestDriverConstraintsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *driverconstraint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(driverconstraint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2089,7 +2089,7 @@ impl IAppxManifestDriverConstraintsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2100,7 +2100,7 @@ impl IAppxManifestDriverConstraintsEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2133,7 +2133,7 @@ impl IAppxManifestDriverDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *driverdependency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(driverdependency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2144,7 +2144,7 @@ impl IAppxManifestDriverDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2155,7 +2155,7 @@ impl IAppxManifestDriverDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2183,7 +2183,7 @@ impl IAppxManifestDriverDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetDriverConstraints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *driverconstraints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(driverconstraints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2211,7 +2211,7 @@ impl IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hostruntimedependency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hostruntimedependency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2222,7 +2222,7 @@ impl IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2233,7 +2233,7 @@ impl IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2263,7 +2263,7 @@ impl IAppxManifestHostRuntimeDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2274,7 +2274,7 @@ impl IAppxManifestHostRuntimeDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetPublisher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *publisher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(publisher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2285,7 +2285,7 @@ impl IAppxManifestHostRuntimeDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2313,7 +2313,7 @@ impl IAppxManifestHostRuntimeDependency2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagefamilyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagefamilyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2341,7 +2341,7 @@ impl IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mainpackagedependency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mainpackagedependency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2352,7 +2352,7 @@ impl IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2363,7 +2363,7 @@ impl IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2393,7 +2393,7 @@ impl IAppxManifestMainPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2404,7 +2404,7 @@ impl IAppxManifestMainPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetPublisher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *publisher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(publisher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2415,7 +2415,7 @@ impl IAppxManifestMainPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagefamilyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagefamilyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2448,7 +2448,7 @@ impl IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ospackagedependency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ospackagedependency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2459,7 +2459,7 @@ impl IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2470,7 +2470,7 @@ impl IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2499,7 +2499,7 @@ impl IAppxManifestOSPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2510,7 +2510,7 @@ impl IAppxManifestOSPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *version = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(version, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2541,7 +2541,7 @@ impl IAppxManifestOptionalPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsOptionalPackage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isoptionalpackage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isoptionalpackage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2552,7 +2552,7 @@ impl IAppxManifestOptionalPackageInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMainPackageName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mainpackagename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mainpackagename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2584,7 +2584,7 @@ impl IAppxManifestPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dependency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dependency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2595,7 +2595,7 @@ impl IAppxManifestPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2606,7 +2606,7 @@ impl IAppxManifestPackageDependenciesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2636,7 +2636,7 @@ impl IAppxManifestPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2647,7 +2647,7 @@ impl IAppxManifestPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetPublisher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *publisher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(publisher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2658,7 +2658,7 @@ impl IAppxManifestPackageDependency_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2686,7 +2686,7 @@ impl IAppxManifestPackageDependency2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxMajorVersionTested() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxmajorversiontested = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxmajorversiontested, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2715,7 +2715,7 @@ impl IAppxManifestPackageDependency3_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsOptional() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isoptional = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isoptional, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2748,7 +2748,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2759,7 +2759,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.GetArchitecture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *architecture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(architecture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2770,7 +2770,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.GetPublisher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *publisher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(publisher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2781,7 +2781,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2792,7 +2792,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2803,7 +2803,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.ComparePublisher(::core::mem::transmute(&other)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *issame = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issame, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2814,7 +2814,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageFullName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagefullname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagefullname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2825,7 +2825,7 @@ impl IAppxManifestPackageId_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagefamilyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagefamilyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2861,7 +2861,7 @@ impl IAppxManifestPackageId2_Vtbl {
             let this = (*this).get_impl();
             match this.GetArchitecture2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *architecture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(architecture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2888,7 +2888,7 @@ impl IAppxManifestProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoolValue(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2899,7 +2899,7 @@ impl IAppxManifestProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2928,7 +2928,7 @@ impl IAppxManifestQualifiedResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *language = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(language, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2939,7 +2939,7 @@ impl IAppxManifestQualifiedResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetScale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scale = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scale, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2950,7 +2950,7 @@ impl IAppxManifestQualifiedResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetDXFeatureLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dxfeaturelevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dxfeaturelevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2983,7 +2983,7 @@ impl IAppxManifestQualifiedResourcesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2994,7 +2994,7 @@ impl IAppxManifestQualifiedResourcesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3005,7 +3005,7 @@ impl IAppxManifestQualifiedResourcesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3044,7 +3044,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3055,7 +3055,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3066,7 +3066,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageDependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3077,7 +3077,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *capabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(capabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3088,7 +3088,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3099,7 +3099,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicecapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicecapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3110,7 +3110,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrerequisite(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3121,7 +3121,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *applications = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(applications, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3132,7 +3132,7 @@ impl IAppxManifestReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *manifeststream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(manifeststream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3169,7 +3169,7 @@ impl IAppxManifestReader2_Vtbl {
             let this = (*this).get_impl();
             match this.GetQualifiedResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3196,7 +3196,7 @@ impl IAppxManifestReader3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilitiesByCapabilityClass(::core::mem::transmute_copy(&capabilityclass)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *capabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(capabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3207,7 +3207,7 @@ impl IAppxManifestReader3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetDeviceFamilies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetdevicefamilies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetdevicefamilies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3237,7 +3237,7 @@ impl IAppxManifestReader4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionalPackageInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *optionalpackageinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(optionalpackageinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3260,7 +3260,7 @@ impl IAppxManifestReader5_Vtbl {
             let this = (*this).get_impl();
             match this.GetMainPackageDependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mainpackagedependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mainpackagedependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3289,7 +3289,7 @@ impl IAppxManifestReader6_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsNonQualifiedResourcePackage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnonqualifiedresourcepackage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnonqualifiedresourcepackage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3317,7 +3317,7 @@ impl IAppxManifestReader7_Vtbl {
             let this = (*this).get_impl();
             match this.GetDriverDependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *driverdependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(driverdependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3328,7 +3328,7 @@ impl IAppxManifestReader7_Vtbl {
             let this = (*this).get_impl();
             match this.GetOSPackageDependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ospackagedependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ospackagedependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3339,7 +3339,7 @@ impl IAppxManifestReader7_Vtbl {
             let this = (*this).get_impl();
             match this.GetHostRuntimeDependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hostruntimedependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hostruntimedependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3372,7 +3372,7 @@ impl IAppxManifestResourcesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3383,7 +3383,7 @@ impl IAppxManifestResourcesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3394,7 +3394,7 @@ impl IAppxManifestResourcesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3427,7 +3427,7 @@ impl IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetdevicefamily = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetdevicefamily, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3438,7 +3438,7 @@ impl IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetHasCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hascurrent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hascurrent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3449,7 +3449,7 @@ impl IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3479,7 +3479,7 @@ impl IAppxManifestTargetDeviceFamily_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3490,7 +3490,7 @@ impl IAppxManifestTargetDeviceFamily_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3501,7 +3501,7 @@ impl IAppxManifestTargetDeviceFamily_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxVersionTested() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxversiontested = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxversiontested, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3591,7 +3591,7 @@ impl IAppxPackageReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetBlockMap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *blockmapreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(blockmapreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3602,7 +3602,7 @@ impl IAppxPackageReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetFootprintFile(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *file = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(file, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3613,7 +3613,7 @@ impl IAppxPackageReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPayloadFile(::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *file = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(file, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3624,7 +3624,7 @@ impl IAppxPackageReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetPayloadFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filesenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filesenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3635,7 +3635,7 @@ impl IAppxPackageReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetManifest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *manifestreader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(manifestreader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3780,7 +3780,7 @@ impl IAppxSourceContentGroupMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequiredGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requiredgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requiredgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3791,7 +3791,7 @@ impl IAppxSourceContentGroupMapReader_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutomaticGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *automaticgroupsenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(automaticgroupsenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
@@ -30,7 +30,7 @@ impl IOpcCertificateEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -74,7 +74,7 @@ impl IOpcCertificateSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *certificateenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(certificateenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -135,7 +135,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignaturePartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturepartname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturepartname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -146,7 +146,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturemethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturemethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -167,7 +167,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignaturePartReferenceEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partreferenceenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partreferenceenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -178,7 +178,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureRelationshipReferenceEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipreferenceenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipreferenceenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -189,7 +189,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSigningTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signingtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signingtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -205,7 +205,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageObjectReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageobjectreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageobjectreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -216,7 +216,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *certificateenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(certificateenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -227,7 +227,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomReferenceEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customreferenceenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customreferenceenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -238,7 +238,7 @@ impl IOpcDigitalSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomObjectEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customobjectenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customobjectenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -289,7 +289,7 @@ impl IOpcDigitalSignatureEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -300,7 +300,7 @@ impl IOpcDigitalSignatureEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -311,7 +311,7 @@ impl IOpcDigitalSignatureEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *digitalsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digitalsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -322,7 +322,7 @@ impl IOpcDigitalSignatureEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -361,7 +361,7 @@ impl IOpcDigitalSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureOriginPartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureoriginpartname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureoriginpartname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -377,7 +377,7 @@ impl IOpcDigitalSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -393,7 +393,7 @@ impl IOpcDigitalSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSigningOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signingoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signingoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -409,7 +409,7 @@ impl IOpcDigitalSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.Sign(::core::mem::transmute_copy(&certificate), ::core::mem::transmute(&signingoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *digitalsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digitalsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -420,7 +420,7 @@ impl IOpcDigitalSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.ReplaceSignatureXml(::core::mem::transmute(&signaturepartname), ::core::mem::transmute_copy(&newsignaturexml), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *digitalsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digitalsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -462,7 +462,7 @@ impl IOpcFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageRootUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rooturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rooturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -473,7 +473,7 @@ impl IOpcFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePartUri(::core::mem::transmute(&pwzuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *parturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -484,7 +484,7 @@ impl IOpcFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStreamOnFile(::core::mem::transmute(&filename), ::core::mem::transmute_copy(&iomode), ::core::mem::transmute_copy(&securityattributes), ::core::mem::transmute_copy(&dwflagsandattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -495,7 +495,7 @@ impl IOpcFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -506,7 +506,7 @@ impl IOpcFactory_Vtbl {
             let this = (*this).get_impl();
             match this.ReadPackageFromStream(::core::mem::transmute(&stream), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -522,7 +522,7 @@ impl IOpcFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDigitalSignatureManager(::core::mem::transmute(&package)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturemanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturemanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -555,7 +555,7 @@ impl IOpcPackage_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -566,7 +566,7 @@ impl IOpcPackage_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationshipSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -600,7 +600,7 @@ impl IOpcPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationshipSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -611,7 +611,7 @@ impl IOpcPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -622,7 +622,7 @@ impl IOpcPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -633,7 +633,7 @@ impl IOpcPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -644,7 +644,7 @@ impl IOpcPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompressionOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *compressionoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(compressionoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl IOpcPartEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -691,7 +691,7 @@ impl IOpcPartEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -702,7 +702,7 @@ impl IOpcPartEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *part = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(part, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -713,7 +713,7 @@ impl IOpcPartEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -749,7 +749,7 @@ impl IOpcPartSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetPart(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *part = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(part, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -760,7 +760,7 @@ impl IOpcPartSet_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePart(::core::mem::transmute(&name), ::core::mem::transmute(&contenttype), ::core::mem::transmute_copy(&compressionoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *part = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(part, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -776,7 +776,7 @@ impl IOpcPartSet_Vtbl {
             let this = (*this).get_impl();
             match this.PartExists(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *partexists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partexists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -787,7 +787,7 @@ impl IOpcPartSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -822,7 +822,7 @@ impl IOpcPartUri_Vtbl {
             let this = (*this).get_impl();
             match this.ComparePartUri(::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *comparisonresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(comparisonresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -833,7 +833,7 @@ impl IOpcPartUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sourceuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sourceuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -844,7 +844,7 @@ impl IOpcPartUri_Vtbl {
             let this = (*this).get_impl();
             match this.IsRelationshipsPartUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isrelationshipuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isrelationshipuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -879,7 +879,7 @@ impl IOpcRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipidentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipidentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -890,7 +890,7 @@ impl IOpcRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationshipType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshiptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshiptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -901,7 +901,7 @@ impl IOpcRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sourceuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sourceuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -912,7 +912,7 @@ impl IOpcRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targeturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targeturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -923,7 +923,7 @@ impl IOpcRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -959,7 +959,7 @@ impl IOpcRelationshipEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -970,7 +970,7 @@ impl IOpcRelationshipEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -981,7 +981,7 @@ impl IOpcRelationshipEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationship = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationship, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -992,7 +992,7 @@ impl IOpcRelationshipEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1022,7 +1022,7 @@ impl IOpcRelationshipSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1033,7 +1033,7 @@ impl IOpcRelationshipSelector_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectionCriterion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selectioncriterion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selectioncriterion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1066,7 +1066,7 @@ impl IOpcRelationshipSelectorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1077,7 +1077,7 @@ impl IOpcRelationshipSelectorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1088,7 +1088,7 @@ impl IOpcRelationshipSelectorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipselector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipselector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1099,7 +1099,7 @@ impl IOpcRelationshipSelectorEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1130,7 +1130,7 @@ impl IOpcRelationshipSelectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&selector), ::core::mem::transmute(&selectioncriterion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipselector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipselector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1146,7 +1146,7 @@ impl IOpcRelationshipSelectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipselectorenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipselectorenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1183,7 +1183,7 @@ impl IOpcRelationshipSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationship(::core::mem::transmute(&relationshipidentifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationship = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationship, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1194,7 +1194,7 @@ impl IOpcRelationshipSet_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRelationship(::core::mem::transmute(&relationshipidentifier), ::core::mem::transmute(&relationshiptype), ::core::mem::transmute(&targeturi), ::core::mem::transmute_copy(&targetmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationship = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationship, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1210,7 +1210,7 @@ impl IOpcRelationshipSet_Vtbl {
             let this = (*this).get_impl();
             match this.RelationshipExists(::core::mem::transmute(&relationshipidentifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipexists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipexists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1221,7 +1221,7 @@ impl IOpcRelationshipSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1232,7 +1232,7 @@ impl IOpcRelationshipSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumeratorForType(::core::mem::transmute(&relationshiptype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1243,7 +1243,7 @@ impl IOpcRelationshipSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationshipsContentStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1298,7 +1298,7 @@ impl IOpcSignatureCustomObjectEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1309,7 +1309,7 @@ impl IOpcSignatureCustomObjectEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1320,7 +1320,7 @@ impl IOpcSignatureCustomObjectEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1331,7 +1331,7 @@ impl IOpcSignatureCustomObjectEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1362,7 +1362,7 @@ impl IOpcSignatureCustomObjectSet_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&xmlmarkup), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *customobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1378,7 +1378,7 @@ impl IOpcSignatureCustomObjectSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customobjectenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customobjectenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1413,7 +1413,7 @@ impl IOpcSignaturePartReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1424,7 +1424,7 @@ impl IOpcSignaturePartReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1435,7 +1435,7 @@ impl IOpcSignaturePartReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetDigestMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *digestmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digestmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1451,7 +1451,7 @@ impl IOpcSignaturePartReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1487,7 +1487,7 @@ impl IOpcSignaturePartReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1498,7 +1498,7 @@ impl IOpcSignaturePartReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1509,7 +1509,7 @@ impl IOpcSignaturePartReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1520,7 +1520,7 @@ impl IOpcSignaturePartReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1554,7 +1554,7 @@ impl IOpcSignaturePartReferenceSet_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&parturi), ::core::mem::transmute(&digestmethod), ::core::mem::transmute_copy(&transformmethod)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *partreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1570,7 +1570,7 @@ impl IOpcSignaturePartReferenceSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partreferenceenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partreferenceenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1606,7 +1606,7 @@ impl IOpcSignatureReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *referenceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(referenceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1617,7 +1617,7 @@ impl IOpcSignatureReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *referenceuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(referenceuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1628,7 +1628,7 @@ impl IOpcSignatureReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1639,7 +1639,7 @@ impl IOpcSignatureReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1650,7 +1650,7 @@ impl IOpcSignatureReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetDigestMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *digestmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digestmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1692,7 +1692,7 @@ impl IOpcSignatureReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1703,7 +1703,7 @@ impl IOpcSignatureReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1714,7 +1714,7 @@ impl IOpcSignatureReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1725,7 +1725,7 @@ impl IOpcSignatureReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1759,7 +1759,7 @@ impl IOpcSignatureReferenceSet_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&referenceuri), ::core::mem::transmute(&referenceid), ::core::mem::transmute(&r#type), ::core::mem::transmute(&digestmethod), ::core::mem::transmute_copy(&transformmethod)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *reference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1775,7 +1775,7 @@ impl IOpcSignatureReferenceSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *referenceenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(referenceenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1811,7 +1811,7 @@ impl IOpcSignatureRelationshipReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sourceuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sourceuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1822,7 +1822,7 @@ impl IOpcSignatureRelationshipReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetDigestMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *digestmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digestmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1838,7 +1838,7 @@ impl IOpcSignatureRelationshipReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transformmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transformmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1849,7 +1849,7 @@ impl IOpcSignatureRelationshipReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationshipSigningOption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipsigningoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipsigningoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1860,7 +1860,7 @@ impl IOpcSignatureRelationshipReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationshipSelectorEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selectorenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selectorenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1897,7 +1897,7 @@ impl IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasnext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasnext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1908,7 +1908,7 @@ impl IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MovePrevious() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hasprevious = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hasprevious, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1919,7 +1919,7 @@ impl IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1930,7 +1930,7 @@ impl IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *copy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(copy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1965,7 +1965,7 @@ impl IOpcSignatureRelationshipReferenceSet_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&sourceuri), ::core::mem::transmute(&digestmethod), ::core::mem::transmute_copy(&relationshipsigningoption), ::core::mem::transmute(&selectorset), ::core::mem::transmute_copy(&transformmethod)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1976,7 +1976,7 @@ impl IOpcSignatureRelationshipReferenceSet_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRelationshipSelectorSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selectorset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selectorset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1992,7 +1992,7 @@ impl IOpcSignatureRelationshipReferenceSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipreferenceenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipreferenceenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2040,7 +2040,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2056,7 +2056,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturemethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturemethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2072,7 +2072,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultDigestMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *digestmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digestmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2088,7 +2088,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateEmbeddingOption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *embeddingoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(embeddingoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2104,7 +2104,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timeformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timeformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2120,7 +2120,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignaturePartReferenceSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partreferenceset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partreferenceset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2131,7 +2131,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureRelationshipReferenceSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipreferenceset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipreferenceset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2142,7 +2142,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomObjectSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2153,7 +2153,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomReferenceSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customreferenceset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customreferenceset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2164,7 +2164,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *certificateset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(certificateset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2175,7 +2175,7 @@ impl IOpcSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignaturePartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturepartname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturepartname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2227,7 +2227,7 @@ impl IOpcUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationshipsPartUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *relationshipparturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relationshipparturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2238,7 +2238,7 @@ impl IOpcUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelativeUri(::core::mem::transmute(&targetparturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *relativeuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(relativeuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2249,7 +2249,7 @@ impl IOpcUri_Vtbl {
             let this = (*this).get_impl();
             match this.CombinePartUri(::core::mem::transmute(&relativeuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *combineduri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(combineduri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
@@ -27,7 +27,7 @@ impl IEnumVdsObject_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -141,7 +141,7 @@ impl IVdsController_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontrollerprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontrollerprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -152,7 +152,7 @@ impl IVdsController_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubsystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubsystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -163,7 +163,7 @@ impl IVdsController_Vtbl {
             let this = (*this).get_impl();
             match this.GetPortProperties(::core::mem::transmute_copy(&sportnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pportprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pportprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -189,7 +189,7 @@ impl IVdsController_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAssociatedLuns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -227,7 +227,7 @@ impl IVdsControllerControllerPort_Vtbl {
             let this = (*this).get_impl();
             match this.QueryControllerPorts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -254,7 +254,7 @@ impl IVdsControllerPort_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pportprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pportprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl IVdsControllerPort_Vtbl {
             let this = (*this).get_impl();
             match this.GetController() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontroller = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontroller, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl IVdsControllerPort_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAssociatedLuns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -324,7 +324,7 @@ impl IVdsDrive_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdriveprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdriveprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -335,7 +335,7 @@ impl IVdsDrive_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubsystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubsystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -386,7 +386,7 @@ impl IVdsDrive2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdriveprop2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdriveprop2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -411,7 +411,7 @@ impl IVdsHwProvider_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySubSystems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -452,7 +452,7 @@ impl IVdsHwProviderPrivate_Vtbl {
             let this = (*this).get_impl();
             match this.QueryIfCreatedLun(::core::mem::transmute(&pwszdevicepath), ::core::mem::transmute_copy(&pvdsluninformation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plunid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plunid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -500,7 +500,7 @@ impl IVdsHwProviderStoragePools_Vtbl {
             let this = (*this).get_impl();
             match this.QueryStoragePools(::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&ullremainingfreespace), ::core::mem::transmute_copy(&ppoolattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -511,7 +511,7 @@ impl IVdsHwProviderStoragePools_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLunInStoragePool(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&ullsizeinbytes), ::core::mem::transmute(&storagepoolid), ::core::mem::transmute(&pwszunmaskinglist), ::core::mem::transmute_copy(&phints2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -522,7 +522,7 @@ impl IVdsHwProviderStoragePools_Vtbl {
             let this = (*this).get_impl();
             match this.QueryMaxLunCreateSizeInStoragePool(::core::mem::transmute_copy(&r#type), ::core::mem::transmute(&storagepoolid), ::core::mem::transmute_copy(&phints2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullmaxlunsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullmaxlunsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -550,7 +550,7 @@ impl IVdsHwProviderType_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -573,7 +573,7 @@ impl IVdsHwProviderType2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderType2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -602,7 +602,7 @@ impl IVdsIscsiPortal_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pportalprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pportalprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -613,7 +613,7 @@ impl IVdsIscsiPortal_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubsystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubsystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -624,7 +624,7 @@ impl IVdsIscsiPortal_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAssociatedPortalGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -645,7 +645,7 @@ impl IVdsIscsiPortal_Vtbl {
             let this = (*this).get_impl();
             match this.GetIpsecSecurity(::core::mem::transmute_copy(&pinitiatorportaladdress)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullsecurityflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullsecurityflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -687,7 +687,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pportalgroupprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pportalgroupprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -698,7 +698,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -709,7 +709,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAssociatedPortals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -720,7 +720,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
             let this = (*this).get_impl();
             match this.AddPortal(::core::mem::transmute(&portalid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -731,7 +731,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
             let this = (*this).get_impl();
             match this.RemovePortal(::core::mem::transmute(&portalid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -742,7 +742,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Delete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -785,7 +785,7 @@ impl IVdsIscsiTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptargetprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptargetprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -796,7 +796,7 @@ impl IVdsIscsiTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubsystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubsystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -807,7 +807,7 @@ impl IVdsIscsiTarget_Vtbl {
             let this = (*this).get_impl();
             match this.QueryPortalGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -818,7 +818,7 @@ impl IVdsIscsiTarget_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAssociatedLuns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -829,7 +829,7 @@ impl IVdsIscsiTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePortalGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -840,7 +840,7 @@ impl IVdsIscsiTarget_Vtbl {
             let this = (*this).get_impl();
             match this.Delete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -914,7 +914,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plunprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plunprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -925,7 +925,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubsystem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubsystem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -936,7 +936,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.GetIdentificationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pluninfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pluninfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -947,7 +947,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.QueryActiveControllers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -958,7 +958,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.Extend(::core::mem::transmute_copy(&ullnumberofbytestoadd), ::core::mem::transmute_copy(&pdriveidarray), ::core::mem::transmute_copy(&lnumberofdrives)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -969,7 +969,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.Shrink(::core::mem::transmute_copy(&ullnumberofbytestoremove)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -980,7 +980,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.QueryPlexes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -991,7 +991,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.AddPlex(::core::mem::transmute(&lunid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1002,7 +1002,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.RemovePlex(::core::mem::transmute(&plexid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1013,7 +1013,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.Recover() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1039,7 +1039,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1060,7 +1060,7 @@ impl IVdsLun_Vtbl {
             let this = (*this).get_impl();
             match this.QueryMaxLunExtendSize(::core::mem::transmute_copy(&pdriveidarray), ::core::mem::transmute_copy(&lnumberofdrives)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullmaxbytestobeadded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullmaxbytestobeadded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1106,7 +1106,7 @@ impl IVdsLun2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHints2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phints2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phints2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1144,7 +1144,7 @@ impl IVdsLunControllerPorts_Vtbl {
             let this = (*this).get_impl();
             match this.QueryActiveControllerPorts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1177,7 +1177,7 @@ impl IVdsLunIscsi_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAssociatedTargets() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1225,7 +1225,7 @@ impl IVdsLunMpio_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedLbPolicies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullbflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullbflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1271,7 +1271,7 @@ impl IVdsLunNumber_Vtbl {
             let this = (*this).get_impl();
             match this.GetLunNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullunnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullunnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1301,7 +1301,7 @@ impl IVdsLunPlex_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplexprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplexprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1312,7 +1312,7 @@ impl IVdsLunPlex_Vtbl {
             let this = (*this).get_impl();
             match this.GetLun() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1328,7 +1328,7 @@ impl IVdsLunPlex_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1397,7 +1397,7 @@ impl IVdsProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproviderprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproviderprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1425,7 +1425,7 @@ impl IVdsProviderPrivate_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject(::core::mem::transmute(&objectid), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjectunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjectunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1463,7 +1463,7 @@ impl IVdsProviderSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersionSupport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ulversionsupport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ulversionsupport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1494,7 +1494,7 @@ impl IVdsStoragePool_Vtbl {
             let this = (*this).get_impl();
             match this.GetProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1505,7 +1505,7 @@ impl IVdsStoragePool_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstoragepoolprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstoragepoolprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1516,7 +1516,7 @@ impl IVdsStoragePool_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstoragepoolattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstoragepoolattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1532,7 +1532,7 @@ impl IVdsStoragePool_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAllocatedLuns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1543,7 +1543,7 @@ impl IVdsStoragePool_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAllocatedStoragePools() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1588,7 +1588,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psubsystemprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psubsystemprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1599,7 +1599,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.GetProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1610,7 +1610,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.QueryControllers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1621,7 +1621,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.QueryLuns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1632,7 +1632,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDrives() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1643,7 +1643,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.GetDrive(::core::mem::transmute_copy(&sbusnumber), ::core::mem::transmute_copy(&sslotnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdrive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdrive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1664,7 +1664,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLun(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&ullsizeinbytes), ::core::mem::transmute_copy(&pdriveidarray), ::core::mem::transmute_copy(&lnumberofdrives), ::core::mem::transmute(&pwszunmaskinglist), ::core::mem::transmute_copy(&phints)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1685,7 +1685,7 @@ impl IVdsSubSystem_Vtbl {
             let this = (*this).get_impl();
             match this.QueryMaxLunCreateSize(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&pdriveidarray), ::core::mem::transmute_copy(&lnumberofdrives), ::core::mem::transmute_copy(&phints)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullmaxlunsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullmaxlunsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1728,7 +1728,7 @@ impl IVdsSubSystem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psubsystemprop2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psubsystemprop2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1739,7 +1739,7 @@ impl IVdsSubSystem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDrive2(::core::mem::transmute_copy(&sbusnumber), ::core::mem::transmute_copy(&sslotnumber), ::core::mem::transmute_copy(&ulenclosurenumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdrive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdrive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1750,7 +1750,7 @@ impl IVdsSubSystem2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLun2(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&ullsizeinbytes), ::core::mem::transmute_copy(&pdriveidarray), ::core::mem::transmute_copy(&lnumberofdrives), ::core::mem::transmute(&pwszunmaskinglist), ::core::mem::transmute_copy(&phints2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1761,7 +1761,7 @@ impl IVdsSubSystem2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryMaxLunCreateSize2(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&pdriveidarray), ::core::mem::transmute_copy(&lnumberofdrives), ::core::mem::transmute_copy(&phints2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullmaxlunsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullmaxlunsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1790,7 +1790,7 @@ impl IVdsSubSystemInterconnect_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedInterconnects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulsupportedinterconnectsflag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulsupportedinterconnectsflag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1816,7 +1816,7 @@ impl IVdsSubSystemIscsi_Vtbl {
             let this = (*this).get_impl();
             match this.QueryTargets() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1827,7 +1827,7 @@ impl IVdsSubSystemIscsi_Vtbl {
             let this = (*this).get_impl();
             match this.QueryPortals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1838,7 +1838,7 @@ impl IVdsSubSystemIscsi_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTarget(::core::mem::transmute(&pwsziscsiname), ::core::mem::transmute(&pwszfriendlyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
@@ -22,7 +22,7 @@ impl IVssAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.QueryProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -58,7 +58,7 @@ impl IVssAdminEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderCapability(::core::mem::transmute(&pproviderid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plloriginalcapabilitymask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plloriginalcapabilitymask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -69,7 +69,7 @@ impl IVssAdminEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderContext(::core::mem::transmute(&providerid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IVssComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlternateLocationMapping(::core::mem::transmute_copy(&imapping)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfiledesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfiledesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -252,7 +252,7 @@ impl IVssComponent_Vtbl {
             let this = (*this).get_impl();
             match this.GetNewTarget(::core::mem::transmute_copy(&inewtarget)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfiledesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfiledesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -449,7 +449,7 @@ impl IVssComponentEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrepareForBackupFailureMsg() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfailuremsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfailuremsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -460,7 +460,7 @@ impl IVssComponentEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetPostSnapshotFailureMsg() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfailuremsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfailuremsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -471,7 +471,7 @@ impl IVssComponentEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetAuthoritativeRestore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbauth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbauth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -487,7 +487,7 @@ impl IVssComponentEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestoreName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -589,7 +589,7 @@ impl IVssCreateExpressWriterMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.SaveAsXML() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrxml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrxml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -686,7 +686,7 @@ impl IVssCreateWriterMetadata_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdoc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdoc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -742,7 +742,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVolumesSupportedForDiffAreas(::core::mem::transmute_copy(&pwszoriginalvolumename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -753,7 +753,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDiffAreasForVolume(::core::mem::transmute_copy(&pwszvolumename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -764,7 +764,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDiffAreasOnVolume(::core::mem::transmute_copy(&pwszvolumename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -775,7 +775,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDiffAreasForSnapshot(::core::mem::transmute(&snapshotid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -822,7 +822,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryMigrationStatus(::core::mem::transmute_copy(&pwszvolumename), ::core::mem::transmute_copy(&pwszdiffareavolumename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -868,7 +868,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt3_Vtbl {
             let this = (*this).get_impl();
             match this.GetVolumeProtectLevel(::core::mem::transmute_copy(&pwszvolumename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *protectionlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(protectionlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -998,7 +998,7 @@ impl IVssExpressWriter_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMetadata(::core::mem::transmute(&writerid), ::core::mem::transmute(&writername), ::core::mem::transmute_copy(&usagetype), ::core::mem::transmute_copy(&versionmajor), ::core::mem::transmute_copy(&versionminor), ::core::mem::transmute_copy(&reserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmetadata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmetadata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1057,7 +1057,7 @@ impl IVssFileShareSnapshotProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapshotProperties(::core::mem::transmute(&snapshotid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1068,7 +1068,7 @@ impl IVssFileShareSnapshotProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Query(::core::mem::transmute(&queriedobjectid), ::core::mem::transmute_copy(&equeriedobjecttype), ::core::mem::transmute_copy(&ereturnedobjectstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1089,7 +1089,7 @@ impl IVssFileShareSnapshotProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsPathSupported(::core::mem::transmute_copy(&pwszsharepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsupportedbythisprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsupportedbythisprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1196,7 +1196,7 @@ impl IVssHardwareSnapshotProviderEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plloriginalcapabilitymask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plloriginalcapabilitymask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1212,7 +1212,7 @@ impl IVssHardwareSnapshotProviderEx_Vtbl {
             let this = (*this).get_impl();
             match this.ResyncLuns(::core::mem::transmute_copy(&psourceluns), ::core::mem::transmute_copy(&ptargetluns), ::core::mem::transmute_copy(&dwcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1340,7 +1340,7 @@ impl IVssSnapshotMgmt_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderMgmtInterface(::core::mem::transmute(&providerid), ::core::mem::transmute_copy(&interfaceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1351,7 +1351,7 @@ impl IVssSnapshotMgmt_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVolumesSupportedForSnapshots(::core::mem::transmute(&providerid), ::core::mem::transmute_copy(&lcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1362,7 +1362,7 @@ impl IVssSnapshotMgmt_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySnapshotsByVolume(::core::mem::transmute_copy(&pwszvolumename), ::core::mem::transmute(&providerid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1390,7 +1390,7 @@ impl IVssSnapshotMgmt2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinDiffAreaSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllmindiffareasize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllmindiffareasize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1430,7 +1430,7 @@ impl IVssSoftwareSnapshotProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapshotProperties(::core::mem::transmute(&snapshotid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1441,7 +1441,7 @@ impl IVssSoftwareSnapshotProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Query(::core::mem::transmute(&queriedobjectid), ::core::mem::transmute_copy(&equeriedobjecttype), ::core::mem::transmute_copy(&ereturnedobjectstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1462,7 +1462,7 @@ impl IVssSoftwareSnapshotProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsVolumeSupported(::core::mem::transmute_copy(&pwszvolumename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsupportedbythisprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsupportedbythisprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1488,7 +1488,7 @@ impl IVssSoftwareSnapshotProvider_Vtbl {
             let this = (*this).get_impl();
             match this.QueryRevertStatus(::core::mem::transmute_copy(&pwszvolume)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1567,7 +1567,7 @@ impl IVssWMFiledesc_Vtbl {
             let this = (*this).get_impl();
             match this.GetPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1578,7 +1578,7 @@ impl IVssWMFiledesc_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilespec() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfilespec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfilespec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1589,7 +1589,7 @@ impl IVssWMFiledesc_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecursive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbrecursive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbrecursive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1600,7 +1600,7 @@ impl IVssWMFiledesc_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlternateLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstralternatelocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstralternatelocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1611,7 +1611,7 @@ impl IVssWMFiledesc_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackupTypeMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwtypemask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwtypemask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1653,7 +1653,7 @@ impl IVssWriterComponents_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponent(::core::mem::transmute_copy(&icomponent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1731,7 +1731,7 @@ impl IVssWriterImpl_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapshotDeviceName(::core::mem::transmute(&wszoriginalvolume)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszsnapshotdevice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszsnapshotdevice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1807,7 +1807,7 @@ impl IVssWriterImpl_Vtbl {
             let this = (*this).get_impl();
             match this.GetSessionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *idsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(idsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
@@ -69,7 +69,7 @@ impl IPrintDocumentPackageTargetFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDocumentPackageTargetForPrintJob(::core::mem::transmute(&printername), ::core::mem::transmute(&jobname), ::core::mem::transmute(&joboutputstream), ::core::mem::transmute(&jobprintticketstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *docpackagetarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(docpackagetarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -101,7 +101,7 @@ impl IXpsPrintJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetJobStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *jobstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(jobstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
@@ -14,7 +14,7 @@ impl IXpsDocumentPackageTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetXpsOMPackageWriter(::core::mem::transmute(&documentsequencepartname), ::core::mem::transmute(&discardcontrolpartname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25,7 +25,7 @@ impl IXpsDocumentPackageTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetXpsOMFactory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xpsfactory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xpsfactory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36,7 +36,7 @@ impl IXpsDocumentPackageTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetXpsType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -68,7 +68,7 @@ impl IXpsDocumentPackageTarget3D_Vtbl {
             let this = (*this).get_impl();
             match this.GetXpsOMPackageWriter3D(::core::mem::transmute(&documentsequencepartname), ::core::mem::transmute(&discardcontrolpartname), ::core::mem::transmute(&modelpartname), ::core::mem::transmute(&modeldata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -79,7 +79,7 @@ impl IXpsDocumentPackageTarget3D_Vtbl {
             let this = (*this).get_impl();
             match this.GetXpsOMFactory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xpsfactory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xpsfactory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -107,7 +107,7 @@ impl IXpsOMBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetOpacity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *opacity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(opacity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -154,7 +154,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisuals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visuals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visuals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -165,7 +165,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.GetUseAliasedEdgeMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usealiasededgemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usealiasededgemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -181,7 +181,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccessibilityShortDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *shortdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(shortdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -197,7 +197,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccessibilityLongDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *longdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(longdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -213,7 +213,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcedictionary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcedictionary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -224,7 +224,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionaryLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcedictionary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcedictionary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -240,7 +240,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionaryResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remotedictionaryresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remotedictionaryresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -256,7 +256,7 @@ impl IXpsOMCanvas_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *canvas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(canvas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IXpsOMColorProfileResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -339,7 +339,7 @@ impl IXpsOMColorProfileResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -350,7 +350,7 @@ impl IXpsOMColorProfileResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -381,7 +381,7 @@ impl IXpsOMColorProfileResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetByPartName(::core::mem::transmute(&partname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *part = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(part, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -449,7 +449,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -460,7 +460,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *category = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(category, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -476,7 +476,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -492,7 +492,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -508,7 +508,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetCreated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *created = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(created, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -524,7 +524,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetCreator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *creator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(creator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetIdentifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *identifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(identifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -572,7 +572,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeywords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keywords = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keywords, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -588,7 +588,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *language = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(language, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -604,7 +604,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastModifiedBy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastmodifiedby = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastmodifiedby, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -620,7 +620,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastPrinted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastprinted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastprinted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -636,7 +636,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetModified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -652,7 +652,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetRevision() {
                 ::core::result::Result::Ok(ok__) => {
-                    *revision = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(revision, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -668,7 +668,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *subject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(subject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -684,7 +684,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *title = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(title, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -700,7 +700,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *version = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(version, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -716,7 +716,7 @@ impl IXpsOMCoreProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *coreproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(coreproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -780,7 +780,7 @@ impl IXpsOMDashCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -791,7 +791,7 @@ impl IXpsOMDashCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -851,7 +851,7 @@ impl IXpsOMDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -862,7 +862,7 @@ impl IXpsOMDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -878,7 +878,7 @@ impl IXpsOMDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.GetByKey(::core::mem::transmute(&key), ::core::mem::transmute(&beforeentry)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *entry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(entry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -889,7 +889,7 @@ impl IXpsOMDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndex(::core::mem::transmute(&entry)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -920,7 +920,7 @@ impl IXpsOMDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dictionary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dictionary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -965,7 +965,7 @@ impl IXpsOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documentsequence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documentsequence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -976,7 +976,7 @@ impl IXpsOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageReferences() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagereferences = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagereferences, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -987,7 +987,7 @@ impl IXpsOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintTicketResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *printticketresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(printticketresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1003,7 +1003,7 @@ impl IXpsOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentStructureResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documentstructureresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documentstructureresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1019,7 +1019,7 @@ impl IXpsOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureBlockResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureblockresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureblockresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1030,7 +1030,7 @@ impl IXpsOMDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *document = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(document, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1068,7 +1068,7 @@ impl IXpsOMDocumentCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1079,7 +1079,7 @@ impl IXpsOMDocumentCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *document = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(document, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1136,7 +1136,7 @@ impl IXpsOMDocumentSequence_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1147,7 +1147,7 @@ impl IXpsOMDocumentSequence_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocuments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1158,7 +1158,7 @@ impl IXpsOMDocumentSequence_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintTicketResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *printticketresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(printticketresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1197,7 +1197,7 @@ impl IXpsOMDocumentStructureResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1208,7 +1208,7 @@ impl IXpsOMDocumentStructureResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1246,7 +1246,7 @@ impl IXpsOMFontResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *readerstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(readerstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1262,7 +1262,7 @@ impl IXpsOMFontResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbeddingOption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *embeddingoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(embeddingoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1299,7 +1299,7 @@ impl IXpsOMFontResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1310,7 +1310,7 @@ impl IXpsOMFontResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1341,7 +1341,7 @@ impl IXpsOMFontResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetByPartName(::core::mem::transmute(&partname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *part = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(part, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1381,7 +1381,7 @@ impl IXpsOMGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetFigures() {
                 ::core::result::Result::Ok(ok__) => {
-                    *figures = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(figures, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1392,7 +1392,7 @@ impl IXpsOMGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetFillRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fillrule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fillrule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1408,7 +1408,7 @@ impl IXpsOMGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1419,7 +1419,7 @@ impl IXpsOMGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1435,7 +1435,7 @@ impl IXpsOMGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lookup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lookup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1451,7 +1451,7 @@ impl IXpsOMGeometry_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1502,7 +1502,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1533,7 +1533,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetStartPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *startpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(startpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1549,7 +1549,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsClosed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isclosed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isclosed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1565,7 +1565,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsFilled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isfilled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isfilled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1581,7 +1581,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetSegmentCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *segmentcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(segmentcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1592,7 +1592,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetSegmentDataCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *segmentdatacount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(segmentdatacount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1603,7 +1603,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.GetSegmentStrokePattern() {
                 ::core::result::Result::Ok(ok__) => {
-                    *segmentstrokepattern = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(segmentstrokepattern, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1614,7 +1614,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometryfigure = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometryfigure, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1659,7 +1659,7 @@ impl IXpsOMGeometryFigureCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1670,7 +1670,7 @@ impl IXpsOMGeometryFigureCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometryfigure = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometryfigure, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1750,7 +1750,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnicodeString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *unicodestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(unicodestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1761,7 +1761,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphIndexCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *indexcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(indexcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1777,7 +1777,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphMappingCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphmappingcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphmappingcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1793,7 +1793,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetProhibitedCaretStopCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prohibitedcaretstopcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prohibitedcaretstopcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1809,7 +1809,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetBidiLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bidilevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bidilevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1820,7 +1820,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsSideways() {
                 ::core::result::Result::Ok(ok__) => {
-                    *issideways = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issideways, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1831,7 +1831,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceFontName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicefontname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicefontname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1842,7 +1842,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetStyleSimulations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stylesimulations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stylesimulations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1858,7 +1858,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetOrigin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *origin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(origin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1874,7 +1874,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontRenderingEmSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontrenderingemsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontrenderingemsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1890,7 +1890,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1906,7 +1906,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontFaceIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontfaceindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontfaceindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1922,7 +1922,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetFillBrush() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fillbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fillbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1933,7 +1933,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetFillBrushLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fillbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fillbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1949,7 +1949,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetFillBrushLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1965,7 +1965,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphsEditor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *editor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(editor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1976,7 +1976,7 @@ impl IXpsOMGlyphs_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2053,7 +2053,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnicodeString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *unicodestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(unicodestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2069,7 +2069,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphIndexCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *indexcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(indexcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2090,7 +2090,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlyphMappingCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphmappingcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphmappingcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2111,7 +2111,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             let this = (*this).get_impl();
             match this.GetProhibitedCaretStopCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prohibitedcaretstopcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prohibitedcaretstopcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2132,7 +2132,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             let this = (*this).get_impl();
             match this.GetBidiLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bidilevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bidilevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2148,7 +2148,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsSideways() {
                 ::core::result::Result::Ok(ok__) => {
-                    *issideways = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issideways, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2164,7 +2164,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceFontName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *devicefontname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(devicefontname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2221,7 +2221,7 @@ impl IXpsOMGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetGradientStops() {
                 ::core::result::Result::Ok(ok__) => {
-                    *gradientstops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gradientstops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2232,7 +2232,7 @@ impl IXpsOMGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2243,7 +2243,7 @@ impl IXpsOMGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2259,7 +2259,7 @@ impl IXpsOMGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2275,7 +2275,7 @@ impl IXpsOMGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpreadMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *spreadmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(spreadmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2291,7 +2291,7 @@ impl IXpsOMGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetColorInterpolationMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorinterpolationmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorinterpolationmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2336,7 +2336,7 @@ impl IXpsOMGradientStop_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2347,7 +2347,7 @@ impl IXpsOMGradientStop_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2373,7 +2373,7 @@ impl IXpsOMGradientStop_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *gradientstop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gradientstop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2409,7 +2409,7 @@ impl IXpsOMGradientStopCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2420,7 +2420,7 @@ impl IXpsOMGradientStopCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2475,7 +2475,7 @@ impl IXpsOMImageBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imageresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imageresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2491,7 +2491,7 @@ impl IXpsOMImageBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetColorProfileResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorprofileresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorprofileresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2507,7 +2507,7 @@ impl IXpsOMImageBrush_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagebrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagebrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2542,7 +2542,7 @@ impl IXpsOMImageResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *readerstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(readerstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2558,7 +2558,7 @@ impl IXpsOMImageResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2595,7 +2595,7 @@ impl IXpsOMImageResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2606,7 +2606,7 @@ impl IXpsOMImageResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2637,7 +2637,7 @@ impl IXpsOMImageResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetByPartName(::core::mem::transmute(&partname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *part = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(part, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2673,7 +2673,7 @@ impl IXpsOMLinearGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetStartPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *startpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(startpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2689,7 +2689,7 @@ impl IXpsOMLinearGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *endpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2705,7 +2705,7 @@ impl IXpsOMLinearGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lineargradientbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lineargradientbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2737,7 +2737,7 @@ impl IXpsOMMatrixTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatrix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2753,7 +2753,7 @@ impl IXpsOMMatrixTransform_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrixtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrixtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2782,7 +2782,7 @@ impl IXpsOMNameCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2793,7 +2793,7 @@ impl IXpsOMNameCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2859,7 +2859,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2870,7 +2870,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageFromFile(::core::mem::transmute(&filename), ::core::mem::transmute_copy(&reuseobjects)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2881,7 +2881,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageFromStream(::core::mem::transmute(&stream), ::core::mem::transmute_copy(&reuseobjects)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2892,7 +2892,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStoryFragmentsResource(::core::mem::transmute(&acquiredstream), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyfragmentsresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyfragmentsresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2903,7 +2903,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDocumentStructureResource(::core::mem::transmute(&acquiredstream), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *documentstructureresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documentstructureresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2914,7 +2914,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSignatureBlockResource(::core::mem::transmute(&acquiredstream), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureblockresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureblockresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2925,7 +2925,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRemoteDictionaryResource(::core::mem::transmute(&dictionary), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *remotedictionaryresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remotedictionaryresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2936,7 +2936,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRemoteDictionaryResourceFromStream(::core::mem::transmute(&dictionarymarkupstream), ::core::mem::transmute(&dictionaryparturi), ::core::mem::transmute(&resources)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dictionaryresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dictionaryresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2947,7 +2947,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePartResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2958,7 +2958,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDocumentSequence(::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *documentsequence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documentsequence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2969,7 +2969,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDocument(::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *document = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(document, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2980,7 +2980,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePageReference(::core::mem::transmute_copy(&advisorypagedimensions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2991,7 +2991,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePage(::core::mem::transmute_copy(&pagedimensions), ::core::mem::transmute(&language), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *page = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(page, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3002,7 +3002,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePageFromStream(::core::mem::transmute(&pagemarkupstream), ::core::mem::transmute(&parturi), ::core::mem::transmute(&resources), ::core::mem::transmute_copy(&reuseobjects)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *page = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(page, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3013,7 +3013,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCanvas() {
                 ::core::result::Result::Ok(ok__) => {
-                    *canvas = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(canvas, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3024,7 +3024,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGlyphs(::core::mem::transmute(&fontresource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *glyphs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(glyphs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3035,7 +3035,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3046,7 +3046,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeometry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3057,7 +3057,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGeometryFigure(::core::mem::transmute_copy(&startpoint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *figure = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(figure, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3068,7 +3068,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMatrixTransform(::core::mem::transmute_copy(&matrix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3079,7 +3079,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSolidColorBrush(::core::mem::transmute_copy(&color), ::core::mem::transmute(&colorprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *solidcolorbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(solidcolorbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3090,7 +3090,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateColorProfileResource(::core::mem::transmute(&acquiredstream), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorprofileresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorprofileresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3101,7 +3101,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageBrush(::core::mem::transmute(&image), ::core::mem::transmute_copy(&viewbox), ::core::mem::transmute_copy(&viewport)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagebrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagebrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3112,7 +3112,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVisualBrush(::core::mem::transmute_copy(&viewbox), ::core::mem::transmute_copy(&viewport)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *visualbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visualbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3123,7 +3123,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageResource(::core::mem::transmute(&acquiredstream), ::core::mem::transmute_copy(&contenttype), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *imageresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imageresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3134,7 +3134,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePrintTicketResource(::core::mem::transmute(&acquiredstream), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *printticketresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(printticketresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3145,7 +3145,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFontResource(::core::mem::transmute(&acquiredstream), ::core::mem::transmute_copy(&fontembedding), ::core::mem::transmute(&parturi), ::core::mem::transmute_copy(&isobfsourcestream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3156,7 +3156,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGradientStop(::core::mem::transmute_copy(&color), ::core::mem::transmute(&colorprofile), ::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *gradientstop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(gradientstop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3167,7 +3167,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearGradientBrush(::core::mem::transmute(&gradstop1), ::core::mem::transmute(&gradstop2), ::core::mem::transmute_copy(&startpoint), ::core::mem::transmute_copy(&endpoint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lineargradientbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lineargradientbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3178,7 +3178,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRadialGradientBrush(::core::mem::transmute(&gradstop1), ::core::mem::transmute(&gradstop2), ::core::mem::transmute_copy(&centerpoint), ::core::mem::transmute_copy(&gradientorigin), ::core::mem::transmute_copy(&radiisizes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *radialgradientbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radialgradientbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3189,7 +3189,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCoreProperties(::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *coreproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(coreproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3200,7 +3200,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDictionary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dictionary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dictionary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3211,7 +3211,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePartUriCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parturicollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parturicollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3222,7 +3222,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageWriterOnFile(::core::mem::transmute(&filename), ::core::mem::transmute_copy(&securityattributes), ::core::mem::transmute_copy(&flagsandattributes), ::core::mem::transmute_copy(&optimizemarkupsize), ::core::mem::transmute_copy(&interleaving), ::core::mem::transmute(&documentsequencepartname), ::core::mem::transmute(&coreproperties), ::core::mem::transmute(&packagethumbnail), ::core::mem::transmute(&documentsequenceprintticket), ::core::mem::transmute(&discardcontrolpartname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3233,7 +3233,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageWriterOnStream(::core::mem::transmute(&outputstream), ::core::mem::transmute_copy(&optimizemarkupsize), ::core::mem::transmute_copy(&interleaving), ::core::mem::transmute(&documentsequencepartname), ::core::mem::transmute(&coreproperties), ::core::mem::transmute(&packagethumbnail), ::core::mem::transmute(&documentsequenceprintticket), ::core::mem::transmute(&discardcontrolpartname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3244,7 +3244,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePartUri(::core::mem::transmute(&uri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *parturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3255,7 +3255,7 @@ impl IXpsOMObjectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateReadOnlyStreamOnFile(::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3331,7 +3331,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentTypeFromFile(::core::mem::transmute(&filename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *documenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3342,7 +3342,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentTypeFromStream(::core::mem::transmute(&xpsdocumentstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *documenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3375,7 +3375,7 @@ impl IXpsOMObjectFactory1_Vtbl {
                 ::core::mem::transmute_copy(&documenttype),
             ) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3386,7 +3386,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageWriterOnStream1(::core::mem::transmute(&outputstream), ::core::mem::transmute_copy(&optimizemarkupsize), ::core::mem::transmute_copy(&interleaving), ::core::mem::transmute(&documentsequencepartname), ::core::mem::transmute(&coreproperties), ::core::mem::transmute(&packagethumbnail), ::core::mem::transmute(&documentsequenceprintticket), ::core::mem::transmute(&discardcontrolpartname), ::core::mem::transmute_copy(&documenttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3397,7 +3397,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackage1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3408,7 +3408,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageFromStream1(::core::mem::transmute(&stream), ::core::mem::transmute_copy(&reuseobjects)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3419,7 +3419,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePackageFromFile1(::core::mem::transmute(&filename), ::core::mem::transmute_copy(&reuseobjects)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *package = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(package, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3430,7 +3430,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePage1(::core::mem::transmute_copy(&pagedimensions), ::core::mem::transmute(&language), ::core::mem::transmute(&parturi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *page = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(page, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3441,7 +3441,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePageFromStream1(::core::mem::transmute(&pagemarkupstream), ::core::mem::transmute(&parturi), ::core::mem::transmute(&resources), ::core::mem::transmute_copy(&reuseobjects)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *page = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(page, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3452,7 +3452,7 @@ impl IXpsOMObjectFactory1_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRemoteDictionaryResourceFromStream1(::core::mem::transmute(&dictionarymarkupstream), ::core::mem::transmute(&parturi), ::core::mem::transmute(&resources)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dictionaryresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dictionaryresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3501,7 +3501,7 @@ impl IXpsOMPackage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentSequence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documentsequence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documentsequence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3517,7 +3517,7 @@ impl IXpsOMPackage_Vtbl {
             let this = (*this).get_impl();
             match this.GetCoreProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *coreproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(coreproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3533,7 +3533,7 @@ impl IXpsOMPackage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDiscardControlPartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *discardcontrolparturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(discardcontrolparturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3549,7 +3549,7 @@ impl IXpsOMPackage_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnailResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imageresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imageresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3604,7 +3604,7 @@ impl IXpsOMPackage1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3645,7 +3645,7 @@ impl IXpsOMPackageTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateXpsOMPackageWriter(::core::mem::transmute(&documentsequencepartname), ::core::mem::transmute(&documentsequenceprintticket), ::core::mem::transmute(&discardcontrolpartname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagewriter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagewriter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3695,7 +3695,7 @@ impl IXpsOMPackageWriter_Vtbl {
             let this = (*this).get_impl();
             match this.IsClosed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isclosed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isclosed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3779,7 +3779,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3790,7 +3790,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisuals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visuals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visuals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3801,7 +3801,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageDimensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagedimensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagedimensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3817,7 +3817,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentBox() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentbox = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentbox, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3833,7 +3833,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetBleedBox() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bleedbox = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bleedbox, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3849,7 +3849,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *language = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(language, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3865,7 +3865,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3881,7 +3881,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsHyperlinkTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ishyperlinktarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ishyperlinktarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3897,7 +3897,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcedictionary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcedictionary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3908,7 +3908,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionaryLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcedictionary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcedictionary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3924,7 +3924,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionaryResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *remotedictionaryresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remotedictionaryresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3945,7 +3945,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateUnusedLookupKey(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3956,7 +3956,7 @@ impl IXpsOMPage_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *page = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(page, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4007,7 +4007,7 @@ impl IXpsOMPage1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4058,7 +4058,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *document = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(document, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4069,7 +4069,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *page = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(page, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4090,7 +4090,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.IsPageLoaded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ispageloaded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ispageloaded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4101,7 +4101,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdvisoryPageDimensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagedimensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagedimensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4117,7 +4117,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryFragmentsResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyfragmentsresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyfragmentsresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4133,7 +4133,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrintTicketResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *printticketresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(printticketresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4149,7 +4149,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetThumbnailResource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imageresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imageresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4165,7 +4165,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.CollectLinkTargets() {
                 ::core::result::Result::Ok(ok__) => {
-                    *linktargets = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(linktargets, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4176,7 +4176,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.CollectPartResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4187,7 +4187,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.HasRestrictedFonts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *restrictedfonts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(restrictedfonts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4198,7 +4198,7 @@ impl IXpsOMPageReference_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4245,7 +4245,7 @@ impl IXpsOMPageReferenceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4256,7 +4256,7 @@ impl IXpsOMPageReferenceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pagereference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pagereference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4311,7 +4311,7 @@ impl IXpsOMPart_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4346,7 +4346,7 @@ impl IXpsOMPartResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fontresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fontresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4357,7 +4357,7 @@ impl IXpsOMPartResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imageresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imageresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4368,7 +4368,7 @@ impl IXpsOMPartResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetColorProfileResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *colorprofileresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(colorprofileresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4379,7 +4379,7 @@ impl IXpsOMPartResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetRemoteDictionaryResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dictionaryresources = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dictionaryresources, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4416,7 +4416,7 @@ impl IXpsOMPartUriCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4427,7 +4427,7 @@ impl IXpsOMPartUriCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *parturi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parturi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4517,7 +4517,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeometry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4528,7 +4528,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeometryLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *geometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(geometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4544,7 +4544,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeometryLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lookup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lookup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4560,7 +4560,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccessibilityShortDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *shortdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(shortdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4576,7 +4576,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccessibilityLongDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *longdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(longdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4592,7 +4592,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapsToPixels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *snapstopixels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(snapstopixels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4608,7 +4608,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeBrush() {
                 ::core::result::Result::Ok(ok__) => {
-                    *brush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(brush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4619,7 +4619,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeBrushLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *brush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(brush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4635,7 +4635,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeBrushLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lookup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lookup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4651,7 +4651,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeDashes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokedashes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokedashes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4662,7 +4662,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeDashCap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokedashcap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokedashcap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4678,7 +4678,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeDashOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokedashoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokedashoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4694,7 +4694,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeStartLineCap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokestartlinecap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokestartlinecap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4710,7 +4710,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeEndLineCap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokeendlinecap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokeendlinecap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4726,7 +4726,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeLineJoin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokelinejoin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokelinejoin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4742,7 +4742,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeMiterLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokemiterlimit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokemiterlimit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4758,7 +4758,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokeThickness() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokethickness = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokethickness, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4774,7 +4774,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetFillBrush() {
                 ::core::result::Result::Ok(ok__) => {
-                    *brush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(brush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4785,7 +4785,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetFillBrushLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *brush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(brush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4801,7 +4801,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetFillBrushLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lookup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lookup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4817,7 +4817,7 @@ impl IXpsOMPath_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4883,7 +4883,7 @@ impl IXpsOMPrintTicketResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4921,7 +4921,7 @@ impl IXpsOMRadialGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetCenter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *center = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(center, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4937,7 +4937,7 @@ impl IXpsOMRadialGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadiiSizes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radiisizes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radiisizes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4953,7 +4953,7 @@ impl IXpsOMRadialGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetGradientOrigin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *origin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(origin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4969,7 +4969,7 @@ impl IXpsOMRadialGradientBrush_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radialgradientbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radialgradientbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5005,7 +5005,7 @@ impl IXpsOMRemoteDictionaryResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dictionary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dictionary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5041,7 +5041,7 @@ impl IXpsOMRemoteDictionaryResource1_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *documenttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(documenttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5082,7 +5082,7 @@ impl IXpsOMRemoteDictionaryResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5093,7 +5093,7 @@ impl IXpsOMRemoteDictionaryResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5124,7 +5124,7 @@ impl IXpsOMRemoteDictionaryResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetByPartName(::core::mem::transmute(&partname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *remotedictionaryresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(remotedictionaryresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5170,7 +5170,7 @@ impl IXpsOMShareable_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5181,7 +5181,7 @@ impl IXpsOMShareable_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5213,7 +5213,7 @@ impl IXpsOMSignatureBlockResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5224,7 +5224,7 @@ impl IXpsOMSignatureBlockResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5266,7 +5266,7 @@ impl IXpsOMSignatureBlockResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5277,7 +5277,7 @@ impl IXpsOMSignatureBlockResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureblockresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureblockresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5308,7 +5308,7 @@ impl IXpsOMSignatureBlockResourceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetByPartName(::core::mem::transmute(&partname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureblockresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureblockresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5352,7 +5352,7 @@ impl IXpsOMSolidColorBrush_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *solidcolorbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(solidcolorbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5385,7 +5385,7 @@ impl IXpsOMStoryFragmentsResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *owner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(owner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5396,7 +5396,7 @@ impl IXpsOMStoryFragmentsResource_Vtbl {
             let this = (*this).get_impl();
             match this.GetStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5432,7 +5432,7 @@ impl IXpsOMThumbnailGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateThumbnail(::core::mem::transmute(&page), ::core::mem::transmute_copy(&thumbnailtype), ::core::mem::transmute_copy(&thumbnailsize), ::core::mem::transmute(&imageresourcepartname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *imageresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imageresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5465,7 +5465,7 @@ impl IXpsOMTileBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5476,7 +5476,7 @@ impl IXpsOMTileBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *transform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5492,7 +5492,7 @@ impl IXpsOMTileBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5508,7 +5508,7 @@ impl IXpsOMTileBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewbox() {
                 ::core::result::Result::Ok(ok__) => {
-                    *viewbox = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(viewbox, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5524,7 +5524,7 @@ impl IXpsOMTileBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewport() {
                 ::core::result::Result::Ok(ok__) => {
-                    *viewport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(viewport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5540,7 +5540,7 @@ impl IXpsOMTileBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetTileMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tilemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tilemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5608,7 +5608,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrixtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrixtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5619,7 +5619,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *matrixtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matrixtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5635,7 +5635,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5651,7 +5651,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipGeometry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clipgeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clipgeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5662,7 +5662,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipGeometryLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clipgeometry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clipgeometry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5678,7 +5678,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipGeometryLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5694,7 +5694,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetOpacity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *opacity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(opacity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5710,7 +5710,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetOpacityMaskBrush() {
                 ::core::result::Result::Ok(ok__) => {
-                    *opacitymaskbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(opacitymaskbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5721,7 +5721,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetOpacityMaskBrushLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *opacitymaskbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(opacitymaskbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5737,7 +5737,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetOpacityMaskBrushLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5753,7 +5753,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5769,7 +5769,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetIsHyperlinkTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ishyperlink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ishyperlink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5785,7 +5785,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetHyperlinkNavigateUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hyperlinkuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hyperlinkuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5801,7 +5801,7 @@ impl IXpsOMVisual_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *language = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(language, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5861,7 +5861,7 @@ impl IXpsOMVisualBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisual() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5872,7 +5872,7 @@ impl IXpsOMVisualBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisualLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visual = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visual, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5888,7 +5888,7 @@ impl IXpsOMVisualBrush_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisualLookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lookup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lookup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5904,7 +5904,7 @@ impl IXpsOMVisualBrush_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visualbrush = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visualbrush, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5940,7 +5940,7 @@ impl IXpsOMVisualCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5951,7 +5951,7 @@ impl IXpsOMVisualCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6016,7 +6016,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sigid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sigid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6032,7 +6032,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *certificateenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(certificateenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6043,7 +6043,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSigningTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sigdatetimestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sigdatetimestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6054,7 +6054,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSigningTimeFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timeformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timeformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6065,7 +6065,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignaturePartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturepartname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturepartname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6076,7 +6076,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.Verify(::core::mem::transmute_copy(&x509certificate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sigstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sigstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6087,7 +6087,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *policy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(policy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6098,7 +6098,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomObjectEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customobjectenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customobjectenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6109,7 +6109,7 @@ impl IXpsSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomReferenceEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customreferenceenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customreferenceenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6163,7 +6163,7 @@ impl IXpsSignatureBlock_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequests() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requests = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requests, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6174,7 +6174,7 @@ impl IXpsSignatureBlock_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *partname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(partname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6185,7 +6185,7 @@ impl IXpsSignatureBlock_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fixeddocumentindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fixeddocumentindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6196,7 +6196,7 @@ impl IXpsSignatureBlock_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fixeddocumentname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fixeddocumentname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6207,7 +6207,7 @@ impl IXpsSignatureBlock_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRequest(::core::mem::transmute(&requestid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6239,7 +6239,7 @@ impl IXpsSignatureBlockCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6250,7 +6250,7 @@ impl IXpsSignatureBlockCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6285,7 +6285,7 @@ impl IXpsSignatureCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6296,7 +6296,7 @@ impl IXpsSignatureCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6352,7 +6352,7 @@ impl IXpsSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.Sign(::core::mem::transmute(&signoptions), ::core::mem::transmute_copy(&x509certificate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6363,7 +6363,7 @@ impl IXpsSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureOriginPartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureoriginpartname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureoriginpartname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6379,7 +6379,7 @@ impl IXpsSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatures() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatures = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatures, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6390,7 +6390,7 @@ impl IXpsSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.AddSignatureBlock(::core::mem::transmute(&partname), ::core::mem::transmute_copy(&fixeddocumentindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureblock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureblock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6401,7 +6401,7 @@ impl IXpsSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureBlocks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureblocks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureblocks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6412,7 +6412,7 @@ impl IXpsSignatureManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSigningOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signingoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signingoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6472,7 +6472,7 @@ impl IXpsSignatureRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *intent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(intent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6488,7 +6488,7 @@ impl IXpsSignatureRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestedSigner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6504,7 +6504,7 @@ impl IXpsSignatureRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestSignByDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *datestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(datestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6520,7 +6520,7 @@ impl IXpsSignatureRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetSigningLocale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *place = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(place, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6546,7 +6546,7 @@ impl IXpsSignatureRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetRequestId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *requestid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(requestid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6557,7 +6557,7 @@ impl IXpsSignatureRequest_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6596,7 +6596,7 @@ impl IXpsSignatureRequestCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6607,7 +6607,7 @@ impl IXpsSignatureRequestCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturerequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturerequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6659,7 +6659,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signatureid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signatureid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6675,7 +6675,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignatureMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturemethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturemethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6691,7 +6691,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetDigestMethod() {
                 ::core::result::Result::Ok(ok__) => {
-                    *digestmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(digestmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6707,7 +6707,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSignaturePartName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *signaturepartname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signaturepartname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6723,7 +6723,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *policy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(policy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6739,7 +6739,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSigningTimeFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timeformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timeformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6755,7 +6755,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6766,7 +6766,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomReferences() {
                 ::core::result::Result::Ok(ok__) => {
-                    *customreferenceset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(customreferenceset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6777,7 +6777,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetCertificateSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *certificateset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(certificateset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6788,7 +6788,7 @@ impl IXpsSigningOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
@@ -15,7 +15,7 @@ impl IABContainer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEntry(::core::mem::transmute_copy(&cbentryid), ::core::mem::transmute_copy(&lpentryid), ::core::mem::transmute_copy(&ulcreateflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmapipropentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmapipropentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36,7 +36,7 @@ impl IABContainer_Vtbl {
             let this = (*this).get_impl();
             match this.ResolveNames(::core::mem::transmute_copy(&lpproptagarray), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&lpadrlist)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpflaglist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpflaglist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -226,7 +226,7 @@ impl IDistList_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEntry(::core::mem::transmute_copy(&cbentryid), ::core::mem::transmute_copy(&lpentryid), ::core::mem::transmute_copy(&ulcreateflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmapipropentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmapipropentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -247,7 +247,7 @@ impl IDistList_Vtbl {
             let this = (*this).get_impl();
             match this.ResolveNames(::core::mem::transmute_copy(&lpproptagarray), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&lpadrlist)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpflaglist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpflaglist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -303,7 +303,7 @@ impl IMAPIContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentsTable(::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IMAPIContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetHierarchyTable(::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -361,7 +361,7 @@ impl IMAPIControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastError(::core::mem::transmute_copy(&hresult), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmapierror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmapierror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -427,7 +427,7 @@ impl IMAPIFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolder(::core::mem::transmute_copy(&ulfoldertype), ::core::mem::transmute_copy(&lpszfoldername), ::core::mem::transmute_copy(&lpszfoldercomment), ::core::mem::transmute_copy(&lpinterface), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppfolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppfolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -453,7 +453,7 @@ impl IMAPIFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetMessageStatus(::core::mem::transmute_copy(&cbentryid), ::core::mem::transmute_copy(&lpentryid), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpulmessagestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpulmessagestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -464,7 +464,7 @@ impl IMAPIFolder_Vtbl {
             let this = (*this).get_impl();
             match this.SetMessageStatus(::core::mem::transmute_copy(&cbentryid), ::core::mem::transmute_copy(&lpentryid), ::core::mem::transmute_copy(&ulnewstatus), ::core::mem::transmute_copy(&ulnewstatusmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpuloldstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpuloldstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -895,7 +895,7 @@ impl IMessage_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttachmentTable(::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -906,7 +906,7 @@ impl IMessage_Vtbl {
             let this = (*this).get_impl();
             match this.OpenAttach(::core::mem::transmute_copy(&ulattachmentnum), ::core::mem::transmute_copy(&lpinterface), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppattach = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppattach, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -927,7 +927,7 @@ impl IMessage_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecipientTable(::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -990,7 +990,7 @@ impl IMsgStore_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute_copy(&cbentryid), ::core::mem::transmute_copy(&lpentryid), ::core::mem::transmute_copy(&uleventmask), ::core::mem::transmute(&lpadvisesink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpulconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpulconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1006,7 +1006,7 @@ impl IMsgStore_Vtbl {
             let this = (*this).get_impl();
             match this.CompareEntryIDs(::core::mem::transmute_copy(&cbentryid1), ::core::mem::transmute_copy(&lpentryid1), ::core::mem::transmute_copy(&cbentryid2), ::core::mem::transmute_copy(&lpentryid2), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpulresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpulresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1032,7 +1032,7 @@ impl IMsgStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetReceiveFolderTable(::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1053,7 +1053,7 @@ impl IMsgStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutgoingQueue(::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1170,7 +1170,7 @@ impl IProviderAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastError(::core::mem::transmute_copy(&hresult), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmapierror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmapierror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1181,7 +1181,7 @@ impl IProviderAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderTable(::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1192,7 +1192,7 @@ impl IProviderAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProvider(::core::mem::transmute_copy(&lpszprovider), ::core::mem::transmute_copy(&cvalues), ::core::mem::transmute_copy(&lpprops), ::core::mem::transmute_copy(&uluiparam), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpuid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpuid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1208,7 +1208,7 @@ impl IProviderAdmin_Vtbl {
             let this = (*this).get_impl();
             match this.OpenProfileSection(::core::mem::transmute_copy(&lpuid), ::core::mem::transmute_copy(&lpinterface), ::core::mem::transmute_copy(&ulflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppprofsect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppprofsect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1410,7 +1410,7 @@ impl IWABOBJECT__Vtbl {
             let this = (*this).get_impl();
             match this.LDAPUrl(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&lpszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmailuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmailuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1426,7 +1426,7 @@ impl IWABOBJECT__Vtbl {
             let this = (*this).get_impl();
             match this.VCardRetrieve(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&lpszvcard)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmailuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmailuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1531,7 +1531,7 @@ impl IWABObject_Vtbl {
             let this = (*this).get_impl();
             match this.LDAPUrl(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&lpszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmailuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmailuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1547,7 +1547,7 @@ impl IWABObject_Vtbl {
             let this = (*this).get_impl();
             match this.VCardRetrieve(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&lpszvcard)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lppmailuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lppmailuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
@@ -63,7 +63,7 @@ impl IAntimalware2_Vtbl {
             let this = (*this).get_impl();
             match this.Notify(::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&length), ::core::mem::transmute(&contentname), ::core::mem::transmute(&appname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -88,7 +88,7 @@ impl IAntimalwareProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Scan(::core::mem::transmute(&stream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -104,7 +104,7 @@ impl IAntimalwareProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -132,7 +132,7 @@ impl IAntimalwareProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.Notify(::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&length), ::core::mem::transmute(&contentname), ::core::mem::transmute(&appname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -159,7 +159,7 @@ impl IAntimalwareUacProvider_Vtbl {
             let this = (*this).get_impl();
             match this.UacScan(::core::mem::transmute_copy(&context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -170,7 +170,7 @@ impl IAntimalwareUacProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
@@ -28,7 +28,7 @@ impl IAssemblyCache_Vtbl {
             let this = (*this).get_impl();
             match this.Reserved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -148,7 +148,7 @@ impl IAssemblyName_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -203,7 +203,7 @@ impl IEnumMsmDependency_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pemsmdependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pemsmdependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -253,7 +253,7 @@ impl IEnumMsmError_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pemsmerrors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pemsmerrors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -303,7 +303,7 @@ impl IEnumMsmString_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pemsmstrings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pemsmstrings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -337,7 +337,7 @@ impl IMsmDependencies_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#return = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#return, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -353,7 +353,7 @@ impl IMsmDependencies_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -447,7 +447,7 @@ impl IMsmError_Vtbl {
             let this = (*this).get_impl();
             match this.DatabaseKeys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -463,7 +463,7 @@ impl IMsmError_Vtbl {
             let this = (*this).get_impl();
             match this.ModuleKeys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorkeys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorkeys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -500,7 +500,7 @@ impl IMsmErrors_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#return = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#return, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -516,7 +516,7 @@ impl IMsmErrors_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -547,7 +547,7 @@ impl IMsmGetFiles_Vtbl {
             let this = (*this).get_impl();
             match this.ModuleFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *files = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(files, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -620,7 +620,7 @@ impl IMsmMerge_Vtbl {
             let this = (*this).get_impl();
             match this.Errors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -631,7 +631,7 @@ impl IMsmMerge_Vtbl {
             let this = (*this).get_impl();
             match this.Dependencies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dependencies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dependencies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -704,7 +704,7 @@ impl IMsmStrings_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -789,7 +789,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ProductID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproductid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproductid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -800,7 +800,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.InstanceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinstanceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinstanceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -811,7 +811,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.OfferID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pofferid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pofferid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -837,7 +837,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.NotificationState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisnotified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisnotified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -848,7 +848,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AppInstallType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pappinstalltype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pappinstalltype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -859,7 +859,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -870,7 +870,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsRevoked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisrevoked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisrevoked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -881,7 +881,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisupdateavailable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisupdateavailable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -892,7 +892,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.InstallDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinstalldate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinstalldate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -903,7 +903,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsUninstallable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisuninstallable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisuninstallable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -914,7 +914,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsThemable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisthemable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisthemable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -925,7 +925,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsTrial() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistrial = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistrial, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -946,7 +946,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Genre() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgenre = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgenre, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -982,7 +982,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AppPlatMajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmajorver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmajorver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -993,7 +993,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AppPlatMinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pminorver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pminorver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1004,7 +1004,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PublisherID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppublisherid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppublisherid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1015,7 +1015,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsMultiCore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pismulticore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pismulticore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1031,7 +1031,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AppPlatMajorVersionLightUp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmajorver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmajorver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1042,7 +1042,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AppPlatMinorVersionLightUp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pminorver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pminorver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1073,7 +1073,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsPinableOnKidZone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pispinable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pispinable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1084,7 +1084,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsOriginallyPreInstalled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pispreinstalled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pispreinstalled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1095,7 +1095,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsInstallOnSD() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisinstallonsd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisinstallonsd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1106,7 +1106,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsOptoutOnSD() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisoptoutonsd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisoptoutonsd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1117,7 +1117,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsOptoutBackupRestore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisoptoutbackuprestore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisoptoutbackuprestore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1138,7 +1138,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EnterpriseDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isdisabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isdisabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1149,7 +1149,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EnterpriseUninstallable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isuninstallable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isuninstallable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1160,7 +1160,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsVisibleOnAppList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisvisible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisvisible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1171,7 +1171,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsInboxApp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisinboxapp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisinboxapp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1182,7 +1182,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.StorageID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstorageid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstorageid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1198,7 +1198,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsMovable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pismovable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pismovable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1209,7 +1209,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DeploymentAppEnumerationHubFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hubtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hubtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1220,7 +1220,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ModifiedDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmodifieddate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmodifieddate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1231,7 +1231,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsOriginallyRestored() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisrestored = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisrestored, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1242,7 +1242,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ShouldDeferMdilBind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdefermdilbind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdefermdilbind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1253,7 +1253,7 @@ impl IPMApplicationInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsFullyPreInstall() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisfullypreinstall = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisfullypreinstall, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1343,7 +1343,7 @@ impl IPMApplicationInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppappinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppappinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1382,7 +1382,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ProductID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproductid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproductid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1398,7 +1398,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.BSAID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsaid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsaid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1429,7 +1429,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsPeriodic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisperiodic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisperiodic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1440,7 +1440,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsScheduled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisscheduled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisscheduled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1451,7 +1451,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsScheduleAllowed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisscheduleallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisscheduleallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1467,7 +1467,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsLaunchOnBoot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plaunchonboot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plaunchonboot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1516,7 +1516,7 @@ impl IPMBackgroundServiceAgentInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbsainfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbsainfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1547,7 +1547,7 @@ impl IPMBackgroundWorkerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ProductID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproductid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproductid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1568,7 +1568,7 @@ impl IPMBackgroundWorkerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MaxStartupLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmaxstartuplatency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmaxstartuplatency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1579,7 +1579,7 @@ impl IPMBackgroundWorkerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ExpectedRuntime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pexpectedruntime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pexpectedruntime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1590,7 +1590,7 @@ impl IPMBackgroundWorkerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsBootWorker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisbootworker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisbootworker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1621,7 +1621,7 @@ impl IPMBackgroundWorkerInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbwinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbwinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1793,7 +1793,7 @@ impl IPMDeploymentManager_Vtbl {
             let this = (*this).get_impl();
             match this.SetApplicationsNeedMaintenance(::core::mem::transmute_copy(&requiredmaintenanceoperations)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcapplications = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcapplications, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1809,7 +1809,7 @@ impl IPMDeploymentManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnterprisePolicyIsApplicationAllowed(::core::mem::transmute(&productid), ::core::mem::transmute(&publishername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1969,7 +1969,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_ApplicationInfo(::core::mem::transmute(&productid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppappinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppappinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1980,7 +1980,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_TileInfo(::core::mem::transmute(&productid), ::core::mem::transmute(&tileid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptileinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptileinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1991,7 +1991,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_TaskInfo(::core::mem::transmute(&productid), ::core::mem::transmute(&taskid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptaskinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptaskinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2002,7 +2002,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_TaskInfoEx(::core::mem::transmute(&productid), ::core::mem::transmute(&taskid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptaskinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptaskinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2013,7 +2013,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_BackgroundServiceAgentInfo(::core::mem::transmute_copy(&bsaid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptaskinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptaskinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2024,7 +2024,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.AllLiveTileJobs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplivetilejobenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplivetilejobenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2035,7 +2035,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_LiveTileJob(::core::mem::transmute(&productid), ::core::mem::transmute(&tileid), ::core::mem::transmute_copy(&recurrencetype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplivetilejobinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplivetilejobinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2046,7 +2046,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_ApplicationInfoExternal(::core::mem::transmute(&productid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppappinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppappinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2062,7 +2062,7 @@ impl IPMEnumerationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_ApplicationInfoFromAccessClaims(::core::mem::transmute(&sysappid0), ::core::mem::transmute(&sysappid1)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppappinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppappinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2118,7 +2118,7 @@ impl IPMExtensionCachedFileUpdaterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SupportsUpdates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupportsupdates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupportsupdates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2235,7 +2235,7 @@ impl IPMExtensionFileOpenPickerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SupportsAllFileTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupportsalltypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupportsalltypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2271,7 +2271,7 @@ impl IPMExtensionFileSavePickerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SupportsAllFileTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupportsalltypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupportsalltypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2306,7 +2306,7 @@ impl IPMExtensionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SupplierPID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupplierpid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupplierpid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2362,7 +2362,7 @@ impl IPMExtensionInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppextensioninfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppextensioninfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2430,7 +2430,7 @@ impl IPMExtensionShareTargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SupportsAllFileTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psupportsalltypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psupportsalltypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2484,7 +2484,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ProductID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproductid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproductid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2500,7 +2500,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.NextSchedule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnextschedule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnextschedule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2516,7 +2516,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.StartSchedule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstartschedule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstartschedule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2532,7 +2532,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IntervalDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pintervalduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pintervalduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2548,7 +2548,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RunForever() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isrunforever = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isrunforever, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2564,7 +2564,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.MaxRunCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmaxruncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmaxruncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2580,7 +2580,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RunCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pruncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pruncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2596,7 +2596,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RecurrenceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *precurrencetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precurrencetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2632,7 +2632,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AttemptCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattemptcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattemptcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2648,7 +2648,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdownloadstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdownloadstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2702,7 +2702,7 @@ impl IPMLiveTileJobInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplivetilejobinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplivetilejobinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2748,7 +2748,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ProductID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproductid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproductid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2769,7 +2769,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TaskTransition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptasktransition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptasktransition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2780,7 +2780,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RuntimeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pruntimetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pruntimetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2791,7 +2791,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ActivationPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pactivationpolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pactivationpolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2802,7 +2802,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TaskType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptasktype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptasktype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2838,7 +2838,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsSingleInstanceHost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pissingleinstancehost = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pissingleinstancehost, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2849,7 +2849,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsInteropEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisinteropenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisinteropenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2860,7 +2860,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *papplicationstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(papplicationstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2871,7 +2871,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.InstallType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinstalltype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinstalltype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2887,7 +2887,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.BitsPerPixel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbitsperpixel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbitsperpixel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2898,7 +2898,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SuppressesDehydration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psuppressesdehydration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psuppressesdehydration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2914,7 +2914,7 @@ impl IPMTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsOptedForExtendedMem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisoptedin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisoptedin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2960,7 +2960,7 @@ impl IPMTaskInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptaskinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptaskinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3009,7 +3009,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ProductID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pproductid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pproductid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3025,7 +3025,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TemplateType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptemplatetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptemplatetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3036,7 +3036,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_HubPinnedState(::core::mem::transmute_copy(&hubtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3047,7 +3047,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_HubPosition(::core::mem::transmute_copy(&hubtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3058,7 +3058,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsNotified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisnotified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisnotified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3069,7 +3069,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsDefault() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisdefault = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisdefault, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3085,7 +3085,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TileType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstarttiletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstarttiletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3096,7 +3096,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsThemable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisthemable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisthemable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3107,7 +3107,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_PropertyById(::core::mem::transmute_copy(&propid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3123,7 +3123,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptilepropenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptilepropenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3134,7 +3134,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_HubTileSize(::core::mem::transmute_copy(&hubtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3175,7 +3175,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsRestoring() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisrestoring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisrestoring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3186,7 +3186,7 @@ impl IPMTileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsAutoRestoreDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisautorestoredisabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisautorestoredisabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3245,7 +3245,7 @@ impl IPMTileInfoEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptileinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptileinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3268,7 +3268,7 @@ impl IPMTilePropertyEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3296,7 +3296,7 @@ impl IPMTilePropertyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
@@ -74,7 +74,7 @@ impl IProvideWinSATAssessmentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Score() {
                 ::core::result::Result::Ok(ok__) => {
-                    *score = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(score, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -85,7 +85,7 @@ impl IProvideWinSATAssessmentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *title = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(title, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -96,7 +96,7 @@ impl IProvideWinSATAssessmentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -131,7 +131,7 @@ impl IProvideWinSATResultsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAssessmentInfo(::core::mem::transmute_copy(&assessment)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -142,7 +142,7 @@ impl IProvideWinSATResultsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AssessmentState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -153,7 +153,7 @@ impl IProvideWinSATResultsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AssessmentDateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -164,7 +164,7 @@ impl IProvideWinSATResultsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.SystemRating() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -175,7 +175,7 @@ impl IProvideWinSATResultsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.RatingStateDesc() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -208,7 +208,7 @@ impl IProvideWinSATVisuals_Vtbl {
             let this = (*this).get_impl();
             match this.get_Bitmap(::core::mem::transmute_copy(&bitmapsize), ::core::mem::transmute_copy(&state), ::core::mem::transmute_copy(&rating)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl IQueryAllWinSATAssessments_Vtbl {
             let this = (*this).get_impl();
             match this.get_AllXML(::core::mem::transmute(&xpath), ::core::mem::transmute(&namespaces)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdomnodelist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdomnodelist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -257,7 +257,7 @@ impl IQueryOEMWinSATCustomization_Vtbl {
             let this = (*this).get_impl();
             match this.GetOEMPrePopulationInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -284,7 +284,7 @@ impl IQueryRecentWinSATAssessment_Vtbl {
             let this = (*this).get_impl();
             match this.get_XML(::core::mem::transmute(&xpath), ::core::mem::transmute(&namespaces)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdomnodelist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdomnodelist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -295,7 +295,7 @@ impl IQueryRecentWinSATAssessment_Vtbl {
             let this = (*this).get_impl();
             match this.Info() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwinsatassessmentinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwinsatassessmentinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
@@ -30,7 +30,7 @@ impl ICallFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -71,7 +71,7 @@ impl ICallFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetParamInfo(::core::mem::transmute_copy(&iparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -87,7 +87,7 @@ impl ICallFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetParam(::core::mem::transmute_copy(&iparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl ICallFrame_Vtbl {
             let this = (*this).get_impl();
             match this.Copy(::core::mem::transmute_copy(&copycontrol), ::core::mem::transmute(&pwalker)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl ICallFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetMarshalSizeMax(::core::mem::transmute_copy(&pmshlcontext), ::core::mem::transmute_copy(&mshlflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbbufferneeded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbbufferneeded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -140,7 +140,7 @@ impl ICallFrame_Vtbl {
             let this = (*this).get_impl();
             match this.Unmarshal(::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&cbbuffer), ::core::mem::transmute_copy(&datarep), ::core::mem::transmute_copy(&pcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbunmarshalled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbunmarshalled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -247,7 +247,7 @@ impl ICallIndirect_Vtbl {
             let this = (*this).get_impl();
             match this.GetStackSize(::core::mem::transmute_copy(&imethod)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cbargs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cbargs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -290,7 +290,7 @@ impl ICallInterceptor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegisteredSink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -353,7 +353,7 @@ impl IInterfaceRelated_Vtbl {
             let this = (*this).get_impl();
             match this.GetIID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
@@ -22,7 +22,7 @@ impl IEnumEventObject_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -82,7 +82,7 @@ impl IEventClass_Vtbl {
             let this = (*this).get_impl();
             match this.EventClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstreventclassid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstreventclassid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl IEventClass_Vtbl {
             let this = (*this).get_impl();
             match this.EventClassName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstreventclassname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstreventclassname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -114,7 +114,7 @@ impl IEventClass_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrownersid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrownersid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -130,7 +130,7 @@ impl IEventClass_Vtbl {
             let this = (*this).get_impl();
             match this.FiringInterfaceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfiringinterfaceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfiringinterfaceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -146,7 +146,7 @@ impl IEventClass_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -162,7 +162,7 @@ impl IEventClass_Vtbl {
             let this = (*this).get_impl();
             match this.CustomConfigCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcustomconfigclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcustomconfigclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -178,7 +178,7 @@ impl IEventClass_Vtbl {
             let this = (*this).get_impl();
             match this.TypeLib() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtypelib = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtypelib, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -232,7 +232,7 @@ impl IEventClass2_Vtbl {
             let this = (*this).get_impl();
             match this.PublisherID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpublisherid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpublisherid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -248,7 +248,7 @@ impl IEventClass2_Vtbl {
             let this = (*this).get_impl();
             match this.MultiInterfacePublisherFilterCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpubfilclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpubfilclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -264,7 +264,7 @@ impl IEventClass2_Vtbl {
             let this = (*this).get_impl();
             match this.AllowInprocActivation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallowinprocactivation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallowinprocactivation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -280,7 +280,7 @@ impl IEventClass2_Vtbl {
             let this = (*this).get_impl();
             match this.FireInParallel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pffireinparallel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pffireinparallel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IEventControl_Vtbl {
             let this = (*this).get_impl();
             match this.AllowInprocActivation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallowinprocactivation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallowinprocactivation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -346,7 +346,7 @@ impl IEventControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscriptions(::core::mem::transmute(&methodname), ::core::mem::transmute(&optionalcriteria), ::core::mem::transmute_copy(&optionalerrorindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -357,7 +357,7 @@ impl IEventControl_Vtbl {
             let this = (*this).get_impl();
             match this.SetDefaultQuery(::core::mem::transmute(&methodname), ::core::mem::transmute(&criteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -462,7 +462,7 @@ impl IEventObjectCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -473,7 +473,7 @@ impl IEventObjectCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&objectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -484,7 +484,7 @@ impl IEventObjectCollection_Vtbl {
             let this = (*this).get_impl();
             match this.NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -495,7 +495,7 @@ impl IEventObjectCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -542,7 +542,7 @@ impl IEventProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -558,7 +558,7 @@ impl IEventProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -608,7 +608,7 @@ impl IEventPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.PublisherID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpublisherid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpublisherid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -624,7 +624,7 @@ impl IEventPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.PublisherName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpublishername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpublishername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -640,7 +640,7 @@ impl IEventPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.PublisherType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpublishertype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpublishertype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -656,7 +656,7 @@ impl IEventPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrownersid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrownersid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -672,7 +672,7 @@ impl IEventPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -688,7 +688,7 @@ impl IEventPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultProperty(::core::mem::transmute(&bstrpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -709,7 +709,7 @@ impl IEventPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultPropertyCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -784,7 +784,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.SubscriptionID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubscriptionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubscriptionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -800,7 +800,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.SubscriptionName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubscriptionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubscriptionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -816,7 +816,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.PublisherID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpublisherid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpublisherid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -832,7 +832,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.EventClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstreventclassid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstreventclassid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -848,7 +848,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.MethodName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmethodname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmethodname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -864,7 +864,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.SubscriberCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsubscriberclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsubscriberclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -880,7 +880,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.SubscriberInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubscriberinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubscriberinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -896,7 +896,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.PerUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfperuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfperuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -912,7 +912,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.OwnerSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrownersid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrownersid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -928,7 +928,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -944,7 +944,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -960,7 +960,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.MachineName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmachinename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmachinename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -976,7 +976,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.GetPublisherProperty(::core::mem::transmute(&bstrpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -997,7 +997,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.GetPublisherPropertyCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1008,7 +1008,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscriberProperty(::core::mem::transmute(&bstrpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1029,7 +1029,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscriberPropertyCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1040,7 +1040,7 @@ impl IEventSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.InterfaceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrinterfaceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrinterfaceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1122,7 +1122,7 @@ impl IEventSystem_Vtbl {
             let this = (*this).get_impl();
             match this.Remove(::core::mem::transmute(&progid), ::core::mem::transmute(&querycriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1133,7 +1133,7 @@ impl IEventSystem_Vtbl {
             let this = (*this).get_impl();
             match this.EventObjectChangeEventClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstreventclassid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstreventclassid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1144,7 +1144,7 @@ impl IEventSystem_Vtbl {
             let this = (*this).get_impl();
             match this.QueryS(::core::mem::transmute(&progid), ::core::mem::transmute(&querycriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1214,7 +1214,7 @@ impl IMultiInterfaceEventControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscriptions(::core::mem::transmute_copy(&eventiid), ::core::mem::transmute(&bstrmethodname), ::core::mem::transmute(&optionalcriteria), ::core::mem::transmute_copy(&optionalerrorindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1225,7 +1225,7 @@ impl IMultiInterfaceEventControl_Vtbl {
             let this = (*this).get_impl();
             match this.SetDefaultQuery(::core::mem::transmute_copy(&eventiid), ::core::mem::transmute(&bstrmethodname), ::core::mem::transmute(&bstrcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1236,7 +1236,7 @@ impl IMultiInterfaceEventControl_Vtbl {
             let this = (*this).get_impl();
             match this.AllowInprocActivation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallowinprocactivation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallowinprocactivation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1252,7 +1252,7 @@ impl IMultiInterfaceEventControl_Vtbl {
             let this = (*this).get_impl();
             match this.FireInParallel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pffireinparallel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pffireinparallel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
@@ -77,7 +77,7 @@ impl IMarshalingStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetMarshalingContextAttribute(::core::mem::transmute_copy(&attribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattributevalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattributevalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
@@ -64,7 +64,7 @@ impl IEnumSTATPROPSETSTG_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -111,7 +111,7 @@ impl IEnumSTATPROPSTG_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -161,7 +161,7 @@ impl IEnumSTATSTG_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -196,7 +196,7 @@ impl IFillLockBytes_Vtbl {
             let this = (*this).get_impl();
             match this.FillAppend(::core::mem::transmute_copy(&pv), ::core::mem::transmute_copy(&cb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -207,7 +207,7 @@ impl IFillLockBytes_Vtbl {
             let this = (*this).get_impl();
             match this.FillAt(::core::mem::transmute_copy(&uloffset), ::core::mem::transmute_copy(&pv), ::core::mem::transmute_copy(&cb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -308,7 +308,7 @@ impl ILockBytes_Vtbl {
             let this = (*this).get_impl();
             match this.WriteAt(::core::mem::transmute_copy(&uloffset), ::core::mem::transmute_copy(&pv), ::core::mem::transmute_copy(&cb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -466,7 +466,7 @@ impl IPropertyBag2_Vtbl {
             let this = (*this).get_impl();
             match this.CountProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -509,7 +509,7 @@ impl IPropertySetStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&rfmtid), ::core::mem::transmute_copy(&pclsid), ::core::mem::transmute_copy(&grfflags), ::core::mem::transmute_copy(&grfmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -520,7 +520,7 @@ impl IPropertySetStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Open(::core::mem::transmute_copy(&rfmtid), ::core::mem::transmute_copy(&grfmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -536,7 +536,7 @@ impl IPropertySetStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Enum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -619,7 +619,7 @@ impl IPropertyStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Enum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -640,7 +640,7 @@ impl IPropertyStorage_Vtbl {
             let this = (*this).get_impl();
             match this.Stat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatpsstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatpsstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -711,7 +711,7 @@ impl IStorage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStream(::core::mem::transmute(&pwcsname), ::core::mem::transmute_copy(&grfmode), ::core::mem::transmute_copy(&reserved1), ::core::mem::transmute_copy(&reserved2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -727,7 +727,7 @@ impl IStorage_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStorage(::core::mem::transmute(&pwcsname), ::core::mem::transmute_copy(&grfmode), ::core::mem::transmute_copy(&reserved1), ::core::mem::transmute_copy(&reserved2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -738,7 +738,7 @@ impl IStorage_Vtbl {
             let this = (*this).get_impl();
             match this.OpenStorage(::core::mem::transmute(&pwcsname), ::core::mem::transmute(&pstgpriority), ::core::mem::transmute_copy(&grfmode), ::core::mem::transmute_copy(&snbexclude), ::core::mem::transmute_copy(&reserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
@@ -9,7 +9,7 @@ impl IBindCallbackRedirect_Vtbl {
             let this = (*this).get_impl();
             match this.Redirect(::core::mem::transmute(&lpcurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *vbcancel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(vbcancel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32,7 +32,7 @@ impl IBindHttpSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.GetIgnoreCertMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwignorecertmask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwignorecertmask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -55,7 +55,7 @@ impl IBindProtocol_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBinding(::core::mem::transmute(&szurl), ::core::mem::transmute(&pbc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -79,7 +79,7 @@ impl ICatalogFileInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCatalogFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcatalogfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcatalogfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -166,7 +166,7 @@ impl IEncodingFilterFactory_Vtbl {
             let this = (*this).get_impl();
             match this.FindBestFilter(::core::mem::transmute(&pwzcodein), ::core::mem::transmute(&pwzcodeout), ::core::mem::transmute(&info)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -177,7 +177,7 @@ impl IEncodingFilterFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultFilter(::core::mem::transmute(&pwzcodein), ::core::mem::transmute(&pwzcodeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -207,7 +207,7 @@ impl IGetBindHandle_Vtbl {
             let this = (*this).get_impl();
             match this.GetBindHandle(::core::mem::transmute_copy(&enumrequestedhandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prethandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prethandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -231,7 +231,7 @@ impl IHttpNegotiate_Vtbl {
             let this = (*this).get_impl();
             match this.BeginningTransaction(::core::mem::transmute(&szurl), ::core::mem::transmute(&szheaders), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszadditionalheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszadditionalheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -242,7 +242,7 @@ impl IHttpNegotiate_Vtbl {
             let this = (*this).get_impl();
             match this.OnResponse(::core::mem::transmute_copy(&dwresponsecode), ::core::mem::transmute(&szresponseheaders), ::core::mem::transmute(&szrequestheaders)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszadditionalrequestheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszadditionalrequestheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -426,7 +426,7 @@ impl IInternetPriority_Vtbl {
             let this = (*this).get_impl();
             match this.GetPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -464,7 +464,7 @@ impl IInternetProtocol_Vtbl {
             let this = (*this).get_impl();
             match this.Seek(::core::mem::transmute_copy(&dlibmove), ::core::mem::transmute_copy(&dworigin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plibnewposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plibnewposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -709,7 +709,7 @@ impl IInternetSecurityManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecuritySite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -834,7 +834,7 @@ impl IInternetSecurityMgrSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1014,7 +1014,7 @@ impl IInternetZoneManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetZoneAt(::core::mem::transmute_copy(&dwenum), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwzone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwzone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1160,7 +1160,7 @@ impl IPersistMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.GetClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclassid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclassid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1191,7 +1191,7 @@ impl IPersistMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurMoniker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimkname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimkname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1267,7 +1267,7 @@ impl IUriBuilderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateIUriBuilder(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiuribuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiuribuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1278,7 +1278,7 @@ impl IUriBuilderFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInitializedIUriBuilder(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiuribuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiuribuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1305,7 +1305,7 @@ impl IUriContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetIUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1443,7 +1443,7 @@ impl IWindowForBindingUI_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow(::core::mem::transmute_copy(&rguidreason)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1485,7 +1485,7 @@ impl IZoneIdentifier_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwzone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwzone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1528,7 +1528,7 @@ impl IZoneIdentifier2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastWriterPackageFamilyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packagefamilyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packagefamilyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1549,7 +1549,7 @@ impl IZoneIdentifier2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAppZoneId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *zone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(zone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
@@ -330,7 +330,7 @@ impl IActivationFilter_Vtbl {
             let this = (*this).get_impl();
             match this.HandleActivation(::core::mem::transmute_copy(&dwactivationtype), ::core::mem::transmute_copy(&rclsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *preplacementclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preplacementclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -500,7 +500,7 @@ impl IAsyncManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstateflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstateflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -636,7 +636,7 @@ impl IBindCtx_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningObjectTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -652,7 +652,7 @@ impl IBindCtx_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectParam(::core::mem::transmute(&pszkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -663,7 +663,7 @@ impl IBindCtx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumObjectParam() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -752,7 +752,7 @@ impl IBindStatusCallback_Vtbl {
             let this = (*this).get_impl();
             match this.GetPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -860,7 +860,7 @@ impl IBinding_Vtbl {
             let this = (*this).get_impl();
             match this.GetPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -919,7 +919,7 @@ impl ICallFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCall(::core::mem::transmute_copy(&riid), ::core::mem::transmute(&pctrlunk), ::core::mem::transmute_copy(&riid2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -974,7 +974,7 @@ impl ICatInformation_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCategories(::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcategoryinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcategoryinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -985,7 +985,7 @@ impl ICatInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategoryDesc(::core::mem::transmute_copy(&rcatid), ::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -996,7 +996,7 @@ impl ICatInformation_Vtbl {
             let this = (*this).get_impl();
             match this.EnumClassesOfCategories(::core::mem::transmute_copy(&cimplemented), ::core::mem::transmute_copy(&rgcatidimpl), ::core::mem::transmute_copy(&crequired), ::core::mem::transmute_copy(&rgcatidreq)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1012,7 +1012,7 @@ impl ICatInformation_Vtbl {
             let this = (*this).get_impl();
             match this.EnumImplCategoriesOfClass(::core::mem::transmute_copy(&rclsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcatid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcatid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1023,7 +1023,7 @@ impl ICatInformation_Vtbl {
             let this = (*this).get_impl();
             match this.EnumReqCategoriesOfClass(::core::mem::transmute_copy(&rclsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumcatid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumcatid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1223,7 +1223,7 @@ impl IClientSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.CopyProxy(::core::mem::transmute(&pproxy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcopy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcopy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1254,7 +1254,7 @@ impl IComThreadingInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentApartmentType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *papttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(papttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1265,7 +1265,7 @@ impl IComThreadingInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pthreadtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pthreadtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1276,7 +1276,7 @@ impl IComThreadingInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentLogicalThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidlogicalthreadid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidlogicalthreadid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1314,7 +1314,7 @@ impl IConnectionPoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1325,7 +1325,7 @@ impl IConnectionPoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionPointContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcpc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcpc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1336,7 +1336,7 @@ impl IConnectionPoint_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&punksink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1352,7 +1352,7 @@ impl IConnectionPoint_Vtbl {
             let this = (*this).get_impl();
             match this.EnumConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1383,7 +1383,7 @@ impl IConnectionPointContainer_Vtbl {
             let this = (*this).get_impl();
             match this.EnumConnectionPoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1394,7 +1394,7 @@ impl IConnectionPointContainer_Vtbl {
             let this = (*this).get_impl();
             match this.FindConnectionPoint(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1441,7 +1441,7 @@ impl IDataAdviseHolder_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&pdataobject), ::core::mem::transmute_copy(&pfetc), ::core::mem::transmute_copy(&advf), ::core::mem::transmute(&padvise)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1457,7 +1457,7 @@ impl IDataAdviseHolder_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAdvise() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumadvise = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumadvise, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1502,7 +1502,7 @@ impl IDataObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetData(::core::mem::transmute_copy(&pformatetcin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmedium = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmedium, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1533,7 +1533,7 @@ impl IDataObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFormatEtc(::core::mem::transmute_copy(&dwdirection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumformatetc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumformatetc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1544,7 +1544,7 @@ impl IDataObject_Vtbl {
             let this = (*this).get_impl();
             match this.DAdvise(::core::mem::transmute_copy(&pformatetc), ::core::mem::transmute_copy(&advf), ::core::mem::transmute(&padvsink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1560,7 +1560,7 @@ impl IDataObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDAdvise() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumadvise = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumadvise, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1600,7 +1600,7 @@ impl IDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeInfoCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pctinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pctinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1611,7 +1611,7 @@ impl IDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeInfo(::core::mem::transmute_copy(&itinfo), ::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1668,7 +1668,7 @@ impl IEnumCATEGORYINFO_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1715,7 +1715,7 @@ impl IEnumConnectionPoints_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1762,7 +1762,7 @@ impl IEnumConnections_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1809,7 +1809,7 @@ impl IEnumFORMATETC_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1856,7 +1856,7 @@ impl IEnumGUID_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1903,7 +1903,7 @@ impl IEnumMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1950,7 +1950,7 @@ impl IEnumSTATDATA_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1997,7 +1997,7 @@ impl IEnumString_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2044,7 +2044,7 @@ impl IEnumUnknown_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2080,7 +2080,7 @@ impl IErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2091,7 +2091,7 @@ impl IErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2102,7 +2102,7 @@ impl IErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2113,7 +2113,7 @@ impl IErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelpFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrhelpfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrhelpfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2124,7 +2124,7 @@ impl IErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelpContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhelpcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhelpcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2233,7 +2233,7 @@ impl IGlobalInterfaceTable_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterInterfaceInGlobal(::core::mem::transmute(&punk), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2277,7 +2277,7 @@ impl IGlobalOptions_Vtbl {
             let this = (*this).get_impl();
             match this.Query(::core::mem::transmute_copy(&dwproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2360,7 +2360,7 @@ impl IMachineGlobalObjectTable_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterObject(::core::mem::transmute_copy(&clsid), ::core::mem::transmute(&identifier), ::core::mem::transmute(&object)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *token = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(token, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2585,7 +2585,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.ComposeWith(::core::mem::transmute(&pmkright), ::core::mem::transmute_copy(&fonlyifnotgeneric)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmkcomposite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmkcomposite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2596,7 +2596,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.Enum(::core::mem::transmute_copy(&fforward)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenummoniker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenummoniker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2612,7 +2612,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.Hash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2628,7 +2628,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeOfLastChange(::core::mem::transmute(&pbc), ::core::mem::transmute(&pmktoleft)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfiletime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfiletime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2639,7 +2639,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.Inverse() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2650,7 +2650,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.CommonPrefixWith(::core::mem::transmute(&pmkother)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmkprefix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmkprefix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2661,7 +2661,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.RelativePathTo(::core::mem::transmute(&pmkother)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmkrelpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmkrelpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2672,7 +2672,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName(::core::mem::transmute(&pbc), ::core::mem::transmute(&pmktoleft)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2688,7 +2688,7 @@ impl IMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.IsSystemMoniker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmksys = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmksys, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2788,7 +2788,7 @@ impl IPSFactoryBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStub(::core::mem::transmute_copy(&riid), ::core::mem::transmute(&punkserver)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2815,7 +2815,7 @@ impl IPersist_Vtbl {
             let this = (*this).get_impl();
             match this.GetClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclassid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclassid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2865,7 +2865,7 @@ impl IPersistFile_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2917,7 +2917,7 @@ impl IPersistMemory_Vtbl {
             let this = (*this).get_impl();
             match this.GetSizeMax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2973,7 +2973,7 @@ impl IPersistStream_Vtbl {
             let this = (*this).get_impl();
             match this.GetSizeMax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3024,7 +3024,7 @@ impl IPersistStreamInit_Vtbl {
             let this = (*this).get_impl();
             match this.GetSizeMax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3274,7 +3274,7 @@ impl IRpcChannelBuffer2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3328,7 +3328,7 @@ impl IRpcChannelBuffer3_Vtbl {
             let this = (*this).get_impl();
             match this.GetState(::core::mem::transmute_copy(&pmsg)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3366,7 +3366,7 @@ impl IRpcHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetDCOMProtocolVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcomversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcomversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3377,7 +3377,7 @@ impl IRpcHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetIIDFromOBJREF(::core::mem::transmute_copy(&pobjref)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3410,7 +3410,7 @@ impl IRpcOptions_Vtbl {
             let this = (*this).get_impl();
             match this.Query(::core::mem::transmute(&pprx), ::core::mem::transmute_copy(&dwproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3546,7 +3546,7 @@ impl IRunnableObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3605,7 +3605,7 @@ impl IRunningObjectTable_Vtbl {
             let this = (*this).get_impl();
             match this.Register(::core::mem::transmute_copy(&grfflags), ::core::mem::transmute(&punkobject), ::core::mem::transmute(&pmkobjectname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwregister = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwregister, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3626,7 +3626,7 @@ impl IRunningObjectTable_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject(::core::mem::transmute(&pmkobjectname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3642,7 +3642,7 @@ impl IRunningObjectTable_Vtbl {
             let this = (*this).get_impl();
             match this.GetTimeOfLastChange(::core::mem::transmute(&pmkobjectname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfiletime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfiletime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3653,7 +3653,7 @@ impl IRunningObjectTable_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRunning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenummoniker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenummoniker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3797,7 +3797,7 @@ impl IStream_Vtbl {
             let this = (*this).get_impl();
             match this.Seek(::core::mem::transmute_copy(&dlibmove), ::core::mem::transmute_copy(&dworigin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plibnewposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plibnewposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3843,7 +3843,7 @@ impl IStream_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3931,7 +3931,7 @@ impl ISurrogateService_Vtbl {
             let this = (*this).get_impl();
             match this.Init(::core::mem::transmute_copy(&rguidprocessid), ::core::mem::transmute(&pprocesslock)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfapplicationaware = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfapplicationaware, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4021,7 +4021,7 @@ impl ISynchronizeContainer_Vtbl {
             let this = (*this).get_impl();
             match this.WaitMultiple(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4071,7 +4071,7 @@ impl ISynchronizeHandle_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ph = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ph, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4179,7 +4179,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeAttr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptypeattr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptypeattr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4190,7 +4190,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeComp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptcomp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptcomp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4201,7 +4201,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFuncDesc(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfuncdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfuncdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4212,7 +4212,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetVarDesc(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvardesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvardesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4228,7 +4228,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetRefTypeOfImplType(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *preftype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preftype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4239,7 +4239,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplTypeFlags(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pimpltypeflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pimpltypeflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4270,7 +4270,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetRefTypeInfo(::core::mem::transmute_copy(&hreftype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4291,7 +4291,7 @@ impl ITypeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMops(::core::mem::transmute_copy(&memid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4372,7 +4372,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptypekind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptypekind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4383,7 +4383,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptypeflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptypeflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4394,7 +4394,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFuncIndexOfMemId(::core::mem::transmute_copy(&memid), ::core::mem::transmute_copy(&invkind)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfuncindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfuncindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4405,7 +4405,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetVarIndexOfMemId(::core::mem::transmute_copy(&memid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4416,7 +4416,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustData(::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4427,7 +4427,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFuncCustData(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4438,7 +4438,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetParamCustData(::core::mem::transmute_copy(&indexfunc), ::core::mem::transmute_copy(&indexparam), ::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4449,7 +4449,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetVarCustData(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4460,7 +4460,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplTypeCustData(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4476,7 +4476,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllCustData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcustdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcustdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4487,7 +4487,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllFuncCustData(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcustdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcustdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4498,7 +4498,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllParamCustData(::core::mem::transmute_copy(&indexfunc), ::core::mem::transmute_copy(&indexparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcustdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcustdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4509,7 +4509,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllVarCustData(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcustdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcustdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4520,7 +4520,7 @@ impl ITypeInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllImplTypeCustData(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcustdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcustdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4577,7 +4577,7 @@ impl ITypeLib_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeInfo(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4588,7 +4588,7 @@ impl ITypeLib_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeInfoType(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4599,7 +4599,7 @@ impl ITypeLib_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeInfoOfGuid(::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4610,7 +4610,7 @@ impl ITypeLib_Vtbl {
             let this = (*this).get_impl();
             match this.GetLibAttr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptlibattr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptlibattr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4621,7 +4621,7 @@ impl ITypeLib_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeComp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptcomp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptcomp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4682,7 +4682,7 @@ impl ITypeLib2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustData(::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4703,7 +4703,7 @@ impl ITypeLib2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllCustData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcustdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcustdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4742,7 +4742,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4753,7 +4753,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4764,7 +4764,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetLcid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4775,7 +4775,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetWin32Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwin32path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwin32path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4786,7 +4786,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetWin64Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwin64path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwin64path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4797,7 +4797,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4808,7 +4808,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4819,7 +4819,7 @@ impl ITypeLibRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelpDir() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phelpdir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phelpdir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4852,7 +4852,7 @@ impl ITypeLibRegistrationReader_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTypeLibRegistrations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4917,7 +4917,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.HasProperty(::core::mem::transmute_copy(&uriprop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfhasproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfhasproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4928,7 +4928,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetAbsoluteUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrabsoluteuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrabsoluteuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4939,7 +4939,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetAuthority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrauthority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrauthority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4950,7 +4950,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdisplaystring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdisplaystring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4961,7 +4961,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetDomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdomain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdomain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4972,7 +4972,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrextension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrextension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4983,7 +4983,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetFragment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfragment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfragment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4994,7 +4994,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetHost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrhost = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrhost, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5005,7 +5005,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetPassword() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpassword = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpassword, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5016,7 +5016,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5027,7 +5027,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetPathAndQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathandquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathandquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5038,7 +5038,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5049,7 +5049,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrrawuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrrawuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5060,7 +5060,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetSchemeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrschemename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrschemename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5071,7 +5071,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruserinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruserinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5082,7 +5082,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5093,7 +5093,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetHostType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhosttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhosttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5104,7 +5104,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5115,7 +5115,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetScheme() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwscheme = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwscheme, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5126,7 +5126,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetZone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwzone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwzone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5137,7 +5137,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5148,7 +5148,7 @@ impl IUri_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&puri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5223,7 +5223,7 @@ impl IUriBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUriSimple(::core::mem::transmute_copy(&dwallowencodingpropertymask), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5234,7 +5234,7 @@ impl IUriBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUri(::core::mem::transmute_copy(&dwcreateflags), ::core::mem::transmute_copy(&dwallowencodingpropertymask), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5245,7 +5245,7 @@ impl IUriBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUriWithFlags(::core::mem::transmute_copy(&dwcreateflags), ::core::mem::transmute_copy(&dwuribuilderflags), ::core::mem::transmute_copy(&dwallowencodingpropertymask), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5256,7 +5256,7 @@ impl IUriBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.GetIUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5357,7 +5357,7 @@ impl IUriBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.HasBeenModified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5423,7 +5423,7 @@ impl IWaitMultiple_Vtbl {
             let this = (*this).get_impl();
             match this.WaitMultiple(::core::mem::transmute_copy(&timeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
@@ -16,7 +16,7 @@ impl ContextInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisintx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisintx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27,7 +27,7 @@ impl ContextInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -38,7 +38,7 @@ impl ContextInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransactionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtxid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtxid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -49,7 +49,7 @@ impl ContextInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivityId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstractivityid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstractivityid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -60,7 +60,7 @@ impl ContextInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrctxid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrctxid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -95,7 +95,7 @@ impl ContextInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartitionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__contextinfo20000 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__contextinfo20000, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -106,7 +106,7 @@ impl ContextInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__contextinfo20001 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__contextinfo20001, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -117,7 +117,7 @@ impl ContextInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationInstanceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__contextinfo20002 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__contextinfo20002, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -178,7 +178,7 @@ impl IAssemblyLocator_Vtbl {
             let this = (*this).get_impl();
             match this.GetModules(::core::mem::transmute(&applicationdir), ::core::mem::transmute(&applicationname), ::core::mem::transmute(&assemblyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmodules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmodules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -246,7 +246,7 @@ impl ICOMAdminCatalog_Vtbl {
             let this = (*this).get_impl();
             match this.GetCollection(::core::mem::transmute(&bstrcollname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -257,7 +257,7 @@ impl ICOMAdminCatalog_Vtbl {
             let this = (*this).get_impl();
             match this.Connect(::core::mem::transmute(&bstrcatalogservername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -268,7 +268,7 @@ impl ICOMAdminCatalog_Vtbl {
             let this = (*this).get_impl();
             match this.MajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -279,7 +279,7 @@ impl ICOMAdminCatalog_Vtbl {
             let this = (*this).get_impl();
             match this.MinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -290,7 +290,7 @@ impl ICOMAdminCatalog_Vtbl {
             let this = (*this).get_impl();
             match this.GetCollectionByQuery(::core::mem::transmute(&bstrcollname), ::core::mem::transmute_copy(&ppsavarquery)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -386,7 +386,7 @@ impl ICOMAdminCatalog_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceCheck(::core::mem::transmute_copy(&lservice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -485,7 +485,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCollectionByQuery2(::core::mem::transmute(&bstrcollectionname), ::core::mem::transmute_copy(&pvarquerystrings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -496,7 +496,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationInstanceIDFromProcessID(::core::mem::transmute_copy(&lprocessid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrapplicationinstanceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrapplicationinstanceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -527,7 +527,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.AreApplicationInstancesPaused(::core::mem::transmute_copy(&pvarapplicationinstanceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarboolpaused = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarboolpaused, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -538,7 +538,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.DumpApplicationInstance(::core::mem::transmute(&bstrapplicationinstanceid), ::core::mem::transmute(&bstrdirectory), ::core::mem::transmute_copy(&lmaximages)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdumpfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdumpfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -549,7 +549,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.IsApplicationInstanceDumpSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbooldumpsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbooldumpsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -570,7 +570,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartitionID(::core::mem::transmute(&bstrapplicationidorname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpartitionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpartitionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -581,7 +581,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPartitionName(::core::mem::transmute(&bstrapplicationidorname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpartitionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpartitionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -597,7 +597,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPartitionID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpartitionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpartitionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -608,7 +608,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPartitionName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpartitionname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpartitionname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -619,7 +619,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.GlobalPartitionID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrglobalpartitionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrglobalpartitionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -655,7 +655,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.IsSafeToDelete(::core::mem::transmute(&bstrdllname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcomadmininuse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcomadmininuse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -681,7 +681,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.Is64BitCatalogServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbis64bit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbis64bit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -702,7 +702,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryApplicationFile2(::core::mem::transmute(&bstrapplicationfile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfilesforimport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfilesforimport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -713,7 +713,7 @@ impl ICOMAdminCatalog2_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentVersionCount(::core::mem::transmute(&bstrclsidorprogid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plversioncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plversioncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -828,7 +828,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -839,7 +839,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -850,7 +850,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plobjectcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plobjectcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -866,7 +866,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Add() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -882,7 +882,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.SaveChanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchanges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchanges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -893,7 +893,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCollection(::core::mem::transmute(&bstrcollname), ::core::mem::transmute(&varobjectkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -904,7 +904,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarnamel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarnamel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -915,7 +915,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.AddEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -926,7 +926,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.RemoveEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -937,7 +937,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetUtilInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidispatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidispatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -948,7 +948,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.DataStoreMajorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmajorversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmajorversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -959,7 +959,7 @@ impl ICatalogCollection_Vtbl {
             let this = (*this).get_impl();
             match this.DataStoreMinorVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plminorversionl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plminorversionl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1019,7 +1019,7 @@ impl ICatalogObject_Vtbl {
             let this = (*this).get_impl();
             match this.get_Value(::core::mem::transmute(&bstrpropname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1035,7 +1035,7 @@ impl ICatalogObject_Vtbl {
             let this = (*this).get_impl();
             match this.Key() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1046,7 +1046,7 @@ impl ICatalogObject_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1057,7 +1057,7 @@ impl ICatalogObject_Vtbl {
             let this = (*this).get_impl();
             match this.IsPropertyReadOnly(::core::mem::transmute(&bstrpropname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1068,7 +1068,7 @@ impl ICatalogObject_Vtbl {
             let this = (*this).get_impl();
             match this.Valid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1079,7 +1079,7 @@ impl ICatalogObject_Vtbl {
             let this = (*this).get_impl();
             match this.IsPropertyWriteOnly(::core::mem::transmute(&bstrpropname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1611,7 +1611,7 @@ impl IComMtaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.MTAGetMaxThreadCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxthreads = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxthreads, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1627,7 +1627,7 @@ impl IComMtaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.MTAGetThrottleValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwthrottle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwthrottle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2033,7 +2033,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.GetMinThreadCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minthreads = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minthreads, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2049,7 +2049,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxThreadCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *maxthreads = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(maxthreads, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2065,7 +2065,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivityPerThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *activitiesperthread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(activitiesperthread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2081,7 +2081,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivityRatio() {
                 ::core::result::Result::Ok(ok__) => {
-                    *activityratio = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(activityratio, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2092,7 +2092,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwthreads = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwthreads, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2103,7 +2103,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
             let this = (*this).get_impl();
             match this.GetQueueDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwqdepth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwqdepth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2156,7 +2156,7 @@ impl IComStaThreadPoolKnobs2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxCPULoad() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2172,7 +2172,7 @@ impl IComStaThreadPoolKnobs2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCPUMetricEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmetricenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmetricenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2188,7 +2188,7 @@ impl IComStaThreadPoolKnobs2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCreateThreadsAggressively() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbmetricenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbmetricenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2204,7 +2204,7 @@ impl IComStaThreadPoolKnobs2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxCSR() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcsr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcsr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2220,7 +2220,7 @@ impl IComStaThreadPoolKnobs2_Vtbl {
             let this = (*this).get_impl();
             match this.GetWaitTimeForThreadCleanup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwthreadcleanupwaittime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwthreadcleanupwaittime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2352,7 +2352,7 @@ impl IComTrackingInfoCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2363,7 +2363,7 @@ impl IComTrackingInfoCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2416,7 +2416,7 @@ impl IComTrackingInfoObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&szpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2440,7 +2440,7 @@ impl IComTrackingInfoProperties_Vtbl {
             let this = (*this).get_impl();
             match this.PropCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2451,7 +2451,7 @@ impl IComTrackingInfoProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropName(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpropname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpropname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2603,7 +2603,7 @@ impl IContextProperties_Vtbl {
             let this = (*this).get_impl();
             match this.EnumNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2793,7 +2793,7 @@ impl ICrmCompensator_Vtbl {
             let this = (*this).get_impl();
             match this.PrepareRecord(::core::mem::transmute(&crmlogrec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfforget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfforget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2804,7 +2804,7 @@ impl ICrmCompensator_Vtbl {
             let this = (*this).get_impl();
             match this.EndPrepare() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfoktoprepare = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfoktoprepare, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2820,7 +2820,7 @@ impl ICrmCompensator_Vtbl {
             let this = (*this).get_impl();
             match this.CommitRecord(::core::mem::transmute(&crmlogrec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfforget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfforget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2841,7 +2841,7 @@ impl ICrmCompensator_Vtbl {
             let this = (*this).get_impl();
             match this.AbortRecord(::core::mem::transmute(&crmlogrec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfforget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfforget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2903,7 +2903,7 @@ impl ICrmCompensatorVariants_Vtbl {
             let this = (*this).get_impl();
             match this.PrepareRecordVariants(::core::mem::transmute_copy(&plogrecord)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbforget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbforget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2914,7 +2914,7 @@ impl ICrmCompensatorVariants_Vtbl {
             let this = (*this).get_impl();
             match this.EndPrepareVariants() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pboktoprepare = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pboktoprepare, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2930,7 +2930,7 @@ impl ICrmCompensatorVariants_Vtbl {
             let this = (*this).get_impl();
             match this.CommitRecordVariants(::core::mem::transmute_copy(&plogrecord)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbforget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbforget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2951,7 +2951,7 @@ impl ICrmCompensatorVariants_Vtbl {
             let this = (*this).get_impl();
             match this.AbortRecordVariants(::core::mem::transmute_copy(&plogrecord)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbforget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbforget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2997,7 +2997,7 @@ impl ICrmFormatLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcolumncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcolumncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3008,7 +3008,7 @@ impl ICrmFormatLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pheaders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pheaders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3019,7 +3019,7 @@ impl ICrmFormatLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumn(::core::mem::transmute(&crmlogrec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformattedlogrecord = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformattedlogrecord, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3030,7 +3030,7 @@ impl ICrmFormatLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnVariants(::core::mem::transmute(&logrecord)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformattedlogrecord = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformattedlogrecord, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3068,7 +3068,7 @@ impl ICrmLogControl_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionUOW() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3134,7 +3134,7 @@ impl ICrmMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.GetClerks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclerks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclerks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3145,7 +3145,7 @@ impl ICrmMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.HoldClerk(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3181,7 +3181,7 @@ impl ICrmMonitorClerks_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3192,7 +3192,7 @@ impl ICrmMonitorClerks_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3203,7 +3203,7 @@ impl ICrmMonitorClerks_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3214,7 +3214,7 @@ impl ICrmMonitorClerks_Vtbl {
             let this = (*this).get_impl();
             match this.ProgIdCompensator(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3225,7 +3225,7 @@ impl ICrmMonitorClerks_Vtbl {
             let this = (*this).get_impl();
             match this.Description(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3236,7 +3236,7 @@ impl ICrmMonitorClerks_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionUOW(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3247,7 +3247,7 @@ impl ICrmMonitorClerks_Vtbl {
             let this = (*this).get_impl();
             match this.ActivityId(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3286,7 +3286,7 @@ impl ICrmMonitorLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3297,7 +3297,7 @@ impl ICrmMonitorLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3308,7 +3308,7 @@ impl ICrmMonitorLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.StructuredRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3324,7 +3324,7 @@ impl ICrmMonitorLogRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogRecordVariants(::core::mem::transmute(&indexnumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plogrecord = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plogrecord, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3413,7 +3413,7 @@ impl IDispenserManager_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterDispenser(::core::mem::transmute(&__midl__idispensermanager0000), ::core::mem::transmute(&szdispensername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__idispensermanager0001 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__idispensermanager0001, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3466,7 +3466,7 @@ impl IEnumNames_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3566,7 +3566,7 @@ impl IGetAppTrackerData_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrackerDataAsCollectionObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *toplevelcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(toplevelcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3577,7 +3577,7 @@ impl IGetAppTrackerData_Vtbl {
             let this = (*this).get_impl();
             match this.GetSuggestedPollingInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pollingintervalinseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pollingintervalinseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3624,7 +3624,7 @@ impl IGetContextProperties_Vtbl {
             let this = (*this).get_impl();
             match this.EnumNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3655,7 +3655,7 @@ impl IGetSecurityCallContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityCallContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3855,7 +3855,7 @@ impl IMTSLocator_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventDispatcher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3914,7 +3914,7 @@ impl IManagedObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetIUnknown() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3925,7 +3925,7 @@ impl IManagedObjectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetIObjectControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pctrl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pctrl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4010,7 +4010,7 @@ impl IMessageMover_Vtbl {
             let this = (*this).get_impl();
             match this.SourcePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4026,7 +4026,7 @@ impl IMessageMover_Vtbl {
             let this = (*this).get_impl();
             match this.DestPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4042,7 +4042,7 @@ impl IMessageMover_Vtbl {
             let this = (*this).get_impl();
             match this.CommitBatchSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4058,7 +4058,7 @@ impl IMessageMover_Vtbl {
             let this = (*this).get_impl();
             match this.MoveMessages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmessagesmoved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmessagesmoved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4097,7 +4097,7 @@ impl IMtsEventInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Names() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4108,7 +4108,7 @@ impl IMtsEventInfo_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4119,7 +4119,7 @@ impl IMtsEventInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EventID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sguideventid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sguideventid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4130,7 +4130,7 @@ impl IMtsEventInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4141,7 +4141,7 @@ impl IMtsEventInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_Value(::core::mem::transmute(&skey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4178,7 +4178,7 @@ impl IMtsEvents_Vtbl {
             let this = (*this).get_impl();
             match this.PackageName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4189,7 +4189,7 @@ impl IMtsEvents_Vtbl {
             let this = (*this).get_impl();
             match this.PackageGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4205,7 +4205,7 @@ impl IMtsEvents_Vtbl {
             let this = (*this).get_impl();
             match this.FireEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4216,7 +4216,7 @@ impl IMtsEvents_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4251,7 +4251,7 @@ impl IMtsGrp_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4262,7 +4262,7 @@ impl IMtsGrp_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdispatcher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdispatcher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4498,7 +4498,7 @@ impl IObjectContextInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptrans = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptrans, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4719,7 +4719,7 @@ impl ISecurityCallContext_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4730,7 +4730,7 @@ impl ISecurityCallContext_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4741,7 +4741,7 @@ impl ISecurityCallContext_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4752,7 +4752,7 @@ impl ISecurityCallContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsCallerInRole(::core::mem::transmute(&bstrrole)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4763,7 +4763,7 @@ impl ISecurityCallContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsSecurityEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4774,7 +4774,7 @@ impl ISecurityCallContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsUserInRole(::core::mem::transmute_copy(&puser), ::core::mem::transmute(&bstrrole)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4810,7 +4810,7 @@ impl ISecurityCallersColl_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4821,7 +4821,7 @@ impl ISecurityCallersColl_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4832,7 +4832,7 @@ impl ISecurityCallersColl_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4865,7 +4865,7 @@ impl ISecurityIdentityColl_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4876,7 +4876,7 @@ impl ISecurityIdentityColl_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4887,7 +4887,7 @@ impl ISecurityIdentityColl_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5250,7 +5250,7 @@ impl IServicePoolConfig_Vtbl {
             let this = (*this).get_impl();
             match this.ClassFactory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfactory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfactory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5472,7 +5472,7 @@ impl ISharedProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5515,7 +5515,7 @@ impl ISharedPropertyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.get_PropertyByPosition(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5531,7 +5531,7 @@ impl ISharedPropertyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.get_Property(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5570,7 +5570,7 @@ impl ISharedPropertyGroupManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_Group(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5581,7 +5581,7 @@ impl ISharedPropertyGroupManager_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5727,7 +5727,7 @@ impl ITransactionContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute(&pszprogid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5861,7 +5861,7 @@ impl ITransactionProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransactionResourcePool() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptxpool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptxpool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5963,7 +5963,7 @@ impl ITransactionProxy_Vtbl {
             let this = (*this).get_impl();
             match this.Promote() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5974,7 +5974,7 @@ impl ITransactionProxy_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVoter(::core::mem::transmute(&ptxasync)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppballot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppballot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6027,7 +6027,7 @@ impl ITransactionResourcePool_Vtbl {
             let this = (*this).get_impl();
             match this.GetResource(::core::mem::transmute(&ppool)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6113,7 +6113,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute(&bstrprogid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6144,7 +6144,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisintx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisintx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6155,7 +6155,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsSecurityEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6166,7 +6166,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsCallerInRole(::core::mem::transmute(&bstrrole)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbinrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbinrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6177,7 +6177,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6188,7 +6188,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6199,7 +6199,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6210,7 +6210,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.Security() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecurityproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecurityproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6221,7 +6221,7 @@ impl ObjectContext_Vtbl {
             let this = (*this).get_impl();
             match this.ContextInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontextinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontextinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6299,7 +6299,7 @@ impl SecurityProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectCallerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6310,7 +6310,7 @@ impl SecurityProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetDirectCreatorName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6321,7 +6321,7 @@ impl SecurityProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalCallerName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6332,7 +6332,7 @@ impl SecurityProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalCreatorName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
@@ -56,7 +56,7 @@ impl IContactAggregationAggregate_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcomponentitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcomponentitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -72,7 +72,7 @@ impl IContactAggregationAggregate_Vtbl {
             let this = (*this).get_impl();
             match this.get_Groups(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -83,7 +83,7 @@ impl IContactAggregationAggregate_Vtbl {
             let this = (*this).get_impl();
             match this.AntiLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppantilink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppantilink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -99,7 +99,7 @@ impl IContactAggregationAggregate_Vtbl {
             let this = (*this).get_impl();
             match this.FavoriteOrder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfavoriteorder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfavoriteorder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -115,7 +115,7 @@ impl IContactAggregationAggregate_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -152,7 +152,7 @@ impl IContactAggregationAggregateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirst() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaggregate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaggregate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -163,7 +163,7 @@ impl IContactAggregationAggregateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByAntiLinkId(::core::mem::transmute(&pantilinkid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaggregate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaggregate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -174,7 +174,7 @@ impl IContactAggregationAggregateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaggregate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaggregate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -185,7 +185,7 @@ impl IContactAggregationAggregateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -254,7 +254,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.AccountId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaccountid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaccountid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -270,7 +270,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.AggregateId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaggregateid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaggregateid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -281,7 +281,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -292,7 +292,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.IsMe() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisme = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisme, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -303,7 +303,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.IsExternal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisexternal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisexternal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkSourceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnetworksourceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnetworksourceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkSourceIdString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetworksourceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetworksourceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -346,7 +346,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppremoteobjectid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppremoteobjectid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -362,7 +362,7 @@ impl IContactAggregationContact_Vtbl {
             let this = (*this).get_impl();
             match this.SyncIdentityHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncidentityhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncidentityhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -414,7 +414,7 @@ impl IContactAggregationContactCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirst() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -425,7 +425,7 @@ impl IContactAggregationContactCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -436,7 +436,7 @@ impl IContactAggregationContactCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByIdentityHash(::core::mem::transmute(&psourcetype), ::core::mem::transmute(&paccountid), ::core::mem::transmute_copy(&pidentityhash)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -447,7 +447,7 @@ impl IContactAggregationContactCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -458,7 +458,7 @@ impl IContactAggregationContactCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByRemoteId(::core::mem::transmute(&psourcetype), ::core::mem::transmute(&paccountid), ::core::mem::transmute_copy(&premoteobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -517,7 +517,7 @@ impl IContactAggregationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Members() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaggregatecontactcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaggregatecontactcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -528,7 +528,7 @@ impl IContactAggregationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GlobalObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pglobalobjectid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pglobalobjectid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -544,7 +544,7 @@ impl IContactAggregationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -555,7 +555,7 @@ impl IContactAggregationGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -598,7 +598,7 @@ impl IContactAggregationGroupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirst() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -609,7 +609,7 @@ impl IContactAggregationGroupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByGlobalObjectId(::core::mem::transmute_copy(&pglobalobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -620,7 +620,7 @@ impl IContactAggregationGroupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -631,7 +631,7 @@ impl IContactAggregationGroupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -689,7 +689,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.AccountId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaccountid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaccountid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -705,7 +705,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -716,7 +716,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.IsLinkResolved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pislinkresolved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pislinkresolved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -732,7 +732,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkSourceIdString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetworksourceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetworksourceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -748,7 +748,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppremoteobjectid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppremoteobjectid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -764,7 +764,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.ServerPerson() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverpersonid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverpersonid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -780,7 +780,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.ServerPersonBaseline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverpersonid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverpersonid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -796,7 +796,7 @@ impl IContactAggregationLink_Vtbl {
             let this = (*this).get_impl();
             match this.SyncIdentityHash() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncidentityhash = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncidentityhash, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -846,7 +846,7 @@ impl IContactAggregationLinkCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirst() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservercontactlink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservercontactlink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -857,7 +857,7 @@ impl IContactAggregationLinkCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByRemoteId(::core::mem::transmute(&psourcetype), ::core::mem::transmute(&paccountid), ::core::mem::transmute_copy(&premoteid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservercontactlink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservercontactlink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -868,7 +868,7 @@ impl IContactAggregationLinkCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservercontactlink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservercontactlink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -879,7 +879,7 @@ impl IContactAggregationLinkCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -935,7 +935,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateExternalContact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -946,7 +946,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateServerPerson() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverperson = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverperson, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -957,7 +957,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateServerContactLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservercontactlink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservercontactlink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -973,7 +973,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.OpenAggregateContact(::core::mem::transmute(&pitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -984,7 +984,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.OpenContact(::core::mem::transmute(&pitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -995,7 +995,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.OpenServerContactLink(::core::mem::transmute(&pitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1006,7 +1006,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.OpenServerPerson(::core::mem::transmute(&pitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1017,7 +1017,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_Contacts(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1028,7 +1028,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_AggregateContacts(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaggregates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaggregates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1039,7 +1039,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_Groups(::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1050,7 +1050,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ServerPersons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverpersoncollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverpersoncollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1061,7 +1061,7 @@ impl IContactAggregationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_ServerContactLinks(::core::mem::transmute(&ppersonitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservercontactlinkcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservercontactlinkcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1136,7 +1136,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.AggregateId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaggregateid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaggregateid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1152,7 +1152,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.AntiLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppantilink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppantilink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1168,7 +1168,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.AntiLinkBaseline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppantilink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppantilink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1184,7 +1184,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.FavoriteOrder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfavoriteorder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfavoriteorder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1200,7 +1200,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.FavoriteOrderBaseline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfavoriteorder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfavoriteorder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1216,7 +1216,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.Groups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1232,7 +1232,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.GroupsBaseline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroups = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroups, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1248,7 +1248,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1259,7 +1259,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.IsTombstone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistombstone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistombstone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1275,7 +1275,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.LinkedAggregateId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplinkedaggregateid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplinkedaggregateid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1291,7 +1291,7 @@ impl IContactAggregationServerPerson_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjectid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjectid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1349,7 +1349,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirst() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverperson = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverperson, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1360,7 +1360,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByServerId(::core::mem::transmute(&pserverid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverperson = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverperson, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1371,7 +1371,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByAggregateId(::core::mem::transmute(&paggregateid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverperson = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverperson, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1382,7 +1382,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstByLinkedAggregateId(::core::mem::transmute(&paggregateid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverperson = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverperson, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1393,7 +1393,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
             let this = (*this).get_impl();
             match this.FindNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppserverperson = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppserverperson, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1404,7 +1404,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1447,7 +1447,7 @@ impl IContactCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1485,7 +1485,7 @@ impl IContactManager_Vtbl {
             let this = (*this).get_impl();
             match this.Load(::core::mem::transmute(&pszcontactid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1501,7 +1501,7 @@ impl IContactManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetMeContact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmecontact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmecontact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1517,7 +1517,7 @@ impl IContactManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetContactCollection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontactcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontactcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/impl.rs
@@ -15,7 +15,7 @@ impl IWdsTransportCacheable_Vtbl {
             let this = (*this).get_impl();
             match this.Dirty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdirty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdirty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -73,7 +73,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -84,7 +84,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -95,7 +95,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -106,7 +106,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.MacAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszmacaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszmacaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -117,7 +117,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.IpAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszipaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszipaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -128,7 +128,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.PercentCompletion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulpercentcompletion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulpercentcompletion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -139,7 +139,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.JoinDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puljoinduration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puljoinduration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -150,7 +150,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.CpuUtilization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcpuutilization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcpuutilization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -161,7 +161,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.MemoryUtilization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulmemoryutilization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulmemoryutilization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -172,7 +172,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkUtilization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulnetworkutilization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulnetworkutilization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -183,7 +183,7 @@ impl IWdsTransportClient_Vtbl {
             let this = (*this).get_impl();
             match this.UserIdentity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszuseridentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszuseridentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -230,7 +230,7 @@ impl IWdsTransportCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -241,7 +241,7 @@ impl IWdsTransportCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -252,7 +252,7 @@ impl IWdsTransportCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -291,7 +291,7 @@ impl IWdsTransportConfigurationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ServicePolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportservicepolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportservicepolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -302,7 +302,7 @@ impl IWdsTransportConfigurationManager_Vtbl {
             let this = (*this).get_impl();
             match this.DiagnosticsPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportdiagnosticspolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportdiagnosticspolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -313,7 +313,7 @@ impl IWdsTransportConfigurationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_WdsTransportServicesRunning(::core::mem::transmute_copy(&brealtimestatus)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbservicesrunning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbservicesrunning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -380,7 +380,7 @@ impl IWdsTransportConfigurationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.MulticastSessionPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportmulticastsessionpolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportmulticastsessionpolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -413,7 +413,7 @@ impl IWdsTransportContent_Vtbl {
             let this = (*this).get_impl();
             match this.Namespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -424,7 +424,7 @@ impl IWdsTransportContent_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -435,7 +435,7 @@ impl IWdsTransportContent_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -446,7 +446,7 @@ impl IWdsTransportContent_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveSessions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportsessions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportsessions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -487,7 +487,7 @@ impl IWdsTransportContentProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -498,7 +498,7 @@ impl IWdsTransportContentProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -509,7 +509,7 @@ impl IWdsTransportContentProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FilePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszfilepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszfilepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -520,7 +520,7 @@ impl IWdsTransportContentProvider_Vtbl {
             let this = (*this).get_impl();
             match this.InitializationRoutine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszinitializationroutine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszinitializationroutine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -555,7 +555,7 @@ impl IWdsTransportDiagnosticsPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -571,7 +571,7 @@ impl IWdsTransportDiagnosticsPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.Components() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcomponents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcomponents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -608,7 +608,7 @@ impl IWdsTransportManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetWdsTransportServer(::core::mem::transmute(&bszservername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -641,7 +641,7 @@ impl IWdsTransportMulticastSessionPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.SlowClientHandling() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pslowclienthandling = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pslowclienthandling, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -657,7 +657,7 @@ impl IWdsTransportMulticastSessionPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.AutoDisconnectThreshold() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulthreshold = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulthreshold, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -673,7 +673,7 @@ impl IWdsTransportMulticastSessionPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.MultistreamStreamCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstreamcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstreamcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -689,7 +689,7 @@ impl IWdsTransportMulticastSessionPolicy_Vtbl {
             let this = (*this).get_impl();
             match this.SlowClientFallback() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbclientfallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbclientfallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -750,7 +750,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -761,7 +761,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -772,7 +772,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -788,7 +788,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.FriendlyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -804,7 +804,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -820,7 +820,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.ContentProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszcontentprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszcontentprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -836,7 +836,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Configuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszconfiguration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszconfiguration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -852,7 +852,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Registered() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbregistered = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbregistered, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -863,7 +863,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Tombstoned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbtombstoned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbtombstoned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -874,7 +874,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.TombstoneTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptombstonetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptombstonetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -885,7 +885,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.TransmissionStarted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbtransmissionstarted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbtransmissionstarted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -906,7 +906,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportnamespaceclone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportnamespaceclone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -922,7 +922,7 @@ impl IWdsTransportNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveContents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportcontents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportcontents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -986,7 +986,7 @@ impl IWdsTransportNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNamespace(::core::mem::transmute_copy(&namespacetype), ::core::mem::transmute(&bsznamespacename), ::core::mem::transmute(&bszcontentprovider), ::core::mem::transmute(&bszconfiguration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -997,7 +997,7 @@ impl IWdsTransportNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveNamespace(::core::mem::transmute(&bsznamespacename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1008,7 +1008,7 @@ impl IWdsTransportNamespaceManager_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveNamespaces(::core::mem::transmute(&bszcontentprovider), ::core::mem::transmute(&bsznamespacename), ::core::mem::transmute_copy(&bincludetombstones)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportnamespaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportnamespaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1062,7 +1062,7 @@ impl IWdsTransportNamespaceScheduledCastAutoStart_Vtbl {
             let this = (*this).get_impl();
             match this.MinimumClients() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulminimumclients = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulminimumclients, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1078,7 +1078,7 @@ impl IWdsTransportNamespaceScheduledCastAutoStart_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstarttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstarttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1132,7 +1132,7 @@ impl IWdsTransportServer_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1143,7 +1143,7 @@ impl IWdsTransportServer_Vtbl {
             let this = (*this).get_impl();
             match this.SetupManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportsetupmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportsetupmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1154,7 +1154,7 @@ impl IWdsTransportServer_Vtbl {
             let this = (*this).get_impl();
             match this.ConfigurationManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportconfigurationmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportconfigurationmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1165,7 +1165,7 @@ impl IWdsTransportServer_Vtbl {
             let this = (*this).get_impl();
             match this.NamespaceManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportnamespacemanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportnamespacemanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1203,7 +1203,7 @@ impl IWdsTransportServer2_Vtbl {
             let this = (*this).get_impl();
             match this.TftpManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransporttftpmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransporttftpmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1240,7 +1240,7 @@ impl IWdsTransportServicePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.get_IpAddressSource(::core::mem::transmute_copy(&addresstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psourcetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psourcetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1256,7 +1256,7 @@ impl IWdsTransportServicePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.get_StartIpAddress(::core::mem::transmute_copy(&addresstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszstartipaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszstartipaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1272,7 +1272,7 @@ impl IWdsTransportServicePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.get_EndIpAddress(::core::mem::transmute_copy(&addresstype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszendipaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszendipaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1288,7 +1288,7 @@ impl IWdsTransportServicePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.StartPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulstartport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulstartport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1304,7 +1304,7 @@ impl IWdsTransportServicePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.EndPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulendport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulendport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1320,7 +1320,7 @@ impl IWdsTransportServicePolicy_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkProfile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprofiletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprofiletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1370,7 +1370,7 @@ impl IWdsTransportServicePolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.UdpPortPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pudpportpolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pudpportpolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1386,7 +1386,7 @@ impl IWdsTransportServicePolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.TftpMaximumBlockSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pultftpmaximumblocksize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pultftpmaximumblocksize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1402,7 +1402,7 @@ impl IWdsTransportServicePolicy2_Vtbl {
             let this = (*this).get_impl();
             match this.EnableTftpVariableWindowExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabletftpvariablewindowextension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabletftpvariablewindowextension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1448,7 +1448,7 @@ impl IWdsTransportSession_Vtbl {
             let this = (*this).get_impl();
             match this.Content() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportcontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportcontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1459,7 +1459,7 @@ impl IWdsTransportSession_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1470,7 +1470,7 @@ impl IWdsTransportSession_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkInterfaceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsznetworkinterfacename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsznetworkinterfacename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1481,7 +1481,7 @@ impl IWdsTransportSession_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkInterfaceAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsznetworkinterfaceaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsznetworkinterfaceaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1492,7 +1492,7 @@ impl IWdsTransportSession_Vtbl {
             let this = (*this).get_impl();
             match this.TransferRate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pultransferrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pultransferrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1503,7 +1503,7 @@ impl IWdsTransportSession_Vtbl {
             let this = (*this).get_impl();
             match this.MasterClientId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulmasterclientid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulmasterclientid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1514,7 +1514,7 @@ impl IWdsTransportSession_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveClients() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransportclients = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransportclients, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1559,7 +1559,7 @@ impl IWdsTransportSetupManager_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1570,7 +1570,7 @@ impl IWdsTransportSetupManager_Vtbl {
             let this = (*this).get_impl();
             match this.InstalledFeatures() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulinstalledfeatures = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulinstalledfeatures, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1581,7 +1581,7 @@ impl IWdsTransportSetupManager_Vtbl {
             let this = (*this).get_impl();
             match this.Protocols() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulprotocols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulprotocols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1625,7 +1625,7 @@ impl IWdsTransportSetupManager2_Vtbl {
             let this = (*this).get_impl();
             match this.TftpCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pultftpcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pultftpcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1636,7 +1636,7 @@ impl IWdsTransportSetupManager2_Vtbl {
             let this = (*this).get_impl();
             match this.ContentProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprovidercollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprovidercollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1672,7 +1672,7 @@ impl IWdsTransportTftpClient_Vtbl {
             let this = (*this).get_impl();
             match this.FileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1683,7 +1683,7 @@ impl IWdsTransportTftpClient_Vtbl {
             let this = (*this).get_impl();
             match this.IpAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbszipaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbszipaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1694,7 +1694,7 @@ impl IWdsTransportTftpClient_Vtbl {
             let this = (*this).get_impl();
             match this.Timeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pultimeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pultimeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1705,7 +1705,7 @@ impl IWdsTransportTftpClient_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFileOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pul64currentoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pul64currentoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1716,7 +1716,7 @@ impl IWdsTransportTftpClient_Vtbl {
             let this = (*this).get_impl();
             match this.FileSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pul64filesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pul64filesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1727,7 +1727,7 @@ impl IWdsTransportTftpClient_Vtbl {
             let this = (*this).get_impl();
             match this.BlockSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulblocksize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulblocksize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1738,7 +1738,7 @@ impl IWdsTransportTftpClient_Vtbl {
             let this = (*this).get_impl();
             match this.WindowSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulwindowsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulwindowsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1773,7 +1773,7 @@ impl IWdsTransportTftpManager_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveTftpClients() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwdstransporttftpclients = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwdstransporttftpclients, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
@@ -17,7 +17,7 @@ impl IRDPSRAPIApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Windows() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwindowlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwindowlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28,7 +28,7 @@ impl IRDPSRAPIApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -39,7 +39,7 @@ impl IRDPSRAPIApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Shared() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -55,7 +55,7 @@ impl IRDPSRAPIApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -66,7 +66,7 @@ impl IRDPSRAPIApplication_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -103,7 +103,7 @@ impl IRDPSRAPIApplicationFilter_Vtbl {
             let this = (*this).get_impl();
             match this.Applications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *papplications = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(papplications, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -114,7 +114,7 @@ impl IRDPSRAPIApplicationFilter_Vtbl {
             let this = (*this).get_impl();
             match this.Windows() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwindows = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwindows, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -125,7 +125,7 @@ impl IRDPSRAPIApplicationFilter_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -163,7 +163,7 @@ impl IRDPSRAPIApplicationList_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -174,7 +174,7 @@ impl IRDPSRAPIApplicationList_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *papplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(papplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -211,7 +211,7 @@ impl IRDPSRAPIAttendee_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -222,7 +222,7 @@ impl IRDPSRAPIAttendee_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -233,7 +233,7 @@ impl IRDPSRAPIAttendee_Vtbl {
             let this = (*this).get_impl();
             match this.ControlLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -249,7 +249,7 @@ impl IRDPSRAPIAttendee_Vtbl {
             let this = (*this).get_impl();
             match this.Invitation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl IRDPSRAPIAttendee_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -276,7 +276,7 @@ impl IRDPSRAPIAttendee_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectivityInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IRDPSRAPIAttendeeDisconnectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Attendee() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -325,7 +325,7 @@ impl IRDPSRAPIAttendeeDisconnectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Reason() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preason = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preason, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -336,7 +336,7 @@ impl IRDPSRAPIAttendeeDisconnectInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Code() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -368,7 +368,7 @@ impl IRDPSRAPIAttendeeManager_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -379,7 +379,7 @@ impl IRDPSRAPIAttendeeManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -410,7 +410,7 @@ impl IRDPSRAPIAudioStream_Vtbl {
             let this = (*this).get_impl();
             match this.Initialize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnperiodinhundrednsintervals = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnperiodinhundrednsintervals, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -463,7 +463,7 @@ impl IRDPSRAPIClipboardUseEvents_Vtbl {
             let this = (*this).get_impl();
             match this.OnPasteFromClipboard(::core::mem::transmute_copy(&clipboardformat), ::core::mem::transmute(&pattendee)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -495,7 +495,7 @@ impl IRDPSRAPIDebug_Vtbl {
             let this = (*this).get_impl();
             match this.CLXCmdLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclxcmdline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclxcmdline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -528,7 +528,7 @@ impl IRDPSRAPIFrameBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -539,7 +539,7 @@ impl IRDPSRAPIFrameBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -550,7 +550,7 @@ impl IRDPSRAPIFrameBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Bpp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbpp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbpp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -561,7 +561,7 @@ impl IRDPSRAPIFrameBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameBufferBits(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&heigth)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbits = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbits, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -599,7 +599,7 @@ impl IRDPSRAPIInvitation_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -610,7 +610,7 @@ impl IRDPSRAPIInvitation_Vtbl {
             let this = (*this).get_impl();
             match this.GroupName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -621,7 +621,7 @@ impl IRDPSRAPIInvitation_Vtbl {
             let this = (*this).get_impl();
             match this.Password() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -632,7 +632,7 @@ impl IRDPSRAPIInvitation_Vtbl {
             let this = (*this).get_impl();
             match this.AttendeeLimit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl IRDPSRAPIInvitation_Vtbl {
             let this = (*this).get_impl();
             match this.Revoked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -691,7 +691,7 @@ impl IRDPSRAPIInvitationManager_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -702,7 +702,7 @@ impl IRDPSRAPIInvitationManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinvitation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinvitation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -713,7 +713,7 @@ impl IRDPSRAPIInvitationManager_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -724,7 +724,7 @@ impl IRDPSRAPIInvitationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInvitation(::core::mem::transmute(&bstrauthstring), ::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&bstrpassword), ::core::mem::transmute_copy(&attendeelimit)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinvitation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinvitation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -773,7 +773,7 @@ impl IRDPSRAPIPerfCounterLoggingManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLogger(::core::mem::transmute(&bstrcountername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplogger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplogger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -800,7 +800,7 @@ impl IRDPSRAPISessionProperties_Vtbl {
             let this = (*this).get_impl();
             match this.get_Property(::core::mem::transmute(&propertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -863,7 +863,7 @@ impl IRDPSRAPISharingSession_Vtbl {
             let this = (*this).get_impl();
             match this.ColorDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolordepth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolordepth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -874,7 +874,7 @@ impl IRDPSRAPISharingSession_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -885,7 +885,7 @@ impl IRDPSRAPISharingSession_Vtbl {
             let this = (*this).get_impl();
             match this.Attendees() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -896,7 +896,7 @@ impl IRDPSRAPISharingSession_Vtbl {
             let this = (*this).get_impl();
             match this.Invitations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -907,7 +907,7 @@ impl IRDPSRAPISharingSession_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -918,7 +918,7 @@ impl IRDPSRAPISharingSession_Vtbl {
             let this = (*this).get_impl();
             match this.VirtualChannelManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -992,7 +992,7 @@ impl IRDPSRAPISharingSession2_Vtbl {
             let this = (*this).get_impl();
             match this.FrameBuffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1032,7 +1032,7 @@ impl IRDPSRAPITcpConnectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Protocol() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprotocol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprotocol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1043,7 +1043,7 @@ impl IRDPSRAPITcpConnectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LocalPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1054,7 +1054,7 @@ impl IRDPSRAPITcpConnectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LocalIP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsrlocalip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsrlocalip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1065,7 +1065,7 @@ impl IRDPSRAPITcpConnectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PeerPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1076,7 +1076,7 @@ impl IRDPSRAPITcpConnectionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PeerIP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1111,7 +1111,7 @@ impl IRDPSRAPITransportStream_Vtbl {
             let this = (*this).get_impl();
             match this.AllocBuffer(::core::mem::transmute_copy(&maxpayload)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuffer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuffer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1176,7 +1176,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Storage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbstorage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbstorage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1187,7 +1187,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.StorageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1198,7 +1198,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.PayloadSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1214,7 +1214,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.PayloadOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1230,7 +1230,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1246,7 +1246,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
             let this = (*this).get_impl();
             match this.Context() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1346,7 +1346,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.Attendees() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1357,7 +1357,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.Invitations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1368,7 +1368,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1379,7 +1379,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.VirtualChannelManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1395,7 +1395,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.SmartSizing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbsmartsizing = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbsmartsizing, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1416,7 +1416,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.DisconnectedText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdisconnectedtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdisconnectedtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1432,7 +1432,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1443,7 +1443,7 @@ impl IRDPSRAPIViewer_Vtbl {
             let this = (*this).get_impl();
             match this.StartReverseConnectListener(::core::mem::transmute(&bstrconnectionstring), ::core::mem::transmute(&bstrusername), ::core::mem::transmute(&bstrpassword)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrreverseconnectstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrreverseconnectstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1499,7 +1499,7 @@ impl IRDPSRAPIVirtualChannel_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1510,7 +1510,7 @@ impl IRDPSRAPIVirtualChannel_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1521,7 +1521,7 @@ impl IRDPSRAPIVirtualChannel_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1556,7 +1556,7 @@ impl IRDPSRAPIVirtualChannelManager_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1567,7 +1567,7 @@ impl IRDPSRAPIVirtualChannelManager_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1578,7 +1578,7 @@ impl IRDPSRAPIVirtualChannelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVirtualChannel(::core::mem::transmute(&bstrchannelname), ::core::mem::transmute_copy(&priority), ::core::mem::transmute_copy(&channelflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1615,7 +1615,7 @@ impl IRDPSRAPIWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1626,7 +1626,7 @@ impl IRDPSRAPIWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *papplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(papplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1637,7 +1637,7 @@ impl IRDPSRAPIWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Shared() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1653,7 +1653,7 @@ impl IRDPSRAPIWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1669,7 +1669,7 @@ impl IRDPSRAPIWindow_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1705,7 +1705,7 @@ impl IRDPSRAPIWindowList_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1716,7 +1716,7 @@ impl IRDPSRAPIWindowList_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&item)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/WebApp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/WebApp/impl.rs
@@ -29,7 +29,7 @@ impl IWebApplicationAuthoringMode_Vtbl {
             let this = (*this).get_impl();
             match this.AuthoringClientBinary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *designmodedllpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(designmodedllpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -67,7 +67,7 @@ impl IWebApplicationHost_Vtbl {
             let this = (*this).get_impl();
             match this.Document() {
                 ::core::result::Result::Ok(ok__) => {
-                    *htmldocument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(htmldocument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
@@ -134,7 +134,7 @@ impl IActiveScript_Vtbl {
             let this = (*this).get_impl();
             match this.GetScriptState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pssstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pssstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -160,7 +160,7 @@ impl IActiveScript_Vtbl {
             let this = (*this).get_impl();
             match this.GetScriptDispatch(::core::mem::transmute(&pstritemname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -171,7 +171,7 @@ impl IActiveScript_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentScriptThreadID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstidthread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstidthread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -182,7 +182,7 @@ impl IActiveScript_Vtbl {
             let this = (*this).get_impl();
             match this.GetScriptThreadID(::core::mem::transmute_copy(&dwwin32threadid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstidthread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstidthread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -193,7 +193,7 @@ impl IActiveScript_Vtbl {
             let this = (*this).get_impl();
             match this.GetScriptThreadState(::core::mem::transmute_copy(&stidthread)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstsstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstsstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -209,7 +209,7 @@ impl IActiveScript_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscript = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscript, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -288,7 +288,7 @@ impl IActiveScriptAuthor_Vtbl {
             let this = (*this).get_impl();
             match this.GetRoot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -299,7 +299,7 @@ impl IActiveScriptAuthor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguageFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgrfasa = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgrfasa, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -310,7 +310,7 @@ impl IActiveScriptAuthor_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventHandler(::core::mem::transmute(&pdisp), ::core::mem::transmute(&pszitem), ::core::mem::transmute(&pszsubitem), ::core::mem::transmute(&pszevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -336,7 +336,7 @@ impl IActiveScriptAuthor_Vtbl {
             let this = (*this).get_impl();
             match this.GetChars(::core::mem::transmute_copy(&frequestedlist)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrchars = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrchars, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -353,7 +353,7 @@ impl IActiveScriptAuthor_Vtbl {
             let this = (*this).get_impl();
             match this.IsCommitChar(::core::mem::transmute_copy(&ch)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcommit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcommit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -424,7 +424,7 @@ impl IActiveScriptDebug32_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCodeContextsOfPosition(::core::mem::transmute_copy(&dwsourcecontext), ::core::mem::transmute_copy(&ucharacteroffset), ::core::mem::transmute_copy(&unumchars)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppescc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppescc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -464,7 +464,7 @@ impl IActiveScriptDebug64_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCodeContextsOfPosition(::core::mem::transmute_copy(&dwsourcecontext), ::core::mem::transmute_copy(&ucharacteroffset), ::core::mem::transmute_copy(&unumchars)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppescc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppescc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -534,7 +534,7 @@ impl IActiveScriptError_Vtbl {
             let this = (*this).get_impl();
             match this.GetExceptionInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pexcepinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pexcepinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -550,7 +550,7 @@ impl IActiveScriptError_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceLineText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsourceline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsourceline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -602,7 +602,7 @@ impl IActiveScriptErrorDebug_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppssc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppssc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -613,7 +613,7 @@ impl IActiveScriptErrorDebug_Vtbl {
             let this = (*this).get_impl();
             match this.GetStackFrame() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdsf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdsf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -640,7 +640,7 @@ impl IActiveScriptErrorDebug110_Vtbl {
             let this = (*this).get_impl();
             match this.GetExceptionThrownKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pexceptionkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pexceptionkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -805,7 +805,7 @@ impl IActiveScriptParseProcedure32_Vtbl {
             let this = (*this).get_impl();
             match this.ParseProcedureText(::core::mem::transmute(&pstrcode), ::core::mem::transmute(&pstrformalparams), ::core::mem::transmute(&pstrprocedurename), ::core::mem::transmute(&pstritemname), ::core::mem::transmute(&punkcontext), ::core::mem::transmute(&pstrdelimiter), ::core::mem::transmute_copy(&dwsourcecontextcookie), ::core::mem::transmute_copy(&ulstartinglinenumber), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -831,7 +831,7 @@ impl IActiveScriptParseProcedure64_Vtbl {
             let this = (*this).get_impl();
             match this.ParseProcedureText(::core::mem::transmute(&pstrcode), ::core::mem::transmute(&pstrformalparams), ::core::mem::transmute(&pstrprocedurename), ::core::mem::transmute(&pstritemname), ::core::mem::transmute(&punkcontext), ::core::mem::transmute(&pstrdelimiter), ::core::mem::transmute_copy(&dwsourcecontextcookie), ::core::mem::transmute_copy(&ulstartinglinenumber), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -857,7 +857,7 @@ impl IActiveScriptParseProcedureOld32_Vtbl {
             let this = (*this).get_impl();
             match this.ParseProcedureText(::core::mem::transmute(&pstrcode), ::core::mem::transmute(&pstrformalparams), ::core::mem::transmute(&pstritemname), ::core::mem::transmute(&punkcontext), ::core::mem::transmute(&pstrdelimiter), ::core::mem::transmute_copy(&dwsourcecontextcookie), ::core::mem::transmute_copy(&ulstartinglinenumber), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -883,7 +883,7 @@ impl IActiveScriptParseProcedureOld64_Vtbl {
             let this = (*this).get_impl();
             match this.ParseProcedureText(::core::mem::transmute(&pstrcode), ::core::mem::transmute(&pstrformalparams), ::core::mem::transmute(&pstritemname), ::core::mem::transmute(&punkcontext), ::core::mem::transmute(&pstrdelimiter), ::core::mem::transmute_copy(&dwsourcecontextcookie), ::core::mem::transmute_copy(&ulstartinglinenumber), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1066,7 +1066,7 @@ impl IActiveScriptProfilerControl3_Vtbl {
             let this = (*this).get_impl();
             match this.EnumHeap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1106,7 +1106,7 @@ impl IActiveScriptProfilerControl5_Vtbl {
             let this = (*this).get_impl();
             match this.EnumHeap2(::core::mem::transmute_copy(&enumflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1177,7 +1177,7 @@ impl IActiveScriptProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&dwproperty), ::core::mem::transmute_copy(&pvarindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1209,7 +1209,7 @@ impl IActiveScriptSIPInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSIPOID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poid_sip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poid_sip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1242,7 +1242,7 @@ impl IActiveScriptSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetLCID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1258,7 +1258,7 @@ impl IActiveScriptSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocVersionString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1322,7 +1322,7 @@ impl IActiveScriptSiteDebug32_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentContextFromPosition(::core::mem::transmute_copy(&dwsourcecontext), ::core::mem::transmute_copy(&ucharacteroffset), ::core::mem::transmute_copy(&unumchars)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1333,7 +1333,7 @@ impl IActiveScriptSiteDebug32_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1344,7 +1344,7 @@ impl IActiveScriptSiteDebug32_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootApplicationNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdanroot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdanroot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1384,7 +1384,7 @@ impl IActiveScriptSiteDebug64_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentContextFromPosition(::core::mem::transmute_copy(&dwsourcecontext), ::core::mem::transmute_copy(&ucharacteroffset), ::core::mem::transmute_copy(&unumchars)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1395,7 +1395,7 @@ impl IActiveScriptSiteDebug64_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1406,7 +1406,7 @@ impl IActiveScriptSiteDebug64_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootApplicationNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdanroot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdanroot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1443,7 +1443,7 @@ impl IActiveScriptSiteDebugEx_Vtbl {
             let this = (*this).get_impl();
             match this.OnCanNotJITScriptErrorDebug(::core::mem::transmute(&perrordebug)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcallonscripterrorwhencontinuing = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcallonscripterrorwhencontinuing, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1503,7 +1503,7 @@ impl IActiveScriptSiteUIControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetUIBehavior(::core::mem::transmute_copy(&uicitem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puichandling = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puichandling, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1530,7 +1530,7 @@ impl IActiveScriptSiteWindow_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1599,7 +1599,7 @@ impl IActiveScriptStringCompare_Vtbl {
             let this = (*this).get_impl();
             match this.StrComp(::core::mem::transmute(&bszstr1), ::core::mem::transmute(&bszstr2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *iret = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iret, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1654,7 +1654,7 @@ impl IActiveScriptWinRTErrorDebug_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictedErrorString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *errorstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errorstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1665,7 +1665,7 @@ impl IActiveScriptWinRTErrorDebug_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictedErrorReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *referencestring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(referencestring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1676,7 +1676,7 @@ impl IActiveScriptWinRTErrorDebug_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilitySid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *capabilitysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(capabilitysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1714,7 +1714,7 @@ impl IApplicationDebugger_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstanceAtDebugger(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&dwclscontext), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1812,7 +1812,7 @@ impl ICodeAddressConcept_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainingSymbol(::core::mem::transmute(&pcontextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsymbol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsymbol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1835,7 +1835,7 @@ impl IComparableConcept_Vtbl {
             let this = (*this).get_impl();
             match this.CompareObjects(::core::mem::transmute(&contextobject), ::core::mem::transmute(&otherobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *comparisonresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(comparisonresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1867,7 +1867,7 @@ impl IDataModelConcept_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modelname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modelname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1921,7 +1921,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNoValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1932,7 +1932,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateErrorObject(::core::mem::transmute_copy(&hrerror), ::core::mem::transmute(&pwszmessage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1943,7 +1943,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypedObject(::core::mem::transmute(&context), ::core::mem::transmute(&objectlocation), ::core::mem::transmute(&objecttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1954,7 +1954,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypedObjectReference(::core::mem::transmute(&context), ::core::mem::transmute(&objectlocation), ::core::mem::transmute(&objecttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1965,7 +1965,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSyntheticObject(::core::mem::transmute(&context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1976,7 +1976,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDataModelObject(::core::mem::transmute(&datamodel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1987,7 +1987,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateIntrinsicObject(::core::mem::transmute_copy(&objectkind), ::core::mem::transmute_copy(&intrinsicdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1998,7 +1998,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypedIntrinsicObject(::core::mem::transmute_copy(&intrinsicdata), ::core::mem::transmute(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2009,7 +2009,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetModelForTypeSignature(::core::mem::transmute(&typesignature)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *datamodel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(datamodel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2045,7 +2045,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMetadataStore(::core::mem::transmute(&parentstore)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *metadatastore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(metadatastore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2056,7 +2056,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootNamespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rootnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rootnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2077,7 +2077,7 @@ impl IDataModelManager_Vtbl {
             let this = (*this).get_impl();
             match this.AcquireNamedModel(::core::mem::transmute(&modelname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *modelobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modelobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2126,7 +2126,7 @@ impl IDataModelManager2_Vtbl {
             let this = (*this).get_impl();
             match this.AcquireSubNamespace(::core::mem::transmute(&modelname), ::core::mem::transmute(&subnamespacemodelname), ::core::mem::transmute(&accessname), ::core::mem::transmute(&metadata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespacemodelobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespacemodelobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2137,7 +2137,7 @@ impl IDataModelManager2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypedIntrinsicObjectEx(::core::mem::transmute(&context), ::core::mem::transmute_copy(&intrinsicdata), ::core::mem::transmute(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2177,7 +2177,7 @@ impl IDataModelNameBinder_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateValues(::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2188,7 +2188,7 @@ impl IDataModelNameBinder_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateReferences(::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2226,7 +2226,7 @@ impl IDataModelScript_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scriptname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scriptname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2257,7 +2257,7 @@ impl IDataModelScript_Vtbl {
             let this = (*this).get_impl();
             match this.IsInvocable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isinvocable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isinvocable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2333,7 +2333,7 @@ impl IDataModelScriptDebug_Vtbl {
             let this = (*this).get_impl();
             match this.GetStack() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stack = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stack, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2344,7 +2344,7 @@ impl IDataModelScriptDebug_Vtbl {
             let this = (*this).get_impl();
             match this.SetBreakpoint(::core::mem::transmute_copy(&lineposition), ::core::mem::transmute_copy(&columnposition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *breakpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(breakpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2355,7 +2355,7 @@ impl IDataModelScriptDebug_Vtbl {
             let this = (*this).get_impl();
             match this.FindBreakpointById(::core::mem::transmute_copy(&breakpointid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *breakpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(breakpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2366,7 +2366,7 @@ impl IDataModelScriptDebug_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *breakpointenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(breakpointenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2377,7 +2377,7 @@ impl IDataModelScriptDebug_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventFilter(::core::mem::transmute_copy(&eventfilter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isbreakenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isbreakenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2430,7 +2430,7 @@ impl IDataModelScriptDebug2_Vtbl {
             let this = (*this).get_impl();
             match this.SetBreakpointAtFunction(::core::mem::transmute(&functionname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *breakpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(breakpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2517,7 +2517,7 @@ impl IDataModelScriptDebugBreakpointEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *breakpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(breakpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2567,7 +2567,7 @@ impl IDataModelScriptDebugStack_Vtbl {
             let this = (*this).get_impl();
             match this.GetStackFrame(::core::mem::transmute_copy(&framenumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stackframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stackframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2603,7 +2603,7 @@ impl IDataModelScriptDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2619,7 +2619,7 @@ impl IDataModelScriptDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransitionPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *istransitionpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(istransitionpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2635,7 +2635,7 @@ impl IDataModelScriptDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.Evaluate(::core::mem::transmute(&pwszexpression)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2646,7 +2646,7 @@ impl IDataModelScriptDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateLocals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *variablesenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variablesenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2657,7 +2657,7 @@ impl IDataModelScriptDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateArguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *variablesenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variablesenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2725,7 +2725,7 @@ impl IDataModelScriptHostContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamespaceObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaceobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaceobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2757,7 +2757,7 @@ impl IDataModelScriptManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultNameBinder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamebinder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamebinder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2778,7 +2778,7 @@ impl IDataModelScriptManager_Vtbl {
             let this = (*this).get_impl();
             match this.FindProviderForScriptType(::core::mem::transmute(&scripttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *provider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(provider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2789,7 +2789,7 @@ impl IDataModelScriptManager_Vtbl {
             let this = (*this).get_impl();
             match this.FindProviderForScriptExtension(::core::mem::transmute(&scriptextension)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *provider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(provider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2800,7 +2800,7 @@ impl IDataModelScriptManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateScriptProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2838,7 +2838,7 @@ impl IDataModelScriptProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2849,7 +2849,7 @@ impl IDataModelScriptProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *extension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(extension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2860,7 +2860,7 @@ impl IDataModelScriptProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateScript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *script = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(script, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2871,7 +2871,7 @@ impl IDataModelScriptProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultTemplateContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *templatecontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(templatecontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2882,7 +2882,7 @@ impl IDataModelScriptProvider_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateTemplates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2918,7 +2918,7 @@ impl IDataModelScriptProviderEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *provider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(provider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2950,7 +2950,7 @@ impl IDataModelScriptTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *templatename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(templatename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2961,7 +2961,7 @@ impl IDataModelScriptTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *templatedescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(templatedescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2972,7 +2972,7 @@ impl IDataModelScriptTemplate_Vtbl {
             let this = (*this).get_impl();
             match this.GetContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3006,7 +3006,7 @@ impl IDataModelScriptTemplateEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *templatecontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(templatecontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3310,7 +3310,7 @@ impl IDebugApplication11032_Vtbl {
             let this = (*this).get_impl();
             match this.CallableWaitForHandles(::core::mem::transmute_copy(&handlecount), ::core::mem::transmute_copy(&phandles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3353,7 +3353,7 @@ impl IDebugApplication11064_Vtbl {
             let this = (*this).get_impl();
             match this.CallableWaitForHandles(::core::mem::transmute_copy(&handlecount), ::core::mem::transmute_copy(&phandles)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3423,7 +3423,7 @@ impl IDebugApplication32_Vtbl {
             let this = (*this).get_impl();
             match this.HandleBreakPoint(::core::mem::transmute_copy(&br)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbra = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbra, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3444,7 +3444,7 @@ impl IDebugApplication32_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3455,7 +3455,7 @@ impl IDebugApplication32_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAsyncDebugOperation(::core::mem::transmute(&psdo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppado = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppado, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3466,7 +3466,7 @@ impl IDebugApplication32_Vtbl {
             let this = (*this).get_impl();
             match this.AddStackFrameSniffer(::core::mem::transmute(&pdsfs)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3492,7 +3492,7 @@ impl IDebugApplication32_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplicationNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdannew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdannew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl IDebugApplication32_Vtbl {
             let this = (*this).get_impl();
             match this.AddGlobalExpressionContextProvider(::core::mem::transmute(&pdsfs)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3615,7 +3615,7 @@ impl IDebugApplication64_Vtbl {
             let this = (*this).get_impl();
             match this.HandleBreakPoint(::core::mem::transmute_copy(&br)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbra = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbra, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3636,7 +3636,7 @@ impl IDebugApplication64_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3647,7 +3647,7 @@ impl IDebugApplication64_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAsyncDebugOperation(::core::mem::transmute(&psdo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppado = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppado, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3658,7 +3658,7 @@ impl IDebugApplication64_Vtbl {
             let this = (*this).get_impl();
             match this.AddStackFrameSniffer(::core::mem::transmute(&pdsfs)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3684,7 +3684,7 @@ impl IDebugApplication64_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplicationNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdannew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdannew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3715,7 +3715,7 @@ impl IDebugApplication64_Vtbl {
             let this = (*this).get_impl();
             match this.AddGlobalExpressionContextProvider(::core::mem::transmute(&pdsfs)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3773,7 +3773,7 @@ impl IDebugApplicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.EnumChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperddp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperddp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3784,7 +3784,7 @@ impl IDebugApplicationNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprddp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprddp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3842,7 +3842,7 @@ impl IDebugApplicationNode100_Vtbl {
             let this = (*this).get_impl();
             match this.GetExcludedDocuments(::core::mem::transmute_copy(&filter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdocuments = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdocuments, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3973,7 +3973,7 @@ impl IDebugApplicationThread11032_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveThreadRequestCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puithreadrequests = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puithreadrequests, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3984,7 +3984,7 @@ impl IDebugApplicationThread11032_Vtbl {
             let this = (*this).get_impl();
             match this.IsSuspendedForBreakPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfissuspended = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfissuspended, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3995,7 +3995,7 @@ impl IDebugApplicationThread11032_Vtbl {
             let this = (*this).get_impl();
             match this.IsThreadCallable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfiscallable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfiscallable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4035,7 +4035,7 @@ impl IDebugApplicationThread11064_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveThreadRequestCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puithreadrequests = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puithreadrequests, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4046,7 +4046,7 @@ impl IDebugApplicationThread11064_Vtbl {
             let this = (*this).get_impl();
             match this.IsSuspendedForBreakPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfissuspended = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfissuspended, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4057,7 +4057,7 @@ impl IDebugApplicationThread11064_Vtbl {
             let this = (*this).get_impl();
             match this.IsThreadCallable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfiscallable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfiscallable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4159,7 +4159,7 @@ impl IDebugAsyncOperation_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncDebugOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4246,7 +4246,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4262,7 +4262,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *adder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(adder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4273,7 +4273,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4299,7 +4299,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4325,7 +4325,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetPassCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4341,7 +4341,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPassCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4352,7 +4352,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4388,7 +4388,7 @@ impl IDebugBreakpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *params = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(params, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4458,7 +4458,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4474,7 +4474,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *adder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(adder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4485,7 +4485,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4511,7 +4511,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4537,7 +4537,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPassCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4553,7 +4553,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPassCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4564,7 +4564,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4600,7 +4600,7 @@ impl IDebugBreakpoint2_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *params = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(params, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4695,7 +4695,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4711,7 +4711,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *adder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(adder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4722,7 +4722,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4748,7 +4748,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4774,7 +4774,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetPassCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4790,7 +4790,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPassCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4801,7 +4801,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetMatchThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4837,7 +4837,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *params = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(params, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4868,7 +4868,7 @@ impl IDebugBreakpoint3_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4983,7 +4983,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5004,7 +5004,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5035,7 +5035,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5101,7 +5101,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5122,7 +5122,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5133,7 +5133,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5149,7 +5149,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5165,7 +5165,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5181,7 +5181,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5197,7 +5197,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5233,7 +5233,7 @@ impl IDebugClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5385,7 +5385,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5406,7 +5406,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5437,7 +5437,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5503,7 +5503,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5524,7 +5524,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5535,7 +5535,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5551,7 +5551,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5567,7 +5567,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5583,7 +5583,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5599,7 +5599,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5635,7 +5635,7 @@ impl IDebugClient2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5839,7 +5839,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5860,7 +5860,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5891,7 +5891,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5957,7 +5957,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5978,7 +5978,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5989,7 +5989,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6005,7 +6005,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6021,7 +6021,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6037,7 +6037,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6053,7 +6053,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6089,7 +6089,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6150,7 +6150,7 @@ impl IDebugClient3_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableNameWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6329,7 +6329,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6350,7 +6350,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6381,7 +6381,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6447,7 +6447,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6468,7 +6468,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6479,7 +6479,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6495,7 +6495,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6511,7 +6511,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6527,7 +6527,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6543,7 +6543,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6579,7 +6579,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6640,7 +6640,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableNameWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6681,7 +6681,7 @@ impl IDebugClient4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberDumpFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6890,7 +6890,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6911,7 +6911,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6942,7 +6942,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7008,7 +7008,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7029,7 +7029,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7040,7 +7040,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7056,7 +7056,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7072,7 +7072,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7088,7 +7088,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7104,7 +7104,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7140,7 +7140,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7201,7 +7201,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableNameWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7242,7 +7242,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberDumpFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7283,7 +7283,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServerWide(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7304,7 +7304,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7340,7 +7340,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7376,7 +7376,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefix(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7387,7 +7387,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefixWide(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7403,7 +7403,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7414,7 +7414,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7425,7 +7425,7 @@ impl IDebugClient5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEventCallbacks(::core::mem::transmute_copy(&eventflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7674,7 +7674,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7695,7 +7695,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7726,7 +7726,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7792,7 +7792,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7813,7 +7813,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7824,7 +7824,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7840,7 +7840,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7856,7 +7856,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7872,7 +7872,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7888,7 +7888,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7924,7 +7924,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7985,7 +7985,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableNameWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8026,7 +8026,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberDumpFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8067,7 +8067,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServerWide(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8088,7 +8088,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8124,7 +8124,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8160,7 +8160,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefix(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8171,7 +8171,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefixWide(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8187,7 +8187,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8198,7 +8198,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8209,7 +8209,7 @@ impl IDebugClient6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEventCallbacks(::core::mem::transmute_copy(&eventflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8465,7 +8465,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8486,7 +8486,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8517,7 +8517,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8583,7 +8583,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8604,7 +8604,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8615,7 +8615,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8631,7 +8631,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8647,7 +8647,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8663,7 +8663,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8679,7 +8679,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8715,7 +8715,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8776,7 +8776,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableNameWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8817,7 +8817,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberDumpFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8858,7 +8858,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServerWide(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8879,7 +8879,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8915,7 +8915,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8951,7 +8951,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefix(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8962,7 +8962,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefixWide(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8978,7 +8978,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8989,7 +8989,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9000,7 +9000,7 @@ impl IDebugClient7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEventCallbacks(::core::mem::transmute_copy(&eventflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9263,7 +9263,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServer(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9284,7 +9284,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableName(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9315,7 +9315,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9381,7 +9381,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *code = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(code, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9402,7 +9402,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *client = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(client, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9413,7 +9413,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9429,7 +9429,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9445,7 +9445,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9461,7 +9461,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetOtherOutputMask(::core::mem::transmute(&client)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9477,7 +9477,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9513,7 +9513,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9574,7 +9574,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningProcessSystemIdByExecutableNameWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&exename), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9615,7 +9615,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberDumpFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9656,7 +9656,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectProcessServerWide(::core::mem::transmute(&remoteoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9677,7 +9677,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9713,7 +9713,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCallbacksWide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *callbacks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(callbacks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9749,7 +9749,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefix(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9760,7 +9760,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.PushOutputLinePrefixWide(::core::mem::transmute(&newprefix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9776,7 +9776,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberInputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9787,7 +9787,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOutputCallbacks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9798,7 +9798,7 @@ impl IDebugClient8_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEventCallbacks(::core::mem::transmute_copy(&eventflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9954,7 +9954,7 @@ impl IDebugCodeContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10090,7 +10090,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterruptTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10121,7 +10121,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10192,7 +10192,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10208,7 +10208,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.Assemble(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10224,7 +10224,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisassembleEffectiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10235,7 +10235,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.OutputDisassembly(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10251,7 +10251,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNearInstruction(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&delta)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nearoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nearoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10267,7 +10267,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10288,7 +10288,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10299,7 +10299,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutingProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10310,7 +10310,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPossibleExecutingProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10326,7 +10326,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcessors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10343,7 +10343,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10364,7 +10364,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSupportedProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10385,7 +10385,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectiveProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10401,7 +10401,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10417,7 +10417,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10433,7 +10433,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngineOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10479,7 +10479,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10500,7 +10500,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.CoerceValue(::core::mem::transmute_copy(&r#in), ::core::mem::transmute_copy(&outtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10526,7 +10526,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10537,7 +10537,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10548,7 +10548,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10564,7 +10564,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10580,7 +10580,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtension(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10596,7 +10596,7 @@ impl IDebugControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10915,7 +10915,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterruptTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10946,7 +10946,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11017,7 +11017,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11033,7 +11033,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.Assemble(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11049,7 +11049,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisassembleEffectiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11060,7 +11060,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.OutputDisassembly(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11076,7 +11076,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNearInstruction(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&delta)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nearoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nearoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11092,7 +11092,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11113,7 +11113,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11124,7 +11124,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutingProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11135,7 +11135,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPossibleExecutingProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11151,7 +11151,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcessors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11168,7 +11168,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11189,7 +11189,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSupportedProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11210,7 +11210,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectiveProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11226,7 +11226,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11242,7 +11242,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11258,7 +11258,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngineOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11304,7 +11304,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11325,7 +11325,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.CoerceValue(::core::mem::transmute_copy(&r#in), ::core::mem::transmute_copy(&outtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11351,7 +11351,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11362,7 +11362,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11373,7 +11373,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11389,7 +11389,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11405,7 +11405,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtension(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11421,7 +11421,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11522,7 +11522,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTimeDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timedate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timedate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11533,7 +11533,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11544,7 +11544,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDumpFormatFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formatflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formatflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11555,7 +11555,7 @@ impl IDebugControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberTextReplacements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numrepl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numrepl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11825,7 +11825,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterruptTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11856,7 +11856,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11927,7 +11927,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11943,7 +11943,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.Assemble(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11959,7 +11959,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisassembleEffectiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11970,7 +11970,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.OutputDisassembly(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11986,7 +11986,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNearInstruction(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&delta)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nearoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nearoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12002,7 +12002,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12023,7 +12023,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12034,7 +12034,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutingProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12045,7 +12045,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPossibleExecutingProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12061,7 +12061,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcessors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12078,7 +12078,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12099,7 +12099,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSupportedProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12120,7 +12120,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectiveProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12136,7 +12136,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12152,7 +12152,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12168,7 +12168,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngineOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12214,7 +12214,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12235,7 +12235,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.CoerceValue(::core::mem::transmute_copy(&r#in), ::core::mem::transmute_copy(&outtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12261,7 +12261,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12272,7 +12272,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12283,7 +12283,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12299,7 +12299,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12315,7 +12315,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtension(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12331,7 +12331,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12432,7 +12432,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTimeDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timedate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timedate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12443,7 +12443,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12454,7 +12454,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetDumpFormatFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formatflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formatflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12465,7 +12465,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberTextReplacements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numrepl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numrepl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12496,7 +12496,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetAssemblyOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12522,7 +12522,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpressionSyntax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12543,7 +12543,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberExpressionSyntaxes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12559,7 +12559,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *events = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(events, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12570,7 +12570,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescription(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12581,7 +12581,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentEventIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12592,7 +12592,7 @@ impl IDebugControl3_Vtbl {
             let this = (*this).get_impl();
             match this.SetNextEventIndex(::core::mem::transmute_copy(&relation), ::core::mem::transmute_copy(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12908,7 +12908,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterruptTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12939,7 +12939,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13010,7 +13010,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13026,7 +13026,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.Assemble(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13042,7 +13042,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisassembleEffectiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13053,7 +13053,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.OutputDisassembly(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13069,7 +13069,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNearInstruction(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&delta)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nearoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nearoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13085,7 +13085,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13106,7 +13106,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13117,7 +13117,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutingProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13128,7 +13128,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPossibleExecutingProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13144,7 +13144,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcessors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13161,7 +13161,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13182,7 +13182,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSupportedProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13203,7 +13203,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectiveProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13219,7 +13219,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13235,7 +13235,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13251,7 +13251,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngineOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13297,7 +13297,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13318,7 +13318,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.CoerceValue(::core::mem::transmute_copy(&r#in), ::core::mem::transmute_copy(&outtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13344,7 +13344,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13355,7 +13355,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13366,7 +13366,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13382,7 +13382,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13398,7 +13398,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtension(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13414,7 +13414,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13515,7 +13515,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTimeDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timedate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timedate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13526,7 +13526,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13537,7 +13537,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetDumpFormatFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formatflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formatflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13548,7 +13548,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberTextReplacements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numrepl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numrepl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13579,7 +13579,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetAssemblyOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13605,7 +13605,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpressionSyntax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13626,7 +13626,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberExpressionSyntaxes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13642,7 +13642,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *events = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(events, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13653,7 +13653,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescription(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13664,7 +13664,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentEventIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13675,7 +13675,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.SetNextEventIndex(::core::mem::transmute_copy(&relation), ::core::mem::transmute_copy(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13741,7 +13741,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.AssembleWide(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13787,7 +13787,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex2(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13798,7 +13798,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById2(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13809,7 +13809,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint2(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13825,7 +13825,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtensionWide(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13836,7 +13836,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPathWide(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13917,7 +13917,7 @@ impl IDebugControl4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescriptionWide(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14356,7 +14356,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterruptTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14387,7 +14387,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14458,7 +14458,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14474,7 +14474,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.Assemble(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14490,7 +14490,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisassembleEffectiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14501,7 +14501,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.OutputDisassembly(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14517,7 +14517,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNearInstruction(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&delta)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nearoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nearoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14533,7 +14533,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14554,7 +14554,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14565,7 +14565,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutingProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14576,7 +14576,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPossibleExecutingProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14592,7 +14592,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcessors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14609,7 +14609,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14630,7 +14630,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSupportedProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14651,7 +14651,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectiveProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14667,7 +14667,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14683,7 +14683,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14699,7 +14699,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngineOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14745,7 +14745,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14766,7 +14766,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.CoerceValue(::core::mem::transmute_copy(&r#in), ::core::mem::transmute_copy(&outtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14792,7 +14792,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14803,7 +14803,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14814,7 +14814,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14830,7 +14830,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14846,7 +14846,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtension(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14862,7 +14862,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14963,7 +14963,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTimeDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timedate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timedate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14974,7 +14974,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14985,7 +14985,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetDumpFormatFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formatflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formatflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14996,7 +14996,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberTextReplacements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numrepl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numrepl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15027,7 +15027,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetAssemblyOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15053,7 +15053,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpressionSyntax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15074,7 +15074,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberExpressionSyntaxes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15090,7 +15090,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *events = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(events, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15101,7 +15101,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescription(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15112,7 +15112,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentEventIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15123,7 +15123,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.SetNextEventIndex(::core::mem::transmute_copy(&relation), ::core::mem::transmute_copy(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15189,7 +15189,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.AssembleWide(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15235,7 +15235,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex2(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15246,7 +15246,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById2(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15257,7 +15257,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint2(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15273,7 +15273,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtensionWide(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15284,7 +15284,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPathWide(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15365,7 +15365,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescriptionWide(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15461,7 +15461,7 @@ impl IDebugControl5_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByGuid(::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15842,7 +15842,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterruptTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15873,7 +15873,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15944,7 +15944,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15960,7 +15960,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.Assemble(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15976,7 +15976,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisassembleEffectiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15987,7 +15987,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.OutputDisassembly(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16003,7 +16003,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNearInstruction(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&delta)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nearoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nearoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16019,7 +16019,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16040,7 +16040,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16051,7 +16051,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutingProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16062,7 +16062,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPossibleExecutingProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16078,7 +16078,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcessors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16095,7 +16095,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16116,7 +16116,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSupportedProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16137,7 +16137,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectiveProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16153,7 +16153,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16169,7 +16169,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16185,7 +16185,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngineOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16231,7 +16231,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16252,7 +16252,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.CoerceValue(::core::mem::transmute_copy(&r#in), ::core::mem::transmute_copy(&outtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16278,7 +16278,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16289,7 +16289,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16300,7 +16300,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16316,7 +16316,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16332,7 +16332,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtension(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16348,7 +16348,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16449,7 +16449,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTimeDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timedate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timedate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16460,7 +16460,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16471,7 +16471,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetDumpFormatFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formatflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formatflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16482,7 +16482,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberTextReplacements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numrepl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numrepl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16513,7 +16513,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetAssemblyOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16539,7 +16539,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpressionSyntax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16560,7 +16560,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberExpressionSyntaxes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16576,7 +16576,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *events = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(events, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16587,7 +16587,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescription(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16598,7 +16598,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentEventIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16609,7 +16609,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.SetNextEventIndex(::core::mem::transmute_copy(&relation), ::core::mem::transmute_copy(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16675,7 +16675,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.AssembleWide(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16721,7 +16721,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex2(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16732,7 +16732,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById2(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16743,7 +16743,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint2(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16759,7 +16759,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtensionWide(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16770,7 +16770,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPathWide(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16851,7 +16851,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescriptionWide(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16947,7 +16947,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByGuid(::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16958,7 +16958,7 @@ impl IDebugControl6_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatusEx() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17347,7 +17347,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterruptTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17378,7 +17378,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17449,7 +17449,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotifyEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17465,7 +17465,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.Assemble(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17481,7 +17481,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisassembleEffectiveOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17492,7 +17492,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.OutputDisassembly(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17508,7 +17508,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNearInstruction(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&delta)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nearoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nearoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17524,7 +17524,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17545,7 +17545,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetActualProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17556,7 +17556,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutingProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17567,7 +17567,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPossibleExecutingProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17583,7 +17583,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcessors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17600,7 +17600,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17621,7 +17621,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSupportedProcessorTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17642,7 +17642,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectiveProcessorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17658,7 +17658,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17674,7 +17674,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *level = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(level, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17690,7 +17690,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngineOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17736,7 +17736,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetRadix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17757,7 +17757,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.CoerceValue(::core::mem::transmute_copy(&r#in), ::core::mem::transmute_copy(&outtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17783,7 +17783,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberBreakpoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17794,7 +17794,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17805,7 +17805,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17821,7 +17821,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17837,7 +17837,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtension(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17853,7 +17853,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17954,7 +17954,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentTimeDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timedate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timedate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17965,7 +17965,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17976,7 +17976,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetDumpFormatFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *formatflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(formatflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17987,7 +17987,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberTextReplacements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *numrepl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numrepl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18018,7 +18018,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetAssemblyOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18044,7 +18044,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpressionSyntax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18065,7 +18065,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberExpressionSyntaxes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18081,7 +18081,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *events = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(events, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18092,7 +18092,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescription(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18103,7 +18103,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentEventIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18114,7 +18114,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.SetNextEventIndex(::core::mem::transmute_copy(&relation), ::core::mem::transmute_copy(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18180,7 +18180,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.AssembleWide(::core::mem::transmute_copy(&offset), ::core::mem::transmute(&instr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *endoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(endoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18226,7 +18226,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByIndex2(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18237,7 +18237,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointById2(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18248,7 +18248,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.AddBreakpoint2(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&desiredid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18264,7 +18264,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.AddExtensionWide(::core::mem::transmute(&path), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18275,7 +18275,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtensionByPathWide(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18356,7 +18356,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventIndexDescriptionWide(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&which), ::core::mem::transmute(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *descsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18452,7 +18452,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetBreakpointByGuid(::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18463,7 +18463,7 @@ impl IDebugControl7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExecutionStatusEx() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18713,7 +18713,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18724,7 +18724,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.SearchVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize), ::core::mem::transmute_copy(&patterngranularity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18740,7 +18740,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtualUncached(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18766,7 +18766,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.WritePhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18782,7 +18782,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.WriteControl(::core::mem::transmute_copy(&processor), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18798,7 +18798,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.WriteIo(::core::mem::transmute_copy(&interfacetype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&addressspace), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18809,7 +18809,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.ReadMsr(::core::mem::transmute_copy(&msr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18830,7 +18830,7 @@ impl IDebugDataSpaces_Vtbl {
             let this = (*this).get_impl();
             match this.WriteBusData(::core::mem::transmute_copy(&busdatatype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&slotnumber), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18923,7 +18923,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18934,7 +18934,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize), ::core::mem::transmute_copy(&patterngranularity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18950,7 +18950,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtualUncached(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18976,7 +18976,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.WritePhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18992,7 +18992,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteControl(::core::mem::transmute_copy(&processor), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19008,7 +19008,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteIo(::core::mem::transmute_copy(&interfacetype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&addressspace), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19019,7 +19019,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.ReadMsr(::core::mem::transmute_copy(&msr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19040,7 +19040,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteBusData(::core::mem::transmute_copy(&busdatatype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&slotnumber), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19066,7 +19066,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.VirtualToPhysical(::core::mem::transmute_copy(&r#virtual)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *physical = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(physical, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19087,7 +19087,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.FillVirtual(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19098,7 +19098,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.FillPhysical(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19109,7 +19109,7 @@ impl IDebugDataSpaces2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVirtual(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19198,7 +19198,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19209,7 +19209,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.SearchVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize), ::core::mem::transmute_copy(&patterngranularity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19225,7 +19225,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtualUncached(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19251,7 +19251,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.WritePhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19267,7 +19267,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.WriteControl(::core::mem::transmute_copy(&processor), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19283,7 +19283,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.WriteIo(::core::mem::transmute_copy(&interfacetype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&addressspace), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19294,7 +19294,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.ReadMsr(::core::mem::transmute_copy(&msr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19315,7 +19315,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.WriteBusData(::core::mem::transmute_copy(&busdatatype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&slotnumber), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19341,7 +19341,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.VirtualToPhysical(::core::mem::transmute_copy(&r#virtual)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *physical = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(physical, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19362,7 +19362,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.FillVirtual(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19373,7 +19373,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.FillPhysical(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19384,7 +19384,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVirtual(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19395,7 +19395,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.ReadImageNtHeaders(::core::mem::transmute_copy(&imagebase)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *headers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(headers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19411,7 +19411,7 @@ impl IDebugDataSpaces3_Vtbl {
             let this = (*this).get_impl();
             match this.StartEnumTagged() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19525,7 +19525,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19536,7 +19536,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.SearchVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize), ::core::mem::transmute_copy(&patterngranularity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19552,7 +19552,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.WriteVirtualUncached(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19578,7 +19578,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.WritePhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19594,7 +19594,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.WriteControl(::core::mem::transmute_copy(&processor), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19610,7 +19610,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.WriteIo(::core::mem::transmute_copy(&interfacetype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&addressspace), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19621,7 +19621,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.ReadMsr(::core::mem::transmute_copy(&msr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19642,7 +19642,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.WriteBusData(::core::mem::transmute_copy(&busdatatype), ::core::mem::transmute_copy(&busnumber), ::core::mem::transmute_copy(&slotnumber), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19668,7 +19668,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.VirtualToPhysical(::core::mem::transmute_copy(&r#virtual)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *physical = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(physical, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19689,7 +19689,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.FillVirtual(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19700,7 +19700,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.FillPhysical(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19711,7 +19711,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.QueryVirtual(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19722,7 +19722,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.ReadImageNtHeaders(::core::mem::transmute_copy(&imagebase)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *headers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(headers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19738,7 +19738,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.StartEnumTagged() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19764,7 +19764,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextDifferentlyValidOffsetVirtual(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nextoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nextoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19780,7 +19780,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.SearchVirtual2(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&patternsize), ::core::mem::transmute_copy(&patterngranularity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *matchoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(matchoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19816,7 +19816,7 @@ impl IDebugDataSpaces4_Vtbl {
             let this = (*this).get_impl();
             match this.WritePhysical2(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19896,7 +19896,7 @@ impl IDebugDocumentContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19907,7 +19907,7 @@ impl IDebugDocumentContext_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCodeContexts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppescc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppescc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19989,7 +19989,7 @@ impl IDebugDocumentHelper32_Vtbl {
             let this = (*this).get_impl();
             match this.DefineScriptBlock(::core::mem::transmute_copy(&ulcharoffset), ::core::mem::transmute_copy(&cchars), ::core::mem::transmute(&pas), ::core::mem::transmute_copy(&fscriptlet)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsourcecontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsourcecontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20025,7 +20025,7 @@ impl IDebugDocumentHelper32_Vtbl {
             let this = (*this).get_impl();
             match this.GetDebugApplicationNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdan = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdan, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20041,7 +20041,7 @@ impl IDebugDocumentHelper32_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDebugDocumentContext(::core::mem::transmute_copy(&icharpos), ::core::mem::transmute_copy(&cchars)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppddc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppddc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20149,7 +20149,7 @@ impl IDebugDocumentHelper64_Vtbl {
             let this = (*this).get_impl();
             match this.DefineScriptBlock(::core::mem::transmute_copy(&ulcharoffset), ::core::mem::transmute_copy(&cchars), ::core::mem::transmute(&pas), ::core::mem::transmute_copy(&fscriptlet)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsourcecontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsourcecontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20185,7 +20185,7 @@ impl IDebugDocumentHelper64_Vtbl {
             let this = (*this).get_impl();
             match this.GetDebugApplicationNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdan = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdan, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20201,7 +20201,7 @@ impl IDebugDocumentHelper64_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDebugDocumentContext(::core::mem::transmute_copy(&icharpos), ::core::mem::transmute_copy(&cchars)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppddc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppddc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20272,7 +20272,7 @@ impl IDebugDocumentHost_Vtbl {
             let this = (*this).get_impl();
             match this.OnCreateDocumentContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkouter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkouter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20288,7 +20288,7 @@ impl IDebugDocumentHost_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrshortname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrshortname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20328,7 +20328,7 @@ impl IDebugDocumentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetName(::core::mem::transmute_copy(&dnt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20339,7 +20339,7 @@ impl IDebugDocumentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentClassId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsiddocument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsiddocument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20369,7 +20369,7 @@ impl IDebugDocumentProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppssd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppssd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20401,7 +20401,7 @@ impl IDebugDocumentText_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptextdocattr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptextdocattr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20417,7 +20417,7 @@ impl IDebugDocumentText_Vtbl {
             let this = (*this).get_impl();
             match this.GetPositionOfLine(::core::mem::transmute_copy(&clinenumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccharacterposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccharacterposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20443,7 +20443,7 @@ impl IDebugDocumentText_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextOfPosition(::core::mem::transmute_copy(&ccharacterposition), ::core::mem::transmute_copy(&cnumchars)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20577,7 +20577,7 @@ impl IDebugDocumentTextExternalAuthor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrshortname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrshortname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20626,7 +20626,7 @@ impl IDebugEventCallbacks_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterestMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20747,7 +20747,7 @@ impl IDebugEventCallbacksWide_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterestMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20868,7 +20868,7 @@ impl IDebugEventContextCallbacks_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterestMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21059,7 +21059,7 @@ impl IDebugExpressionContext_Vtbl {
             let this = (*this).get_impl();
             match this.ParseLanguageText(::core::mem::transmute(&pstrcode), ::core::mem::transmute_copy(&nradix), ::core::mem::transmute(&pstrdelimiter), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21095,7 +21095,7 @@ impl IDebugExtendedProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtendedPropertyInfo(::core::mem::transmute_copy(&dwfieldspec), ::core::mem::transmute_copy(&nradix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextendedpropertyinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextendedpropertyinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21106,7 +21106,7 @@ impl IDebugExtendedProperty_Vtbl {
             let this = (*this).get_impl();
             match this.EnumExtendedMembers(::core::mem::transmute_copy(&dwfieldspec), ::core::mem::transmute_copy(&nradix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeepi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeepi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21138,7 +21138,7 @@ impl IDebugFormatter_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringForVariant(::core::mem::transmute_copy(&pvar), ::core::mem::transmute_copy(&nradix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21149,7 +21149,7 @@ impl IDebugFormatter_Vtbl {
             let this = (*this).get_impl();
             match this.GetVariantForString(::core::mem::transmute(&pwstrvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21160,7 +21160,7 @@ impl IDebugFormatter_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringForVarType(::core::mem::transmute_copy(&vt), ::core::mem::transmute_copy(&ptdescarraytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21193,7 +21193,7 @@ impl IDebugHelper_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyBrowser(::core::mem::transmute_copy(&pvar), ::core::mem::transmute(&bstrname), ::core::mem::transmute(&pdat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21204,7 +21204,7 @@ impl IDebugHelper_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyBrowserEx(::core::mem::transmute_copy(&pvar), ::core::mem::transmute(&bstrname), ::core::mem::transmute(&pdat), ::core::mem::transmute(&pdf)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdob = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdob, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21215,7 +21215,7 @@ impl IDebugHelper_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSimpleConnectionPoint(::core::mem::transmute(&pdisp)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppscp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppscp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21245,7 +21245,7 @@ impl IDebugHost_Vtbl {
             let this = (*this).get_impl();
             match this.GetHostDefinedInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hostunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hostunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21256,7 +21256,7 @@ impl IDebugHost_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *context = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(context, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21267,7 +21267,7 @@ impl IDebugHost_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultMetadata() {
                 ::core::result::Result::Ok(ok__) => {
-                    *defaultmetadatastore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(defaultmetadatastore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21298,7 +21298,7 @@ impl IDebugHostBaseClass_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21324,7 +21324,7 @@ impl IDebugHostConstant_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21347,7 +21347,7 @@ impl IDebugHostContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqualTo(::core::mem::transmute(&pcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21375,7 +21375,7 @@ impl IDebugHostData_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocationKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locationkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locationkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21386,7 +21386,7 @@ impl IDebugHostData_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *location = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(location, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21397,7 +21397,7 @@ impl IDebugHostData_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21519,7 +21519,7 @@ impl IDebugHostField_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocationKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locationkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locationkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21530,7 +21530,7 @@ impl IDebugHostField_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21541,7 +21541,7 @@ impl IDebugHostField_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *location = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(location, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21552,7 +21552,7 @@ impl IDebugHostField_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21593,7 +21593,7 @@ impl IDebugHostMemory_Vtbl {
             let this = (*this).get_impl();
             match this.WriteBytes(::core::mem::transmute(&context), ::core::mem::transmute(&location), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21614,7 +21614,7 @@ impl IDebugHostMemory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayStringForLocation(::core::mem::transmute(&context), ::core::mem::transmute(&location), ::core::mem::transmute_copy(&verbose)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *locationname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locationname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21647,7 +21647,7 @@ impl IDebugHostMemory2_Vtbl {
             let this = (*this).get_impl();
             match this.LinearizeLocation(::core::mem::transmute(&context), ::core::mem::transmute(&location)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plinearizedlocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plinearizedlocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21678,7 +21678,7 @@ impl IDebugHostModule_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageName(::core::mem::transmute_copy(&allowpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21689,7 +21689,7 @@ impl IDebugHostModule_Vtbl {
             let this = (*this).get_impl();
             match this.GetBaseLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modulebaselocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modulebaselocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21705,7 +21705,7 @@ impl IDebugHostModule_Vtbl {
             let this = (*this).get_impl();
             match this.FindTypeByName(::core::mem::transmute(&typename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21716,7 +21716,7 @@ impl IDebugHostModule_Vtbl {
             let this = (*this).get_impl();
             match this.FindSymbolByRVA(::core::mem::transmute_copy(&rva)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21727,7 +21727,7 @@ impl IDebugHostModule_Vtbl {
             let this = (*this).get_impl();
             match this.FindSymbolByName(::core::mem::transmute(&symbolname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21778,7 +21778,7 @@ impl IDebugHostModuleSignature_Vtbl {
             let this = (*this).get_impl();
             match this.IsMatch(::core::mem::transmute(&pmodule)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ismatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ismatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21805,7 +21805,7 @@ impl IDebugHostPublic_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocationKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locationkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locationkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21816,7 +21816,7 @@ impl IDebugHostPublic_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *location = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(location, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21843,7 +21843,7 @@ impl IDebugHostScriptHost_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContext(::core::mem::transmute(&script)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *scriptcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scriptcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21866,7 +21866,7 @@ impl IDebugHostStatus_Vtbl {
             let this = (*this).get_impl();
             match this.PollUserInterrupt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interruptrequested = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interruptrequested, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21898,7 +21898,7 @@ impl IDebugHostSymbol_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *context = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(context, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21909,7 +21909,7 @@ impl IDebugHostSymbol_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateChildren(::core::mem::transmute_copy(&kind), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21920,7 +21920,7 @@ impl IDebugHostSymbol_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *kind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(kind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21931,7 +21931,7 @@ impl IDebugHostSymbol_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbolname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbolname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21942,7 +21942,7 @@ impl IDebugHostSymbol_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21953,7 +21953,7 @@ impl IDebugHostSymbol_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainingModule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *containingmodule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(containingmodule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21964,7 +21964,7 @@ impl IDebugHostSymbol_Vtbl {
             let this = (*this).get_impl();
             match this.CompareAgainst(::core::mem::transmute(&pcomparisonsymbol), ::core::mem::transmute_copy(&comparisonflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmatches = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmatches, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21999,7 +21999,7 @@ impl IDebugHostSymbol2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22028,7 +22028,7 @@ impl IDebugHostSymbolEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.GetNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22061,7 +22061,7 @@ impl IDebugHostSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.CreateModuleSignature(::core::mem::transmute(&pwszmodulename), ::core::mem::transmute(&pwszminversion), ::core::mem::transmute(&pwszmaxversion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmodulesignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmodulesignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22072,7 +22072,7 @@ impl IDebugHostSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypeSignature(::core::mem::transmute(&signaturespecification), ::core::mem::transmute(&module)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typesignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typesignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22083,7 +22083,7 @@ impl IDebugHostSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypeSignatureForModuleRange(::core::mem::transmute(&signaturespecification), ::core::mem::transmute(&modulename), ::core::mem::transmute(&minversion), ::core::mem::transmute(&maxversion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typesignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typesignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22094,7 +22094,7 @@ impl IDebugHostSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateModules(::core::mem::transmute(&context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *moduleenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moduleenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22105,7 +22105,7 @@ impl IDebugHostSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.FindModuleByName(::core::mem::transmute(&context), ::core::mem::transmute(&modulename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *module = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(module, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22116,7 +22116,7 @@ impl IDebugHostSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.FindModuleByLocation(::core::mem::transmute(&context), ::core::mem::transmute(&modulelocation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *module = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(module, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22174,7 +22174,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *kind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(kind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22185,7 +22185,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22196,7 +22196,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetBaseType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *basetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(basetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22207,7 +22207,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetHashCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hashcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hashcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22228,7 +22228,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetPointerKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pointerkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pointerkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22239,7 +22239,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetMemberType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *membertype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(membertype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22250,7 +22250,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePointerTo(::core::mem::transmute_copy(&kind)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22261,7 +22261,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetArrayDimensionality() {
                 ::core::result::Result::Ok(ok__) => {
-                    *arraydimensionality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(arraydimensionality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22277,7 +22277,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.CreateArrayOf(::core::mem::transmute_copy(&dimensions), ::core::mem::transmute_copy(&pdimensions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22288,7 +22288,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionCallingConvention() {
                 ::core::result::Result::Ok(ok__) => {
-                    *conventionkind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(conventionkind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22299,7 +22299,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionReturnType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *returntype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(returntype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22310,7 +22310,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionParameterTypeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22321,7 +22321,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionParameterTypeAt(::core::mem::transmute_copy(&i)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *parametertype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parametertype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22332,7 +22332,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.IsGeneric() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isgeneric = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isgeneric, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22343,7 +22343,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetGenericArgumentCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *argcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(argcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22354,7 +22354,7 @@ impl IDebugHostType_Vtbl {
             let this = (*this).get_impl();
             match this.GetGenericArgumentAt(::core::mem::transmute_copy(&i)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *argument = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(argument, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22405,7 +22405,7 @@ impl IDebugHostType2_Vtbl {
             let this = (*this).get_impl();
             match this.IsTypedef() {
                 ::core::result::Result::Ok(ok__) => {
-                    *istypedef = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(istypedef, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22416,7 +22416,7 @@ impl IDebugHostType2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypedefBaseType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *basetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(basetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22427,7 +22427,7 @@ impl IDebugHostType2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypedefFinalBaseType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *finalbasetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(finalbasetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22438,7 +22438,7 @@ impl IDebugHostType2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionVarArgsKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varargskind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varargskind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22449,7 +22449,7 @@ impl IDebugHostType2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionInstancePointerType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *instancepointertype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(instancepointertype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22481,7 +22481,7 @@ impl IDebugHostTypeSignature_Vtbl {
             let this = (*this).get_impl();
             match this.GetHashCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hashcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hashcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22497,7 +22497,7 @@ impl IDebugHostTypeSignature_Vtbl {
             let this = (*this).get_impl();
             match this.CompareAgainst(::core::mem::transmute(&typesignature)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22576,7 +22576,7 @@ impl IDebugOutputCallbacks2_Vtbl {
             let this = (*this).get_impl();
             match this.GetInterestMask() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22787,7 +22787,7 @@ impl IDebugProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyInfo(::core::mem::transmute_copy(&dwfieldspec), ::core::mem::transmute_copy(&nradix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropertyinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropertyinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22808,7 +22808,7 @@ impl IDebugProperty_Vtbl {
             let this = (*this).get_impl();
             match this.EnumMembers(::core::mem::transmute_copy(&dwfieldspec), ::core::mem::transmute_copy(&nradix), ::core::mem::transmute_copy(&refiid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppepi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppepi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22819,7 +22819,7 @@ impl IDebugProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdebugprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdebugprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22852,7 +22852,7 @@ impl IDebugPropertyEnumType_All_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *__midl__idebugpropertyenumtype_all0000 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(__midl__idebugpropertyenumtype_all0000, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22940,7 +22940,7 @@ impl IDebugRegisters_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberRegisters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22956,7 +22956,7 @@ impl IDebugRegisters_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22967,7 +22967,7 @@ impl IDebugRegisters_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&register)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22998,7 +22998,7 @@ impl IDebugRegisters_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstructionOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23009,7 +23009,7 @@ impl IDebugRegisters_Vtbl {
             let this = (*this).get_impl();
             match this.GetStackOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23020,7 +23020,7 @@ impl IDebugRegisters_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23084,7 +23084,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberRegisters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23100,7 +23100,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23111,7 +23111,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&register)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23142,7 +23142,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstructionOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23153,7 +23153,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStackOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23164,7 +23164,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23180,7 +23180,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexByNameWide(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23191,7 +23191,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberPseudoRegisters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23212,7 +23212,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPseudoIndexByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23223,7 +23223,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPseudoIndexByNameWide(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23259,7 +23259,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstructionOffset2(::core::mem::transmute_copy(&source)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23270,7 +23270,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStackOffset2(::core::mem::transmute_copy(&source)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23281,7 +23281,7 @@ impl IDebugRegisters2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameOffset2(::core::mem::transmute_copy(&source)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23356,7 +23356,7 @@ impl IDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodeContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23367,7 +23367,7 @@ impl IDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescriptionString(::core::mem::transmute_copy(&flong)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23378,7 +23378,7 @@ impl IDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguageString(::core::mem::transmute_copy(&flong)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlanguage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlanguage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23389,7 +23389,7 @@ impl IDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23400,7 +23400,7 @@ impl IDebugStackFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetDebugProperty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdebugprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdebugprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23434,7 +23434,7 @@ impl IDebugStackFrame110_Vtbl {
             let this = (*this).get_impl();
             match this.GetStackFrameType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstackframekind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstackframekind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23445,7 +23445,7 @@ impl IDebugStackFrame110_Vtbl {
             let this = (*this).get_impl();
             match this.GetScriptInvocationContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinvocationcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinvocationcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23472,7 +23472,7 @@ impl IDebugStackFrameSniffer_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStackFrames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedsf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedsf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23495,7 +23495,7 @@ impl IDebugStackFrameSnifferEx32_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStackFramesEx32(::core::mem::transmute_copy(&dwspmin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedsf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedsf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23518,7 +23518,7 @@ impl IDebugStackFrameSnifferEx64_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStackFramesEx64(::core::mem::transmute_copy(&dwspmin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedsf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedsf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23553,7 +23553,7 @@ impl IDebugSymbolGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSymbols() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23658,7 +23658,7 @@ impl IDebugSymbolGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSymbols() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23749,7 +23749,7 @@ impl IDebugSymbolGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolSize(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23760,7 +23760,7 @@ impl IDebugSymbolGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolOffset(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23771,7 +23771,7 @@ impl IDebugSymbolGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolRegister(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *register = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(register, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23792,7 +23792,7 @@ impl IDebugSymbolGroup2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryInformation(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *entry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(entry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23891,7 +23891,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23922,7 +23922,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByName(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23943,7 +23943,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLine(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23959,7 +23959,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetModuleByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24003,7 +24003,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModule(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24019,7 +24019,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeId(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24030,7 +24030,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeSize(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24041,7 +24041,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffset(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24067,7 +24067,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24088,7 +24088,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataPhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24119,7 +24119,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24130,7 +24130,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24141,7 +24141,7 @@ impl IDebugSymbols_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatch(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24349,7 +24349,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24380,7 +24380,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByName(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24401,7 +24401,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLine(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24417,7 +24417,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetModuleByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24461,7 +24461,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModule(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24477,7 +24477,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeId(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24488,7 +24488,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeSize(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24499,7 +24499,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffset(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24525,7 +24525,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24546,7 +24546,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataPhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24577,7 +24577,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24588,7 +24588,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24599,7 +24599,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatch(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24705,7 +24705,7 @@ impl IDebugSymbols2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24927,7 +24927,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24958,7 +24958,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByName(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24979,7 +24979,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLine(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24995,7 +24995,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetModuleByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25039,7 +25039,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModule(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25055,7 +25055,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeId(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25066,7 +25066,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeSize(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25077,7 +25077,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffset(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25103,7 +25103,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25124,7 +25124,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataPhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25155,7 +25155,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25166,7 +25166,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25177,7 +25177,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatch(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25283,7 +25283,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25314,7 +25314,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByNameWide(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25335,7 +25335,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLineWide(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25351,7 +25351,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModuleWide(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25367,7 +25367,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeIdWide(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25378,7 +25378,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffsetWide(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25394,7 +25394,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup2(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25405,7 +25405,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25416,7 +25416,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatchWide(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25552,7 +25552,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentScopeFrameIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25598,7 +25598,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.AddSyntheticSymbol(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&size), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25609,7 +25609,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.AddSyntheticSymbolWide(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&size), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25640,7 +25640,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryByToken(::core::mem::transmute_copy(&modulebase), ::core::mem::transmute_copy(&token)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25651,7 +25651,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryInformation(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25677,7 +25677,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryBySymbolEntry(::core::mem::transmute_copy(&fromid), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *toid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(toid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25718,7 +25718,7 @@ impl IDebugSymbols3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceEntryBySourceEntry(::core::mem::transmute_copy(&fromentry), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *toentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(toentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25998,7 +25998,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26029,7 +26029,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByName(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26050,7 +26050,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLine(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26066,7 +26066,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetModuleByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26110,7 +26110,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModule(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26126,7 +26126,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeId(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26137,7 +26137,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeSize(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26148,7 +26148,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffset(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26174,7 +26174,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26195,7 +26195,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataPhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26226,7 +26226,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26237,7 +26237,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26248,7 +26248,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatch(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26354,7 +26354,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26385,7 +26385,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByNameWide(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26406,7 +26406,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLineWide(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26422,7 +26422,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModuleWide(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26438,7 +26438,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeIdWide(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26449,7 +26449,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffsetWide(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26465,7 +26465,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup2(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26476,7 +26476,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26487,7 +26487,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatchWide(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26623,7 +26623,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentScopeFrameIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26669,7 +26669,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.AddSyntheticSymbol(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&size), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26680,7 +26680,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.AddSyntheticSymbolWide(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&size), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26711,7 +26711,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryByToken(::core::mem::transmute_copy(&modulebase), ::core::mem::transmute_copy(&token)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26722,7 +26722,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryInformation(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26748,7 +26748,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryBySymbolEntry(::core::mem::transmute_copy(&fromid), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *toid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(toid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26789,7 +26789,7 @@ impl IDebugSymbols4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceEntryBySourceEntry(::core::mem::transmute_copy(&fromentry), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *toentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(toentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27113,7 +27113,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27144,7 +27144,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByName(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27165,7 +27165,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLine(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27181,7 +27181,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetModuleByIndex(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27225,7 +27225,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModule(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27241,7 +27241,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeId(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27252,7 +27252,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeSize(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27263,7 +27263,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffset(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27289,7 +27289,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataVirtual(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27310,7 +27310,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.WriteTypedDataPhysical(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *byteswritten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byteswritten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27341,7 +27341,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27352,7 +27352,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27363,7 +27363,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatch(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27469,7 +27469,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27500,7 +27500,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByNameWide(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27521,7 +27521,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetOffsetByLineWide(::core::mem::transmute_copy(&line), ::core::mem::transmute(&file)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27537,7 +27537,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolModuleWide(::core::mem::transmute(&symbol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *base = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(base, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27553,7 +27553,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeIdWide(::core::mem::transmute_copy(&module), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *typeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(typeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27564,7 +27564,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOffsetWide(::core::mem::transmute_copy(&module), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&field)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27580,7 +27580,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeSymbolGroup2(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&update)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *symbols = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(symbols, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27591,7 +27591,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSymbolGroup2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27602,7 +27602,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.StartSymbolMatchWide(::core::mem::transmute(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27738,7 +27738,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentScopeFrameIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27784,7 +27784,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.AddSyntheticSymbol(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&size), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27795,7 +27795,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.AddSyntheticSymbolWide(::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&size), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27826,7 +27826,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryByToken(::core::mem::transmute_copy(&modulebase), ::core::mem::transmute_copy(&token)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27837,7 +27837,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryInformation(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *info = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(info, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27863,7 +27863,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetSymbolEntryBySymbolEntry(::core::mem::transmute_copy(&fromid), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *toid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(toid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27904,7 +27904,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceEntryBySourceEntry(::core::mem::transmute_copy(&fromentry), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *toentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(toentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27950,7 +27950,7 @@ impl IDebugSymbols5_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentScopeFrameIndexEx(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28114,7 +28114,7 @@ impl IDebugSyncOperation_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppattarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppattarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28125,7 +28125,7 @@ impl IDebugSyncOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Execute() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28186,7 +28186,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28197,7 +28197,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventProcess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28208,7 +28208,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28224,7 +28224,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28240,7 +28240,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberThreads() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28261,7 +28261,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByProcessor(::core::mem::transmute_copy(&processor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28272,7 +28272,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28283,7 +28283,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28294,7 +28294,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadTeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28305,7 +28305,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByTeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28316,7 +28316,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28327,7 +28327,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28338,7 +28338,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28349,7 +28349,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28360,7 +28360,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcesses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28376,7 +28376,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28387,7 +28387,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28398,7 +28398,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessPeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28409,7 +28409,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByPeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28420,7 +28420,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28431,7 +28431,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28442,7 +28442,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28453,7 +28453,7 @@ impl IDebugSystemObjects_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28545,7 +28545,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28556,7 +28556,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventProcess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28567,7 +28567,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28583,7 +28583,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28599,7 +28599,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberThreads() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28620,7 +28620,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByProcessor(::core::mem::transmute_copy(&processor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28631,7 +28631,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28642,7 +28642,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28653,7 +28653,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadTeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28664,7 +28664,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByTeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28675,7 +28675,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28686,7 +28686,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28697,7 +28697,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28708,7 +28708,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28719,7 +28719,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcesses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28735,7 +28735,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28746,7 +28746,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28757,7 +28757,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessPeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28768,7 +28768,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByPeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28779,7 +28779,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28790,7 +28790,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28801,7 +28801,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28812,7 +28812,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28828,7 +28828,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28839,7 +28839,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplicitThreadDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28855,7 +28855,7 @@ impl IDebugSystemObjects2_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplicitProcessDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28961,7 +28961,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28972,7 +28972,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventProcess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28983,7 +28983,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -28999,7 +28999,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29015,7 +29015,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberThreads() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29036,7 +29036,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByProcessor(::core::mem::transmute_copy(&processor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29047,7 +29047,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29058,7 +29058,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29069,7 +29069,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadTeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29080,7 +29080,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByTeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29091,7 +29091,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29102,7 +29102,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29113,7 +29113,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29124,7 +29124,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29135,7 +29135,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcesses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29151,7 +29151,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29162,7 +29162,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29173,7 +29173,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessPeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29184,7 +29184,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByPeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29195,7 +29195,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29206,7 +29206,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29217,7 +29217,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29228,7 +29228,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29244,7 +29244,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29255,7 +29255,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplicitThreadDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29271,7 +29271,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplicitProcessDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29287,7 +29287,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29298,7 +29298,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29314,7 +29314,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSystems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29335,7 +29335,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29346,7 +29346,7 @@ impl IDebugSystemObjects3_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemByServer(::core::mem::transmute_copy(&server)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29463,7 +29463,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29474,7 +29474,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventProcess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29485,7 +29485,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29501,7 +29501,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29517,7 +29517,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberThreads() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29538,7 +29538,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByProcessor(::core::mem::transmute_copy(&processor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29549,7 +29549,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29560,7 +29560,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29571,7 +29571,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadTeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29582,7 +29582,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByTeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29593,7 +29593,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29604,7 +29604,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29615,7 +29615,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentThreadHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29626,7 +29626,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29637,7 +29637,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberProcesses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29653,7 +29653,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29664,7 +29664,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByDataOffset(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29675,7 +29675,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessPeb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29686,7 +29686,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByPeb(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29697,7 +29697,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sysid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sysid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29708,7 +29708,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdBySystemId(::core::mem::transmute_copy(&sysid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29719,7 +29719,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29730,7 +29730,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessIdByHandle(::core::mem::transmute_copy(&handle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29746,7 +29746,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentProcessUpTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29757,7 +29757,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplicitThreadDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29773,7 +29773,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplicitProcessDataOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *offset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(offset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29789,7 +29789,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29800,7 +29800,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29816,7 +29816,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberSystems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *number = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(number, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29837,7 +29837,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSystemServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -29848,7 +29848,7 @@ impl IDebugSystemObjects4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemByServer(::core::mem::transmute_copy(&server)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30027,7 +30027,7 @@ impl IDynamicKeyProviderConcept_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateKeys(::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30073,7 +30073,7 @@ impl IEnumDebugApplicationNodes_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperddp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperddp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30120,7 +30120,7 @@ impl IEnumDebugCodeContexts_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppescc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppescc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30167,7 +30167,7 @@ impl IEnumDebugExpressionContexts_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30218,7 +30218,7 @@ impl IEnumDebugExtendedPropertyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pedpe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pedpe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30229,7 +30229,7 @@ impl IEnumDebugExtendedPropertyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcelt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcelt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30281,7 +30281,7 @@ impl IEnumDebugPropertyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppepi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppepi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30292,7 +30292,7 @@ impl IEnumDebugPropertyInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcelt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcelt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30343,7 +30343,7 @@ impl IEnumDebugStackFrames_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedsf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedsf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30433,7 +30433,7 @@ impl IEnumRemoteDebugApplicationThreads_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperdat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperdat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30480,7 +30480,7 @@ impl IEnumRemoteDebugApplications_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppessd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppessd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30509,7 +30509,7 @@ impl IEquatableConcept_Vtbl {
             let this = (*this).get_impl();
             match this.AreObjectsEqual(::core::mem::transmute(&contextobject), ::core::mem::transmute(&otherobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30551,7 +30551,7 @@ impl IIndexableConcept_Vtbl {
             let this = (*this).get_impl();
             match this.GetDimensionality(::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimensionality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimensionality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30590,7 +30590,7 @@ impl IIterableConcept_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultIndexDimensionality(::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimensionality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimensionality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30601,7 +30601,7 @@ impl IIterableConcept_Vtbl {
             let this = (*this).get_impl();
             match this.GetIterator(::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *iterator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iterator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30628,7 +30628,7 @@ impl IJsDebug_Vtbl {
             let this = (*this).get_impl();
             match this.OpenVirtualProcess(::core::mem::transmute_copy(&processid), ::core::mem::transmute_copy(&runtimejsbaseaddress), ::core::mem::transmute(&pdatatarget)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprocess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprocess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30658,7 +30658,7 @@ impl IJsDebugBreakPoint_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30729,7 +30729,7 @@ impl IJsDebugDataTarget_Vtbl {
             let this = (*this).get_impl();
             match this.AllocateVirtualMemory(::core::mem::transmute_copy(&address), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&allocationtype), ::core::mem::transmute_copy(&pageprotection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pallocatedaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pallocatedaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30745,7 +30745,7 @@ impl IJsDebugDataTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetTlsValue(::core::mem::transmute_copy(&threadid), ::core::mem::transmute_copy(&tlsindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30756,7 +30756,7 @@ impl IJsDebugDataTarget_Vtbl {
             let this = (*this).get_impl();
             match this.ReadBSTR(::core::mem::transmute_copy(&address)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30767,7 +30767,7 @@ impl IJsDebugDataTarget_Vtbl {
             let this = (*this).get_impl();
             match this.ReadNullTerminatedString(::core::mem::transmute_copy(&address), ::core::mem::transmute_copy(&charactersize), ::core::mem::transmute_copy(&maxcharacters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30778,7 +30778,7 @@ impl IJsDebugDataTarget_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStackFrameEnumerator(::core::mem::transmute_copy(&threadid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30831,7 +30831,7 @@ impl IJsDebugFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30852,7 +30852,7 @@ impl IJsDebugFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetDebugProperty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdebugproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdebugproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30863,7 +30863,7 @@ impl IJsDebugFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preturnaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preturnaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30906,7 +30906,7 @@ impl IJsDebugProcess_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStackWalker(::core::mem::transmute_copy(&threadid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstackwalker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstackwalker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30917,7 +30917,7 @@ impl IJsDebugProcess_Vtbl {
             let this = (*this).get_impl();
             match this.CreateBreakPoint(::core::mem::transmute_copy(&documentid), ::core::mem::transmute_copy(&characteroffset), ::core::mem::transmute_copy(&charactercount), ::core::mem::transmute_copy(&isenabled)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdebugbreakpoint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdebugbreakpoint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30933,7 +30933,7 @@ impl IJsDebugProcess_Vtbl {
             let this = (*this).get_impl();
             match this.GetExternalStepAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcodeaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcodeaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30966,7 +30966,7 @@ impl IJsDebugProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyInfo(::core::mem::transmute_copy(&nradix)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropertyinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropertyinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -30977,7 +30977,7 @@ impl IJsDebugProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetMembers(::core::mem::transmute_copy(&members)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31004,7 +31004,7 @@ impl IJsDebugStackWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31033,7 +31033,7 @@ impl IJsEnumDebugProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31140,7 +31140,7 @@ impl IMachineDebugManager_Vtbl {
             let this = (*this).get_impl();
             match this.AddApplication(::core::mem::transmute(&pda)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwappcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwappcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31156,7 +31156,7 @@ impl IMachineDebugManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumApplications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31186,7 +31186,7 @@ impl IMachineDebugManagerCookie_Vtbl {
             let this = (*this).get_impl();
             match this.AddApplication(::core::mem::transmute(&pda), ::core::mem::transmute_copy(&dwdebugappcookie)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwappcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwappcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31202,7 +31202,7 @@ impl IMachineDebugManagerCookie_Vtbl {
             let this = (*this).get_impl();
             match this.EnumApplications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31293,7 +31293,7 @@ impl IModelKeyReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31304,7 +31304,7 @@ impl IModelKeyReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetOriginalObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *originalobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(originalobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31315,7 +31315,7 @@ impl IModelKeyReference_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *containingobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(containingobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31439,7 +31439,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *context = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(context, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31450,7 +31450,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *kind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(kind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31461,7 +31461,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntrinsicValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *intrinsicdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(intrinsicdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31472,7 +31472,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntrinsicValueAs(::core::mem::transmute_copy(&vt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *intrinsicdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(intrinsicdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31493,7 +31493,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateKeyValues() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31504,7 +31504,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawValue(::core::mem::transmute_copy(&kind), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&searchflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31515,7 +31515,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateRawValues(::core::mem::transmute_copy(&kind), ::core::mem::transmute_copy(&searchflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31526,7 +31526,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.Dereference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31537,7 +31537,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.TryCastToRuntimeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *runtimetypedobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(runtimetypedobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31553,7 +31553,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *location = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(location, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31564,7 +31564,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31580,7 +31580,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfParentModels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nummodels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nummodels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31626,7 +31626,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateKeys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31637,7 +31637,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateKeyReferences() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31658,7 +31658,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetRawReference(::core::mem::transmute_copy(&kind), ::core::mem::transmute(&name), ::core::mem::transmute_copy(&searchflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31669,7 +31669,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateRawReferences(::core::mem::transmute_copy(&kind), ::core::mem::transmute_copy(&searchflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31685,7 +31685,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextForDataModel(::core::mem::transmute(&datamodelobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *context = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(context, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31696,7 +31696,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute(&other)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31707,7 +31707,7 @@ impl IModelObject_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqualTo(::core::mem::transmute(&other)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *equal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(equal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31766,7 +31766,7 @@ impl IModelPropertyAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&key), ::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31831,7 +31831,7 @@ impl IPerPropertyBrowsing2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayString(::core::mem::transmute_copy(&dispid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31842,7 +31842,7 @@ impl IPerPropertyBrowsing2_Vtbl {
             let this = (*this).get_impl();
             match this.MapPropertyToPage(::core::mem::transmute_copy(&dispid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsidproppage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsidproppage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31881,7 +31881,7 @@ impl IPreferredRuntimeTypeConcept_Vtbl {
             let this = (*this).get_impl();
             match this.CastToPreferredRuntimeType(::core::mem::transmute(&contextobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *object = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(object, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31911,7 +31911,7 @@ impl IProcessDebugManager32_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31922,7 +31922,7 @@ impl IProcessDebugManager32_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31933,7 +31933,7 @@ impl IProcessDebugManager32_Vtbl {
             let this = (*this).get_impl();
             match this.AddApplication(::core::mem::transmute(&pda)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwappcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwappcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31949,7 +31949,7 @@ impl IProcessDebugManager32_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDebugDocumentHelper(::core::mem::transmute(&punkouter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pddh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pddh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31983,7 +31983,7 @@ impl IProcessDebugManager64_Vtbl {
             let this = (*this).get_impl();
             match this.CreateApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31994,7 +31994,7 @@ impl IProcessDebugManager64_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32005,7 +32005,7 @@ impl IProcessDebugManager64_Vtbl {
             let this = (*this).get_impl();
             match this.AddApplication(::core::mem::transmute(&pda)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwappcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwappcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32021,7 +32021,7 @@ impl IProcessDebugManager64_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDebugDocumentHelper(::core::mem::transmute(&punkouter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pddh = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pddh, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32051,7 +32051,7 @@ impl IProvideExpressionContexts_Vtbl {
             let this = (*this).get_impl();
             match this.EnumExpressionContexts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32137,7 +32137,7 @@ impl IRemoteDebugApplication_Vtbl {
             let this = (*this).get_impl();
             match this.GetDebugger() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pad = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pad, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32148,7 +32148,7 @@ impl IRemoteDebugApplication_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstanceAtApplication(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&dwclscontext), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32164,7 +32164,7 @@ impl IRemoteDebugApplication_Vtbl {
             let this = (*this).get_impl();
             match this.EnumThreads() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperdat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperdat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32175,7 +32175,7 @@ impl IRemoteDebugApplication_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32186,7 +32186,7 @@ impl IRemoteDebugApplication_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdanroot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdanroot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32197,7 +32197,7 @@ impl IRemoteDebugApplication_Vtbl {
             let this = (*this).get_impl();
             match this.EnumGlobalExpressionContexts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedec = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedec, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32240,7 +32240,7 @@ impl IRemoteDebugApplication110_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentDebuggerOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcurrentoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcurrentoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32251,7 +32251,7 @@ impl IRemoteDebugApplication110_Vtbl {
             let this = (*this).get_impl();
             match this.GetMainThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppthread = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppthread, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32373,7 +32373,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwthreadid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwthreadid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32384,7 +32384,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32395,7 +32395,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             let this = (*this).get_impl();
             match this.EnumStackFrames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppedsf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppedsf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32416,7 +32416,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32427,7 +32427,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             let this = (*this).get_impl();
             match this.Suspend() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32438,7 +32438,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             let this = (*this).get_impl();
             match this.Resume() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32449,7 +32449,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             let this = (*this).get_impl();
             match this.GetSuspendCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32536,7 +32536,7 @@ impl IScriptEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32552,7 +32552,7 @@ impl IScriptEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetBody() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32568,7 +32568,7 @@ impl IScriptEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32584,7 +32584,7 @@ impl IScriptEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32645,7 +32645,7 @@ impl IScriptInvocationContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinvocationcontexttype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinvocationcontexttype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32656,7 +32656,7 @@ impl IScriptInvocationContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32667,7 +32667,7 @@ impl IScriptInvocationContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontextobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontextobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32717,7 +32717,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsnparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsnparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32728,7 +32728,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexInParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32739,7 +32739,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetCookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32750,7 +32750,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcsn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcsn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32761,7 +32761,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetChild(::core::mem::transmute_copy(&isn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32772,7 +32772,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32783,7 +32783,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.CreateChildEntry(::core::mem::transmute_copy(&isn), ::core::mem::transmute_copy(&dwcookie), ::core::mem::transmute(&pszdelimiter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32794,7 +32794,7 @@ impl IScriptNode_Vtbl {
             let this = (*this).get_impl();
             match this.CreateChildHandler(::core::mem::transmute(&pszdefaultname), ::core::mem::transmute_copy(&prgpsznames), ::core::mem::transmute_copy(&cpsznames), ::core::mem::transmute(&pszevent), ::core::mem::transmute(&pszdelimiter), ::core::mem::transmute(&ptisignature), ::core::mem::transmute_copy(&imethodsignature), ::core::mem::transmute_copy(&isn), ::core::mem::transmute_copy(&dwcookie)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32837,7 +32837,7 @@ impl IScriptScriptlet_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubItemName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32853,7 +32853,7 @@ impl IScriptScriptlet_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32869,7 +32869,7 @@ impl IScriptScriptlet_Vtbl {
             let this = (*this).get_impl();
             match this.GetSimpleEventName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32911,7 +32911,7 @@ impl ISimpleConnectionPoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32927,7 +32927,7 @@ impl ISimpleConnectionPoint_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&pdisp)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -32964,7 +32964,7 @@ impl IStringDisplayableConcept_Vtbl {
             let this = (*this).get_impl();
             match this.ToDisplayString(::core::mem::transmute(&contextobject), ::core::mem::transmute(&metadata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *displaystring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displaystring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -33028,7 +33028,7 @@ impl IWebAppDiagnosticsSetup_Vtbl {
             let this = (*this).get_impl();
             match this.DiagnosticsSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
@@ -20,7 +20,7 @@ impl ITraceEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31,7 +31,7 @@ impl ITraceEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usercontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usercontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl ITraceEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventRecord() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventrecord = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventrecord, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -169,7 +169,7 @@ impl ITraceRelogger_Vtbl {
             let this = (*this).get_impl();
             match this.AddLogfileTraceStream(::core::mem::transmute(&logfilename), ::core::mem::transmute_copy(&usercontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tracehandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tracehandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -180,7 +180,7 @@ impl ITraceRelogger_Vtbl {
             let this = (*this).get_impl();
             match this.AddRealtimeTraceStream(::core::mem::transmute(&loggername), ::core::mem::transmute_copy(&usercontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tracehandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tracehandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl ITraceRelogger_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEventInstance(::core::mem::transmute_copy(&tracehandle), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *event = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(event, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
@@ -42,7 +42,7 @@ impl IDtcLuRecoveryFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&puclupair), ::core::mem::transmute_copy(&cblupair)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprecovery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprecovery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -206,7 +206,7 @@ impl IDtcLuRecoveryInitiatedByLu_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectToHandleWorkFromLu() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwork = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwork, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -619,7 +619,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnyNetworkAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbanynetworkaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbanynetworkaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -635,7 +635,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkAdministrationAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbnetworkadministrationaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbnetworkadministrationaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -651,7 +651,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkTransactionAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbnetworktransactionaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbnetworktransactionaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -667,7 +667,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkClientAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbnetworkclientaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbnetworkclientaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -683,7 +683,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkTIPAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbnetworktipaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbnetworktipaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -699,7 +699,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetXAAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbxaaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbxaaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -755,7 +755,7 @@ impl IDtcNetworkAccessConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkInboundAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbinbound = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbinbound, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -766,7 +766,7 @@ impl IDtcNetworkAccessConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNetworkOutboundAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pboutbound = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pboutbound, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -787,7 +787,7 @@ impl IDtcNetworkAccessConfig2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAuthenticationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pauthlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pauthlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -827,7 +827,7 @@ impl IDtcNetworkAccessConfig3_Vtbl {
             let this = (*this).get_impl();
             match this.GetLUAccess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbluaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbluaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -868,7 +868,7 @@ impl IDtcToXaHelper_Vtbl {
             let this = (*this).get_impl();
             match this.TranslateTridToXid(::core::mem::transmute(&pitransaction), ::core::mem::transmute_copy(&pguidbqual)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pxid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pxid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -928,7 +928,7 @@ impl IDtcToXaHelperSinglePipe_Vtbl {
             let this = (*this).get_impl();
             match this.EnlistWithRM(::core::mem::transmute_copy(&dwrmcookie), ::core::mem::transmute(&i_pitransaction), ::core::mem::transmute(&i_pitransres)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *o_ppitransenslitment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(o_ppitransenslitment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1026,7 +1026,7 @@ impl IKernelTransaction_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1104,7 +1104,7 @@ impl IPrepareInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrepareInfoSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbprepinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbprepinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1174,7 +1174,7 @@ impl IResourceManager_Vtbl {
             let this = (*this).get_impl();
             match this.Reenlist(::core::mem::transmute_copy(&pprepinfo), ::core::mem::transmute_copy(&cbprepinfo), ::core::mem::transmute_copy(&ltimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pxactstat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pxactstat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1222,7 +1222,7 @@ impl IResourceManager2_Vtbl {
             let this = (*this).get_impl();
             match this.Reenlist2(::core::mem::transmute_copy(&pxid), ::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pxactstat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pxactstat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1249,7 +1249,7 @@ impl IResourceManagerFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&pguidrm), ::core::mem::transmute(&pszrmname), ::core::mem::transmute(&piresmgrsink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresmgr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresmgr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1292,7 +1292,7 @@ impl IResourceManagerRejoinable_Vtbl {
             let this = (*this).get_impl();
             match this.Rejoin(::core::mem::transmute_copy(&pprepinfo), ::core::mem::transmute_copy(&cbprepinfo), ::core::mem::transmute_copy(&ltimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pxactstat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pxactstat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1334,7 +1334,7 @@ impl ITipHelper_Vtbl {
             let this = (*this).get_impl();
             match this.Pull(::core::mem::transmute_copy(&i_psztxurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *o_ppitransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(o_ppitransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1345,7 +1345,7 @@ impl ITipHelper_Vtbl {
             let this = (*this).get_impl();
             match this.PullAsync(::core::mem::transmute_copy(&i_psztxurl), ::core::mem::transmute(&i_ptippullsink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *o_ppitransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(o_ppitransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1356,7 +1356,7 @@ impl ITipHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocalTmUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *o_ppszlocaltmurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(o_ppszlocaltmurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1402,7 +1402,7 @@ impl ITipTransaction_Vtbl {
             let this = (*this).get_impl();
             match this.Push(::core::mem::transmute_copy(&i_pszremotetmurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *o_ppszremotetxurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(o_ppszremotetxurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1413,7 +1413,7 @@ impl ITipTransaction_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransactionUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *o_ppszlocaltxurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(o_ppszlocaltxurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1441,7 +1441,7 @@ impl ITmNodeName_Vtbl {
             let this = (*this).get_impl();
             match this.GetNodeNameSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbnodenamesize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbnodenamesize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1488,7 +1488,7 @@ impl ITransaction_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransactionInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1519,7 +1519,7 @@ impl ITransaction2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransactionInfo2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1545,7 +1545,7 @@ impl ITransactionCloner_Vtbl {
             let this = (*this).get_impl();
             match this.CloneWithCommitDisabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1569,7 +1569,7 @@ impl ITransactionDispenser_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionsObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1580,7 +1580,7 @@ impl ITransactionDispenser_Vtbl {
             let this = (*this).get_impl();
             match this.BeginTransaction(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&isolevel), ::core::mem::transmute_copy(&isoflags), ::core::mem::transmute(&poptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1645,7 +1645,7 @@ impl ITransactionExport_Vtbl {
             let this = (*this).get_impl();
             match this.Export(::core::mem::transmute(&punktransaction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbtransactioncookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbtransactioncookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1678,7 +1678,7 @@ impl ITransactionExportFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetRemoteClassId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1689,7 +1689,7 @@ impl ITransactionExportFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&cbwhereabouts), ::core::mem::transmute_copy(&rgbwhereabouts)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppexport = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppexport, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1734,7 +1734,7 @@ impl ITransactionImportWhereabouts_Vtbl {
             let this = (*this).get_impl();
             match this.GetWhereaboutsSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbwhereabouts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbwhereabouts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1905,7 +1905,7 @@ impl ITransactionPhase0EnlistmentAsync_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1935,7 +1935,7 @@ impl ITransactionPhase0Factory_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&pphase0notify)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppphase0enlistment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppphase0enlistment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1991,7 +1991,7 @@ impl ITransactionReceiver_Vtbl {
             let this = (*this).get_impl();
             match this.UnmarshalPropagationToken(::core::mem::transmute_copy(&cbtoken), ::core::mem::transmute_copy(&rgbtoken)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2002,7 +2002,7 @@ impl ITransactionReceiver_Vtbl {
             let this = (*this).get_impl();
             match this.GetReturnTokenSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbreturntoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbreturntoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2041,7 +2041,7 @@ impl ITransactionReceiverFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Create() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreceiver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreceiver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2161,7 +2161,7 @@ impl ITransactionTransmitter_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropagationTokenSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbtoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbtoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2206,7 +2206,7 @@ impl ITransactionTransmitterFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Create() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransmitter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransmitter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2246,7 +2246,7 @@ impl ITransactionVoterFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&ptransaction), ::core::mem::transmute(&pvoternotify)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvoterballot = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvoterballot, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2333,7 +2333,7 @@ impl IXATransLookup_Vtbl {
             let this = (*this).get_impl();
             match this.Lookup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2359,7 +2359,7 @@ impl IXATransLookup2_Vtbl {
             let this = (*this).get_impl();
             match this.Lookup(::core::mem::transmute_copy(&pxid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
@@ -102,7 +102,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.GetDomain(::core::mem::transmute(&bstrdomain), ::core::mem::transmute(&bstrdomaincontroller), ::core::mem::transmute_copy(&ldcflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pigpmdomain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pigpmdomain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -113,7 +113,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackupDir(::core::mem::transmute(&bstrbackupdir)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pigpmbackupdir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pigpmbackupdir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.GetSitesContainer(::core::mem::transmute(&bstrforest), ::core::mem::transmute(&bstrdomain), ::core::mem::transmute(&bstrdomaincontroller), ::core::mem::transmute_copy(&ldcflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmsitescontainer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmsitescontainer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -135,7 +135,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.GetRSOP(::core::mem::transmute_copy(&gpmrsopmode), ::core::mem::transmute(&bstrnamespace), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmrsop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmrsop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -146,7 +146,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePermission(::core::mem::transmute(&bstrtrustee), ::core::mem::transmute_copy(&perm), ::core::mem::transmute_copy(&binheritable)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppperm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppperm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -157,7 +157,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSearchCriteria() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmsearchcriteria = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmsearchcriteria, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -168,7 +168,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTrustee(::core::mem::transmute(&bstrtrustee)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmtrustee = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmtrustee, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -179,7 +179,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientSideExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmcsecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmcsecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.GetConstants() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmconstants = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmconstants, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.GetMigrationTable(::core::mem::transmute(&bstrmigrationtablepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmigrationtable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmigrationtable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -212,7 +212,7 @@ impl IGPM_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMigrationTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmigrationtable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmigrationtable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -258,7 +258,7 @@ impl IGPM2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackupDirEx(::core::mem::transmute(&bstrbackupdir), ::core::mem::transmute_copy(&backupdirtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmbackupdirex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmbackupdirex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -342,7 +342,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -353,7 +353,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.GPOID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -364,7 +364,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.GPODomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -375,7 +375,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.GPODisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -386,7 +386,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.Timestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -397,7 +397,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.Comment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -408,7 +408,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.BackupDir() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl IGPMBackup_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateReportToFile(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute(&bstrtargetfilepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -469,7 +469,7 @@ impl IGPMBackupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -480,7 +480,7 @@ impl IGPMBackupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -491,7 +491,7 @@ impl IGPMBackupCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmbackup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmbackup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -524,7 +524,7 @@ impl IGPMBackupDir_Vtbl {
             let this = (*this).get_impl();
             match this.BackupDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -535,7 +535,7 @@ impl IGPMBackupDir_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackup(::core::mem::transmute(&bstrid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbackup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbackup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -546,7 +546,7 @@ impl IGPMBackupDir_Vtbl {
             let this = (*this).get_impl();
             match this.SearchBackups(::core::mem::transmute(&pigpmsearchcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmbackupcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmbackupcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -580,7 +580,7 @@ impl IGPMBackupDirEx_Vtbl {
             let this = (*this).get_impl();
             match this.BackupDir() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbackupdir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbackupdir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -591,7 +591,7 @@ impl IGPMBackupDirEx_Vtbl {
             let this = (*this).get_impl();
             match this.BackupType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgpmbackuptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgpmbackuptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -602,7 +602,7 @@ impl IGPMBackupDirEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackup(::core::mem::transmute(&bstrid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbackup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbackup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -613,7 +613,7 @@ impl IGPMBackupDirEx_Vtbl {
             let this = (*this).get_impl();
             match this.SearchBackups(::core::mem::transmute(&pigpmsearchcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbackupcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbackupcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -647,7 +647,7 @@ impl IGPMCSECollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl IGPMCSECollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl IGPMCSECollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmcses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmcses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -703,7 +703,7 @@ impl IGPMClientSideExtension_Vtbl {
             let this = (*this).get_impl();
             match this.ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -714,7 +714,7 @@ impl IGPMClientSideExtension_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -725,7 +725,7 @@ impl IGPMClientSideExtension_Vtbl {
             let this = (*this).get_impl();
             match this.IsUserEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -736,7 +736,7 @@ impl IGPMClientSideExtension_Vtbl {
             let this = (*this).get_impl();
             match this.IsComputerEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -827,7 +827,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermGPOApply() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -838,7 +838,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermGPORead() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -849,7 +849,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermGPOEdit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -860,7 +860,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermGPOEditSecurityAndDelete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -871,7 +871,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermGPOCustom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -882,7 +882,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermWMIFilterEdit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -893,7 +893,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermWMIFilterFullControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -904,7 +904,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermWMIFilterCustom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -915,7 +915,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermSOMLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -926,7 +926,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermSOMLogging() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -937,7 +937,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermSOMPlanning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -948,7 +948,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermSOMGPOCreate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -959,7 +959,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermSOMWMICreate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -970,7 +970,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.PermSOMWMIFullControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -981,7 +981,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPOPermissions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -992,7 +992,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPOEffectivePermissions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1003,7 +1003,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPODisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1014,7 +1014,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPOWMIFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1025,7 +1025,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPOID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1036,7 +1036,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPOComputerExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1047,7 +1047,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPOUserExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1058,7 +1058,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertySOMLinks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1069,7 +1069,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyGPODomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1080,7 +1080,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyBackupMostRecent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1091,7 +1091,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchOpEquals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1102,7 +1102,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchOpContains() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1113,7 +1113,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchOpNotContains() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1124,7 +1124,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SearchOpNotEquals() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1135,7 +1135,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.UsePDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1146,7 +1146,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.UseAnyDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1157,7 +1157,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.DoNotUseW2KDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1168,7 +1168,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SOMSite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1179,7 +1179,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SOMDomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1190,7 +1190,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.SOMOU() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1201,7 +1201,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.get_SecurityFlags(::core::mem::transmute_copy(&vbowner), ::core::mem::transmute_copy(&vbgroup), ::core::mem::transmute_copy(&vbdacl), ::core::mem::transmute_copy(&vbsacl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1212,7 +1212,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.DoNotValidateDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1223,7 +1223,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.ReportHTML() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1234,7 +1234,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.ReportXML() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1245,7 +1245,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RSOPModeUnknown() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1256,7 +1256,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RSOPModePlanning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1267,7 +1267,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RSOPModeLogging() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1278,7 +1278,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.EntryTypeUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1289,7 +1289,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.EntryTypeComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1300,7 +1300,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.EntryTypeLocalGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1311,7 +1311,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.EntryTypeGlobalGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1322,7 +1322,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.EntryTypeUniversalGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1333,7 +1333,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.EntryTypeUNCPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1344,7 +1344,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.EntryTypeUnknown() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1355,7 +1355,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationOptionSameAsSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1366,7 +1366,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationOptionNone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1377,7 +1377,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationOptionByRelativeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1388,7 +1388,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationOptionSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1399,7 +1399,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.MigrationTableOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1410,7 +1410,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessSecurity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1421,7 +1421,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RsopLoggingNoComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1432,7 +1432,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RsopLoggingNoUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1443,7 +1443,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RsopPlanningAssumeSlowLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1454,7 +1454,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.get_RsopPlanningLoopbackOption(::core::mem::transmute_copy(&vbmerge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1465,7 +1465,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RsopPlanningAssumeUserWQLFilterTrue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1476,7 +1476,7 @@ impl IGPMConstants_Vtbl {
             let this = (*this).get_impl();
             match this.RsopPlanningAssumeCompWQLFilterTrue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1578,7 +1578,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.BackupTypeGPO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1589,7 +1589,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.BackupTypeStarterGPO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1600,7 +1600,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.StarterGPOTypeSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1611,7 +1611,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.StarterGPOTypeCustom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1622,7 +1622,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyStarterGPOPermissions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1633,7 +1633,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyStarterGPOEffectivePermissions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1644,7 +1644,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyStarterGPODisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1655,7 +1655,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyStarterGPOID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1666,7 +1666,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchPropertyStarterGPODomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1677,7 +1677,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.PermStarterGPORead() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1688,7 +1688,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.PermStarterGPOEdit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1699,7 +1699,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.PermStarterGPOFullControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1710,7 +1710,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.PermStarterGPOCustom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1721,7 +1721,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.ReportLegacy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1732,7 +1732,7 @@ impl IGPMConstants2_Vtbl {
             let this = (*this).get_impl();
             match this.ReportComments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1784,7 +1784,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.DomainController() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1795,7 +1795,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.Domain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1806,7 +1806,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGPO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewgpo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewgpo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1817,7 +1817,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.GetGPO(::core::mem::transmute(&bstrguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgpo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgpo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1828,7 +1828,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.SearchGPOs(::core::mem::transmute(&pigpmsearchcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmgpocollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmgpocollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1844,7 +1844,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.GetSOM(::core::mem::transmute(&bstrpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1855,7 +1855,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.SearchSOMs(::core::mem::transmute(&pigpmsearchcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmsomcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmsomcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1866,7 +1866,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.GetWMIFilter(::core::mem::transmute(&bstrpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwmifilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwmifilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1877,7 +1877,7 @@ impl IGPMDomain_Vtbl {
             let this = (*this).get_impl();
             match this.SearchWMIFilters(::core::mem::transmute(&pigpmsearchcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmwmifiltercollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmwmifiltercollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1920,7 +1920,7 @@ impl IGPMDomain2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStarterGPO() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewtemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewtemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1931,7 +1931,7 @@ impl IGPMDomain2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGPOFromStarterGPO(::core::mem::transmute(&pgpotemplate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewgpo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewgpo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1942,7 +1942,7 @@ impl IGPMDomain2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStarterGPO(::core::mem::transmute(&bstrguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptemplate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptemplate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1953,7 +1953,7 @@ impl IGPMDomain2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchStarterGPOs(::core::mem::transmute(&pigpmsearchcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmtemplatecollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmtemplatecollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2005,7 +2005,7 @@ impl IGPMDomain3_Vtbl {
             let this = (*this).get_impl();
             match this.InfrastructureDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2075,7 +2075,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2091,7 +2091,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2102,7 +2102,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2113,7 +2113,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.DomainName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2124,7 +2124,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.CreationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2135,7 +2135,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.ModificationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2146,7 +2146,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.UserDSVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2157,7 +2157,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.ComputerDSVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2168,7 +2168,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.UserSysvolVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2179,7 +2179,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.ComputerSysvolVersionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2190,7 +2190,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.GetWMIFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmwmifilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmwmifilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2216,7 +2216,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.IsUserEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2227,7 +2227,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.IsComputerEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2238,7 +2238,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecurityinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecurityinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2274,7 +2274,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateReportToFile(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute(&bstrtargetfilepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2295,7 +2295,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityDescriptor(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2306,7 +2306,7 @@ impl IGPMGPO_Vtbl {
             let this = (*this).get_impl();
             match this.IsACLConsistent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbconsistent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbconsistent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2369,7 +2369,7 @@ impl IGPMGPO2_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2406,7 +2406,7 @@ impl IGPMGPO3_Vtbl {
             let this = (*this).get_impl();
             match this.InfrastructureDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2449,7 +2449,7 @@ impl IGPMGPOCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2460,7 +2460,7 @@ impl IGPMGPOCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2471,7 +2471,7 @@ impl IGPMGPOCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmgpos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmgpos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2510,7 +2510,7 @@ impl IGPMGPOLink_Vtbl {
             let this = (*this).get_impl();
             match this.GPOID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2521,7 +2521,7 @@ impl IGPMGPOLink_Vtbl {
             let this = (*this).get_impl();
             match this.GPODomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2532,7 +2532,7 @@ impl IGPMGPOLink_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2548,7 +2548,7 @@ impl IGPMGPOLink_Vtbl {
             let this = (*this).get_impl();
             match this.Enforced() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2564,7 +2564,7 @@ impl IGPMGPOLink_Vtbl {
             let this = (*this).get_impl();
             match this.SOMLinkOrder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2575,7 +2575,7 @@ impl IGPMGPOLink_Vtbl {
             let this = (*this).get_impl();
             match this.SOM() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmsom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmsom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2619,7 +2619,7 @@ impl IGPMGPOLinksCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2630,7 +2630,7 @@ impl IGPMGPOLinksCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2641,7 +2641,7 @@ impl IGPMGPOLinksCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmlinks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmlinks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2675,7 +2675,7 @@ impl IGPMMapEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Source() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2686,7 +2686,7 @@ impl IGPMMapEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Destination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdestination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdestination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2697,7 +2697,7 @@ impl IGPMMapEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationOption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgpmdestoption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgpmdestoption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2708,7 +2708,7 @@ impl IGPMMapEntry_Vtbl {
             let this = (*this).get_impl();
             match this.EntryType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgpmentrytype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgpmentrytype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2742,7 +2742,7 @@ impl IGPMMapEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2753,7 +2753,7 @@ impl IGPMMapEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2764,7 +2764,7 @@ impl IGPMMapEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2812,7 +2812,7 @@ impl IGPMMigrationTable_Vtbl {
             let this = (*this).get_impl();
             match this.AddEntry(::core::mem::transmute(&bstrsource), ::core::mem::transmute_copy(&gpmentrytype), ::core::mem::transmute_copy(&pvardestination)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2823,7 +2823,7 @@ impl IGPMMigrationTable_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntry(::core::mem::transmute(&bstrsource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2839,7 +2839,7 @@ impl IGPMMigrationTable_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateDestination(::core::mem::transmute(&bstrsource), ::core::mem::transmute_copy(&pvardestination)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2850,7 +2850,7 @@ impl IGPMMigrationTable_Vtbl {
             let this = (*this).get_impl();
             match this.Validate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2861,7 +2861,7 @@ impl IGPMMigrationTable_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppentries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppentries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2901,7 +2901,7 @@ impl IGPMPermission_Vtbl {
             let this = (*this).get_impl();
             match this.Inherited() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2912,7 +2912,7 @@ impl IGPMPermission_Vtbl {
             let this = (*this).get_impl();
             match this.Inheritable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2923,7 +2923,7 @@ impl IGPMPermission_Vtbl {
             let this = (*this).get_impl();
             match this.Denied() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2934,7 +2934,7 @@ impl IGPMPermission_Vtbl {
             let this = (*this).get_impl();
             match this.Permission() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2945,7 +2945,7 @@ impl IGPMPermission_Vtbl {
             let this = (*this).get_impl();
             match this.Trustee() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmtrustee = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmtrustee, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3012,7 +3012,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.Mode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3023,7 +3023,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.Namespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3039,7 +3039,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.LoggingComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3055,7 +3055,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.LoggingUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3071,7 +3071,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.LoggingFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3087,7 +3087,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3103,7 +3103,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningDomainController() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3119,7 +3119,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningSiteName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3135,7 +3135,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3151,7 +3151,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningUserSOM() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3167,7 +3167,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningUserWMIFilters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3183,7 +3183,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningUserSecurityGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3199,7 +3199,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3215,7 +3215,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningComputerSOM() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3231,7 +3231,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningComputerWMIFilters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3247,7 +3247,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.PlanningComputerSecurityGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3258,7 +3258,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.LoggingEnumerateUsers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3284,7 +3284,7 @@ impl IGPMRSOP_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateReportToFile(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute(&bstrtargetfilepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3349,7 +3349,7 @@ impl IGPMResult_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmstatusmsgcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmstatusmsgcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3360,7 +3360,7 @@ impl IGPMResult_Vtbl {
             let this = (*this).get_impl();
             match this.Result() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3405,7 +3405,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.GPOInheritanceBlocked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3421,7 +3421,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3432,7 +3432,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3443,7 +3443,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGPOLink(::core::mem::transmute_copy(&llinkpos), ::core::mem::transmute(&pgpo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewgpolink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewgpolink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3454,7 +3454,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3465,7 +3465,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.GetGPOLinks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgpolinks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgpolinks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3476,7 +3476,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.GetInheritedGPOLinks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgpolinks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgpolinks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3487,7 +3487,7 @@ impl IGPMSOM_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecurityinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecurityinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3532,7 +3532,7 @@ impl IGPMSOMCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3543,7 +3543,7 @@ impl IGPMSOMCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3554,7 +3554,7 @@ impl IGPMSOMCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmsom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmsom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3610,7 +3610,7 @@ impl IGPMSecurityInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3621,7 +3621,7 @@ impl IGPMSecurityInfo_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3632,7 +3632,7 @@ impl IGPMSecurityInfo_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3685,7 +3685,7 @@ impl IGPMSitesContainer_Vtbl {
             let this = (*this).get_impl();
             match this.DomainController() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3696,7 +3696,7 @@ impl IGPMSitesContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Domain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3707,7 +3707,7 @@ impl IGPMSitesContainer_Vtbl {
             let this = (*this).get_impl();
             match this.Forest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3718,7 +3718,7 @@ impl IGPMSitesContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetSite(::core::mem::transmute(&bstrsitename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3729,7 +3729,7 @@ impl IGPMSitesContainer_Vtbl {
             let this = (*this).get_impl();
             match this.SearchSites(::core::mem::transmute(&pigpmsearchcriteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmsomcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmsomcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3782,7 +3782,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3798,7 +3798,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3814,7 +3814,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.Author() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3825,7 +3825,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.Product() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3836,7 +3836,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.CreationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3847,7 +3847,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3858,7 +3858,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.ModifiedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3869,7 +3869,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3880,7 +3880,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.ComputerVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3891,7 +3891,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.UserVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3902,7 +3902,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.StarterGPOVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3929,7 +3929,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.CopyTo(::core::mem::transmute_copy(&pvarnewdisplayname), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3940,7 +3940,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3951,7 +3951,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateReportToFile(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute(&bstrtargetfilepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3962,7 +3962,7 @@ impl IGPMStarterGPO_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecurityinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecurityinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4026,7 +4026,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.BackupDir() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrbackupdir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrbackupdir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4037,7 +4037,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.Comment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcomment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcomment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4048,7 +4048,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4059,7 +4059,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.Domain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtemplatedomain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtemplatedomain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4070,7 +4070,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.StarterGPOID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtemplateid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtemplateid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4081,7 +4081,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4092,7 +4092,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.Timestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptimestamp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptimestamp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4103,7 +4103,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4124,7 +4124,7 @@ impl IGPMStarterGPOBackup_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateReportToFile(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute(&bstrtargetfilepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4165,7 +4165,7 @@ impl IGPMStarterGPOBackupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4176,7 +4176,7 @@ impl IGPMStarterGPOBackupCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4187,7 +4187,7 @@ impl IGPMStarterGPOBackupCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmtmplbackup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmtmplbackup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4220,7 +4220,7 @@ impl IGPMStarterGPOCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4231,7 +4231,7 @@ impl IGPMStarterGPOCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4242,7 +4242,7 @@ impl IGPMStarterGPOCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppigpmtemplates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppigpmtemplates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4278,7 +4278,7 @@ impl IGPMStatusMessage_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4294,7 +4294,7 @@ impl IGPMStatusMessage_Vtbl {
             let this = (*this).get_impl();
             match this.ExtensionName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4305,7 +4305,7 @@ impl IGPMStatusMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SettingsName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4321,7 +4321,7 @@ impl IGPMStatusMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4357,7 +4357,7 @@ impl IGPMStatusMsgCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4368,7 +4368,7 @@ impl IGPMStatusMsgCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4379,7 +4379,7 @@ impl IGPMStatusMsgCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4414,7 +4414,7 @@ impl IGPMTrustee_Vtbl {
             let this = (*this).get_impl();
             match this.TrusteeSid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4425,7 +4425,7 @@ impl IGPMTrustee_Vtbl {
             let this = (*this).get_impl();
             match this.TrusteeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4436,7 +4436,7 @@ impl IGPMTrustee_Vtbl {
             let this = (*this).get_impl();
             match this.TrusteeDomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4447,7 +4447,7 @@ impl IGPMTrustee_Vtbl {
             let this = (*this).get_impl();
             match this.TrusteeDSPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4458,7 +4458,7 @@ impl IGPMTrustee_Vtbl {
             let this = (*this).get_impl();
             match this.TrusteeType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4498,7 +4498,7 @@ impl IGPMWMIFilter_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4514,7 +4514,7 @@ impl IGPMWMIFilter_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4530,7 +4530,7 @@ impl IGPMWMIFilter_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4541,7 +4541,7 @@ impl IGPMWMIFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetQueryList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqrylist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqrylist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4552,7 +4552,7 @@ impl IGPMWMIFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsecurityinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsecurityinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4595,7 +4595,7 @@ impl IGPMWMIFilterCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4606,7 +4606,7 @@ impl IGPMWMIFilterCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4617,7 +4617,7 @@ impl IGPMWMIFilterCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4799,7 +4799,7 @@ impl IRSOPInformation_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventLogEntryText(::core::mem::transmute(&pszeventsource), ::core::mem::transmute(&pszeventlogname), ::core::mem::transmute(&pszeventtime), ::core::mem::transmute_copy(&dweventid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
@@ -45,7 +45,7 @@ impl AsyncIFtpAuthorizationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_GetUserAccessPermission() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftpaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftpaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -78,7 +78,7 @@ impl AsyncIFtpHomeDirectoryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_GetUserHomeDirectoryData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszhomedirectorydata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszhomedirectorydata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -141,7 +141,7 @@ impl AsyncIFtpPostprocessProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_HandlePostprocess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftpprocessstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftpprocessstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -177,7 +177,7 @@ impl AsyncIFtpPreprocessProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_HandlePreprocess() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftpprocessstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftpprocessstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -213,7 +213,7 @@ impl AsyncIFtpRoleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Finish_IsUserInRole() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisinrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisinrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -335,7 +335,7 @@ impl IFtpAuthorizationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserAccessPermission(::core::mem::transmute(&pszsessionid), ::core::mem::transmute(&pszsitename), ::core::mem::transmute(&pszvirtualpath), ::core::mem::transmute(&pszusername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftpaccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftpaccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl IFtpHomeDirectoryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserHomeDirectoryData(::core::mem::transmute(&pszsessionid), ::core::mem::transmute(&pszsitename), ::core::mem::transmute(&pszusername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszhomedirectorydata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszhomedirectorydata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -401,7 +401,7 @@ impl IFtpPostprocessProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HandlePostprocess(::core::mem::transmute_copy(&ppostprocessparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftpprocessstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftpprocessstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -427,7 +427,7 @@ impl IFtpPreprocessProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HandlePreprocess(::core::mem::transmute_copy(&ppreprocessparameters)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftpprocessstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftpprocessstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -473,7 +473,7 @@ impl IFtpRoleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsUserInRole(::core::mem::transmute(&pszsessionid), ::core::mem::transmute(&pszsitename), ::core::mem::transmute(&pszusername), ::core::mem::transmute(&pszrole)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisinrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisinrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -704,7 +704,7 @@ impl IMSAdminBaseW_Vtbl {
             let this = (*this).get_impl();
             match this.OpenKey(::core::mem::transmute_copy(&hmdhandle), ::core::mem::transmute(&pszmdpath), ::core::mem::transmute_copy(&dwmdaccessrequested), ::core::mem::transmute_copy(&dwmdtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phmdnewhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phmdnewhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -730,7 +730,7 @@ impl IMSAdminBaseW_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandleInfo(::core::mem::transmute_copy(&hmdhandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmdhiinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmdhiinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -741,7 +741,7 @@ impl IMSAdminBaseW_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemChangeNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsystemchangenumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsystemchangenumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -752,7 +752,7 @@ impl IMSAdminBaseW_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataSetNumber(::core::mem::transmute_copy(&hmdhandle), ::core::mem::transmute(&pszmdpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmddatasetnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmddatasetnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -803,7 +803,7 @@ impl IMSAdminBaseW_Vtbl {
             let this = (*this).get_impl();
             match this.UnmarshalInterface() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piadmbwinterface = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piadmbwinterface, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/impl.rs
@@ -12,7 +12,7 @@ impl IMSMQApplication_Vtbl {
             let this = (*this).get_impl();
             match this.MachineIdOfMachineName(::core::mem::transmute(&machinename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -49,7 +49,7 @@ impl IMSMQApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.MachineNameOfMachineId(::core::mem::transmute(&bstrguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmachinename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmachinename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -60,7 +60,7 @@ impl IMSMQApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.MSMQVersionMajor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psmsmqversionmajor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psmsmqversionmajor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -71,7 +71,7 @@ impl IMSMQApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.MSMQVersionMinor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psmsmqversionminor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psmsmqversionminor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -82,7 +82,7 @@ impl IMSMQApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.MSMQVersionBuild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psmsmqversionbuild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psmsmqversionbuild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -93,7 +93,7 @@ impl IMSMQApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.IsDsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisdsenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisdsenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -104,7 +104,7 @@ impl IMSMQApplication2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -148,7 +148,7 @@ impl IMSMQApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.ActiveQueues() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvactivequeues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvactivequeues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -159,7 +159,7 @@ impl IMSMQApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.PrivateQueues() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvprivatequeues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvprivatequeues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -170,7 +170,7 @@ impl IMSMQApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.DirectoryServiceServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdirectoryserviceserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdirectoryserviceserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -181,7 +181,7 @@ impl IMSMQApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -192,7 +192,7 @@ impl IMSMQApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.BytesInAllQueues() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbytesinallqueues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbytesinallqueues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -208,7 +208,7 @@ impl IMSMQApplication3_Vtbl {
             let this = (*this).get_impl();
             match this.Machine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmachine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmachine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -263,7 +263,7 @@ impl IMSMQCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarret = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarret, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -274,7 +274,7 @@ impl IMSMQCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -285,7 +285,7 @@ impl IMSMQCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IMSMQCoordinatedTransactionDispenser_Vtbl {
             let this = (*this).get_impl();
             match this.BeginTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -343,7 +343,7 @@ impl IMSMQCoordinatedTransactionDispenser2_Vtbl {
             let this = (*this).get_impl();
             match this.BeginTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -354,7 +354,7 @@ impl IMSMQCoordinatedTransactionDispenser2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -385,7 +385,7 @@ impl IMSMQCoordinatedTransactionDispenser3_Vtbl {
             let this = (*this).get_impl();
             match this.BeginTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -396,7 +396,7 @@ impl IMSMQCoordinatedTransactionDispenser3_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -449,7 +449,7 @@ impl IMSMQDestination_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -460,7 +460,7 @@ impl IMSMQDestination_Vtbl {
             let this = (*this).get_impl();
             match this.IADs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiads = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiads, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -476,7 +476,7 @@ impl IMSMQDestination_Vtbl {
             let this = (*this).get_impl();
             match this.ADsPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstradspath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstradspath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -492,7 +492,7 @@ impl IMSMQDestination_Vtbl {
             let this = (*this).get_impl();
             match this.PathName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -508,7 +508,7 @@ impl IMSMQDestination_Vtbl {
             let this = (*this).get_impl();
             match this.FormatName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrformatname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrformatname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -524,7 +524,7 @@ impl IMSMQDestination_Vtbl {
             let this = (*this).get_impl();
             match this.Destinations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestinations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestinations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IMSMQDestination_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -595,7 +595,7 @@ impl IMSMQEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -647,7 +647,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.FormatName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrformatname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrformatname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.Machine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmachine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmachine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -669,7 +669,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.MessageCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmessagecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmessagecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.ForeignStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plforeignstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plforeignstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -691,7 +691,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.QueueType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plqueuetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plqueuetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -702,7 +702,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.IsLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfislocal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfislocal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -713,7 +713,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionalStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltransactionalstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltransactionalstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -724,7 +724,7 @@ impl IMSMQManagement_Vtbl {
             let this = (*this).get_impl();
             match this.BytesInQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbytesinqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbytesinqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -809,7 +809,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Class() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -820,7 +820,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -836,7 +836,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.AuthLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -852,7 +852,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.IsAuthenticated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisauthenticated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisauthenticated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -863,7 +863,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Delivery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldelivery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldelivery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -879,7 +879,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Trace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltrace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltrace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -895,7 +895,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -911,7 +911,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -927,7 +927,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.AppSpecific() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plappspecific = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plappspecific, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -959,7 +959,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SourceMachineGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidsrcmachine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidsrcmachine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -970,7 +970,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.BodyLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -981,7 +981,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Body() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -997,7 +997,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1013,7 +1013,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1024,7 +1024,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.CorrelationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1040,7 +1040,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Ack() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plack = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plack, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1056,7 +1056,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1072,7 +1072,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReachQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreachqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreachqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1088,7 +1088,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReceive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreceive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreceive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1104,7 +1104,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhashalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhashalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1120,7 +1120,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plencryptalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plencryptalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1136,7 +1136,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SentTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1147,7 +1147,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.ArrivedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plarrivedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plarrivedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1158,7 +1158,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfodest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfodest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1169,7 +1169,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SenderCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsendercert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsendercert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1185,7 +1185,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SenderId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenderid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenderid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1196,7 +1196,7 @@ impl IMSMQMessage_Vtbl {
             let this = (*this).get_impl();
             match this.SenderIdType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsenderidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsenderidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1362,7 +1362,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Class() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1373,7 +1373,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1389,7 +1389,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.AuthLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1405,7 +1405,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.IsAuthenticated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisauthenticated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisauthenticated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1416,7 +1416,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Delivery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldelivery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldelivery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1432,7 +1432,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Trace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltrace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltrace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1448,7 +1448,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1464,7 +1464,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1480,7 +1480,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo_v1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1496,7 +1496,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.AppSpecific() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plappspecific = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plappspecific, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1512,7 +1512,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SourceMachineGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidsrcmachine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidsrcmachine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1523,7 +1523,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.BodyLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1534,7 +1534,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Body() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1550,7 +1550,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo_v1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1566,7 +1566,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1577,7 +1577,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.CorrelationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1593,7 +1593,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Ack() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plack = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plack, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1609,7 +1609,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1625,7 +1625,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReachQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreachqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreachqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1641,7 +1641,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReceive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreceive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreceive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1657,7 +1657,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhashalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhashalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1673,7 +1673,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plencryptalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plencryptalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1689,7 +1689,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SentTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1700,7 +1700,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.ArrivedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plarrivedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plarrivedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1711,7 +1711,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfodest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfodest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1722,7 +1722,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SenderCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsendercert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsendercert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1738,7 +1738,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SenderId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenderid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenderid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1749,7 +1749,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SenderIdType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsenderidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsenderidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1775,7 +1775,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.SenderVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsenderversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsenderversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1786,7 +1786,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Extension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarextension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarextension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1802,7 +1802,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectorTypeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidconnectortype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidconnectortype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1818,7 +1818,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionStatusQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoxactstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoxactstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1829,7 +1829,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationSymmetricKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardestsymmkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardestsymmkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1845,7 +1845,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Signature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1861,7 +1861,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationProviderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthprovtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthprovtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1877,7 +1877,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrauthprovname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrauthprovname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1898,7 +1898,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.MsgClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmsgclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmsgclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1914,7 +1914,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1925,7 +1925,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarxactid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarxactid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1936,7 +1936,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.IsFirstInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisfirstinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisfirstinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1947,7 +1947,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.IsLastInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pislastinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pislastinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1958,7 +1958,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1974,7 +1974,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1990,7 +1990,7 @@ impl IMSMQMessage2_Vtbl {
             let this = (*this).get_impl();
             match this.ReceivedAuthenticationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psreceivedauthenticationlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psreceivedauthenticationlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2183,7 +2183,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Class() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2194,7 +2194,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2210,7 +2210,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.AuthLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2226,7 +2226,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.IsAuthenticated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisauthenticated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisauthenticated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2237,7 +2237,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Delivery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldelivery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldelivery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2253,7 +2253,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Trace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltrace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltrace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2269,7 +2269,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2285,7 +2285,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2301,7 +2301,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo_v1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2317,7 +2317,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.AppSpecific() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plappspecific = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plappspecific, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2333,7 +2333,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.SourceMachineGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidsrcmachine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidsrcmachine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2344,7 +2344,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.BodyLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2355,7 +2355,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Body() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2371,7 +2371,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo_v1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2387,7 +2387,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2398,7 +2398,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.CorrelationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2414,7 +2414,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Ack() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plack = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plack, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2430,7 +2430,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2446,7 +2446,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReachQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreachqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreachqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2462,7 +2462,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReceive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreceive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreceive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2478,7 +2478,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhashalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhashalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2494,7 +2494,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plencryptalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plencryptalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2510,7 +2510,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.SentTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2521,7 +2521,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.ArrivedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plarrivedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plarrivedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2532,7 +2532,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfodest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfodest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2543,7 +2543,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.SenderCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsendercert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsendercert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2559,7 +2559,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.SenderId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenderid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenderid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2570,7 +2570,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.SenderIdType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsenderidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsenderidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2596,7 +2596,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.SenderVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsenderversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsenderversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2607,7 +2607,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Extension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarextension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarextension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2623,7 +2623,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectorTypeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidconnectortype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidconnectortype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2639,7 +2639,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionStatusQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoxactstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoxactstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2650,7 +2650,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationSymmetricKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardestsymmkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardestsymmkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2666,7 +2666,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Signature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2682,7 +2682,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationProviderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthprovtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthprovtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2698,7 +2698,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrauthprovname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrauthprovname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2719,7 +2719,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.MsgClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmsgclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmsgclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2735,7 +2735,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2746,7 +2746,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarxactid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarxactid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2757,7 +2757,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.IsFirstInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisfirstinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisfirstinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2768,7 +2768,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.IsLastInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pislastinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pislastinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2779,7 +2779,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo_v2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2795,7 +2795,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo_v2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2811,7 +2811,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceivedAuthenticationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psreceivedauthenticationlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psreceivedauthenticationlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2822,7 +2822,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2838,7 +2838,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2854,7 +2854,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseDestination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2870,7 +2870,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.Destination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestdestination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestdestination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2881,7 +2881,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.LookupId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarlookupid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarlookupid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2892,7 +2892,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.IsAuthenticated2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisauthenticated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisauthenticated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2903,7 +2903,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.IsFirstInTransaction2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisfirstinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisfirstinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2914,7 +2914,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.IsLastInTransaction2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pislastinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pislastinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2930,7 +2930,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.SoapEnvelope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsoapenvelope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsoapenvelope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2941,7 +2941,7 @@ impl IMSMQMessage3_Vtbl {
             let this = (*this).get_impl();
             match this.CompoundMessage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcompoundmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcompoundmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3160,7 +3160,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Class() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3171,7 +3171,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3187,7 +3187,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.AuthLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3203,7 +3203,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.IsAuthenticated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisauthenticated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisauthenticated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3214,7 +3214,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Delivery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pldelivery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pldelivery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3230,7 +3230,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Trace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltrace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltrace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3246,7 +3246,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3262,7 +3262,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3278,7 +3278,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo_v1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3294,7 +3294,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.AppSpecific() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plappspecific = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plappspecific, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3310,7 +3310,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.SourceMachineGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidsrcmachine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidsrcmachine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3321,7 +3321,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.BodyLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3332,7 +3332,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Body() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbody = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbody, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3348,7 +3348,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo_v1() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3364,7 +3364,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3375,7 +3375,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.CorrelationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmsgid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmsgid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3391,7 +3391,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Ack() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plack = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plack, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3407,7 +3407,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3423,7 +3423,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReachQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreachqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreachqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3439,7 +3439,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.MaxTimeToReceive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxtimetoreceive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxtimetoreceive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3455,7 +3455,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.HashAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhashalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhashalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3471,7 +3471,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.EncryptAlgorithm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plencryptalg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plencryptalg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3487,7 +3487,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.SentTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3498,7 +3498,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.ArrivedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plarrivedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plarrivedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3509,7 +3509,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfodest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfodest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3520,7 +3520,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.SenderCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsendercert = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsendercert, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3536,7 +3536,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.SenderId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsenderid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsenderid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3547,7 +3547,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.SenderIdType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsenderidtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsenderidtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3573,7 +3573,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.SenderVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsenderversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsenderversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3584,7 +3584,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Extension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarextension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarextension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3600,7 +3600,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectorTypeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidconnectortype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidconnectortype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3616,7 +3616,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionStatusQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoxactstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoxactstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3627,7 +3627,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.DestinationSymmetricKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardestsymmkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardestsymmkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3643,7 +3643,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Signature() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsignature = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsignature, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3659,7 +3659,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationProviderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthprovtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthprovtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3675,7 +3675,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrauthprovname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrauthprovname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3696,7 +3696,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.MsgClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmsgclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmsgclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3712,7 +3712,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3723,7 +3723,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarxactid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarxactid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3734,7 +3734,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.IsFirstInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisfirstinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisfirstinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3745,7 +3745,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.IsLastInTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pislastinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pislastinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3756,7 +3756,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo_v2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3772,7 +3772,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo_v2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3788,7 +3788,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceivedAuthenticationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psreceivedauthenticationlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psreceivedauthenticationlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3799,7 +3799,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinforesponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinforesponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3815,7 +3815,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.AdminQueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfoadmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfoadmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3831,7 +3831,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.ResponseDestination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3847,7 +3847,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.Destination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdestdestination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdestdestination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3858,7 +3858,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.LookupId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarlookupid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarlookupid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3869,7 +3869,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.IsAuthenticated2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisauthenticated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisauthenticated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3880,7 +3880,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.IsFirstInTransaction2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisfirstinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisfirstinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3891,7 +3891,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.IsLastInTransaction2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pislastinxact = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pislastinxact, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3907,7 +3907,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.SoapEnvelope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsoapenvelope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsoapenvelope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3918,7 +3918,7 @@ impl IMSMQMessage4_Vtbl {
             let this = (*this).get_impl();
             match this.CompoundMessage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcompoundmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcompoundmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4052,7 +4052,7 @@ impl IMSMQOutgoingQueueManagement_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4063,7 +4063,7 @@ impl IMSMQOutgoingQueueManagement_Vtbl {
             let this = (*this).get_impl();
             match this.NextHops() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvnexthops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvnexthops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4074,7 +4074,7 @@ impl IMSMQOutgoingQueueManagement_Vtbl {
             let this = (*this).get_impl();
             match this.EodGetSendInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4124,7 +4124,7 @@ impl IMSMQPrivateDestination_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4161,7 +4161,7 @@ impl IMSMQPrivateEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Hwnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4202,7 +4202,7 @@ impl IMSMQQuery_Vtbl {
             let this = (*this).get_impl();
             match this.LookupQueue(::core::mem::transmute_copy(&queueguid), ::core::mem::transmute_copy(&servicetypeguid), ::core::mem::transmute_copy(&label), ::core::mem::transmute_copy(&createtime), ::core::mem::transmute_copy(&modifytime), ::core::mem::transmute_copy(&relservicetype), ::core::mem::transmute_copy(&rellabel), ::core::mem::transmute_copy(&relcreatetime), ::core::mem::transmute_copy(&relmodifytime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4229,7 +4229,7 @@ impl IMSMQQuery2_Vtbl {
             let this = (*this).get_impl();
             match this.LookupQueue(::core::mem::transmute_copy(&queueguid), ::core::mem::transmute_copy(&servicetypeguid), ::core::mem::transmute_copy(&label), ::core::mem::transmute_copy(&createtime), ::core::mem::transmute_copy(&modifytime), ::core::mem::transmute_copy(&relservicetype), ::core::mem::transmute_copy(&rellabel), ::core::mem::transmute_copy(&relcreatetime), ::core::mem::transmute_copy(&relmodifytime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4240,7 +4240,7 @@ impl IMSMQQuery2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4272,7 +4272,7 @@ impl IMSMQQuery3_Vtbl {
             let this = (*this).get_impl();
             match this.LookupQueue_v2(::core::mem::transmute_copy(&queueguid), ::core::mem::transmute_copy(&servicetypeguid), ::core::mem::transmute_copy(&label), ::core::mem::transmute_copy(&createtime), ::core::mem::transmute_copy(&modifytime), ::core::mem::transmute_copy(&relservicetype), ::core::mem::transmute_copy(&rellabel), ::core::mem::transmute_copy(&relcreatetime), ::core::mem::transmute_copy(&relmodifytime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4283,7 +4283,7 @@ impl IMSMQQuery3_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4306,7 +4306,7 @@ impl IMSMQQuery3_Vtbl {
                 ::core::mem::transmute_copy(&relmulticastaddress),
             ) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4339,7 +4339,7 @@ impl IMSMQQuery4_Vtbl {
             let this = (*this).get_impl();
             match this.LookupQueue_v2(::core::mem::transmute_copy(&queueguid), ::core::mem::transmute_copy(&servicetypeguid), ::core::mem::transmute_copy(&label), ::core::mem::transmute_copy(&createtime), ::core::mem::transmute_copy(&modifytime), ::core::mem::transmute_copy(&relservicetype), ::core::mem::transmute_copy(&rellabel), ::core::mem::transmute_copy(&relcreatetime), ::core::mem::transmute_copy(&relmodifytime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4350,7 +4350,7 @@ impl IMSMQQuery4_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4373,7 +4373,7 @@ impl IMSMQQuery4_Vtbl {
                 ::core::mem::transmute_copy(&relmulticastaddress),
             ) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4416,7 +4416,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Access() {
                 ::core::result::Result::Ok(ok__) => {
-                    *placcess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(placcess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4427,7 +4427,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.ShareMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsharemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsharemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4438,7 +4438,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.QueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4449,7 +4449,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4460,7 +4460,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4476,7 +4476,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Receive(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4487,7 +4487,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.Peek(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4508,7 +4508,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveCurrent(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4519,7 +4519,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNext(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4530,7 +4530,7 @@ impl IMSMQQueue_Vtbl {
             let this = (*this).get_impl();
             match this.PeekCurrent(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4589,7 +4589,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.Access() {
                 ::core::result::Result::Ok(ok__) => {
-                    *placcess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(placcess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4600,7 +4600,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.ShareMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsharemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsharemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4611,7 +4611,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.QueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4622,7 +4622,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4633,7 +4633,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4649,7 +4649,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.Receive_v1(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4660,7 +4660,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.Peek_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4681,7 +4681,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveCurrent_v1(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4692,7 +4692,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNext_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4703,7 +4703,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.PeekCurrent_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4714,7 +4714,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.Receive(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4725,7 +4725,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.Peek(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4736,7 +4736,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveCurrent(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4747,7 +4747,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNext(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4758,7 +4758,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.PeekCurrent(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4769,7 +4769,7 @@ impl IMSMQQueue2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4847,7 +4847,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Access() {
                 ::core::result::Result::Ok(ok__) => {
-                    *placcess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(placcess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4858,7 +4858,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ShareMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsharemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsharemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4869,7 +4869,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.QueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4880,7 +4880,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4891,7 +4891,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4907,7 +4907,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Receive_v1(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4918,7 +4918,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Peek_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4939,7 +4939,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveCurrent_v1(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4950,7 +4950,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNext_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4961,7 +4961,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekCurrent_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4972,7 +4972,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Receive(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4983,7 +4983,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Peek(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4994,7 +4994,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveCurrent(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5005,7 +5005,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNext(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5016,7 +5016,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekCurrent(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5027,7 +5027,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5038,7 +5038,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.Handle2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5049,7 +5049,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5060,7 +5060,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveNextByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5071,7 +5071,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceivePreviousByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5082,7 +5082,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveFirstByLookupId(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5093,7 +5093,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveLastByLookupId(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5104,7 +5104,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5115,7 +5115,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNextByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5126,7 +5126,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekPreviousByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5137,7 +5137,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekFirstByLookupId(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5148,7 +5148,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.PeekLastByLookupId(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5164,7 +5164,7 @@ impl IMSMQQueue3_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpen2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5256,7 +5256,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Access() {
                 ::core::result::Result::Ok(ok__) => {
-                    *placcess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(placcess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5267,7 +5267,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ShareMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsharemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsharemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5278,7 +5278,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.QueueInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5289,7 +5289,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5300,7 +5300,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5316,7 +5316,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Receive_v1(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5327,7 +5327,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Peek_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5348,7 +5348,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveCurrent_v1(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5359,7 +5359,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNext_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5370,7 +5370,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekCurrent_v1(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5381,7 +5381,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Receive(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5392,7 +5392,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Peek(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5403,7 +5403,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveCurrent(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5414,7 +5414,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNext(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5425,7 +5425,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekCurrent(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&receivetimeout), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5436,7 +5436,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5447,7 +5447,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.Handle2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarhandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarhandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5458,7 +5458,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5469,7 +5469,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveNextByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5480,7 +5480,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceivePreviousByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5491,7 +5491,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveFirstByLookupId(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5502,7 +5502,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveLastByLookupId(::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5513,7 +5513,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5524,7 +5524,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekNextByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5535,7 +5535,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekPreviousByLookupId(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5546,7 +5546,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekFirstByLookupId(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5557,7 +5557,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.PeekLastByLookupId(::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5573,7 +5573,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.IsOpen2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5584,7 +5584,7 @@ impl IMSMQQueue4_Vtbl {
             let this = (*this).get_impl();
             match this.ReceiveByLookupIdAllowPeek(::core::mem::transmute(&lookupid), ::core::mem::transmute_copy(&transaction), ::core::mem::transmute_copy(&wantdestinationqueue), ::core::mem::transmute_copy(&wantbody), ::core::mem::transmute_copy(&wantconnectortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmsg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmsg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5674,7 +5674,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.QueueGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5685,7 +5685,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceTypeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidservicetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidservicetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5701,7 +5701,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5717,7 +5717,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PathName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5733,7 +5733,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.FormatName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrformatname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrformatname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5749,7 +5749,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransactional() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistransactional = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistransactional, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5760,7 +5760,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5776,7 +5776,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5792,7 +5792,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Quota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5808,7 +5808,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.BasePriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbasepriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbasepriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5824,7 +5824,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcreatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcreatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5835,7 +5835,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ModifyTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodifytime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodifytime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5846,7 +5846,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Authenticate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthenticate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthenticate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5862,7 +5862,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.JournalQuota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournalquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournalquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5878,7 +5878,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorldReadable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisworldreadable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisworldreadable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5899,7 +5899,7 @@ impl IMSMQQueueInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Open(::core::mem::transmute_copy(&access), ::core::mem::transmute_copy(&sharemode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6000,7 +6000,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.QueueGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6011,7 +6011,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceTypeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidservicetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidservicetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6027,7 +6027,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6043,7 +6043,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.PathName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6059,7 +6059,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.FormatName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrformatname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrformatname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6075,7 +6075,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransactional() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistransactional = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistransactional, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6086,7 +6086,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6102,7 +6102,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6118,7 +6118,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.Quota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6134,7 +6134,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.BasePriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbasepriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbasepriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6150,7 +6150,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcreatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcreatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6161,7 +6161,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.ModifyTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodifytime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodifytime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6172,7 +6172,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.Authenticate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthenticate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthenticate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6188,7 +6188,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.JournalQuota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournalquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournalquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6204,7 +6204,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorldReadable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisworldreadable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisworldreadable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6225,7 +6225,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.Open(::core::mem::transmute_copy(&access), ::core::mem::transmute_copy(&sharemode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6246,7 +6246,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.PathNameDNS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathnamedns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathnamedns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6257,7 +6257,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6268,7 +6268,7 @@ impl IMSMQQueueInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.Security() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6373,7 +6373,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.QueueGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6384,7 +6384,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceTypeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidservicetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidservicetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6400,7 +6400,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6416,7 +6416,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.PathName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6432,7 +6432,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.FormatName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrformatname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrformatname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6448,7 +6448,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransactional() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistransactional = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistransactional, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6459,7 +6459,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6475,7 +6475,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6491,7 +6491,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.Quota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6507,7 +6507,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.BasePriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbasepriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbasepriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6523,7 +6523,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcreatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcreatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6534,7 +6534,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.ModifyTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodifytime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodifytime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6545,7 +6545,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.Authenticate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthenticate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthenticate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6561,7 +6561,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.JournalQuota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournalquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournalquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6577,7 +6577,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorldReadable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisworldreadable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisworldreadable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6598,7 +6598,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.Open(::core::mem::transmute_copy(&access), ::core::mem::transmute_copy(&sharemode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6619,7 +6619,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.PathNameDNS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathnamedns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathnamedns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6630,7 +6630,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6641,7 +6641,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.Security() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6657,7 +6657,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransactional2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistransactional = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistransactional, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6668,7 +6668,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorldReadable2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisworldreadable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisworldreadable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6679,7 +6679,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.MulticastAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmulticastaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmulticastaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6695,7 +6695,7 @@ impl IMSMQQueueInfo3_Vtbl {
             let this = (*this).get_impl();
             match this.ADsPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstradspath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstradspath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6800,7 +6800,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.QueueGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidqueue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidqueue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6811,7 +6811,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceTypeGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrguidservicetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrguidservicetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6827,7 +6827,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6843,7 +6843,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.PathName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6859,7 +6859,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.FormatName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrformatname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrformatname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6875,7 +6875,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransactional() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistransactional = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistransactional, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6886,7 +6886,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.PrivLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plprivlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plprivlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6902,7 +6902,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.Journal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6918,7 +6918,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.Quota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6934,7 +6934,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.BasePriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plbasepriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plbasepriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6950,7 +6950,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarcreatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarcreatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6961,7 +6961,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.ModifyTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarmodifytime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarmodifytime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6972,7 +6972,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.Authenticate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plauthenticate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plauthenticate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6988,7 +6988,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.JournalQuota() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournalquota = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournalquota, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7004,7 +7004,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorldReadable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisworldreadable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisworldreadable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7025,7 +7025,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.Open(::core::mem::transmute_copy(&access), ::core::mem::transmute_copy(&sharemode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppq = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppq, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7046,7 +7046,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.PathNameDNS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpathnamedns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpathnamedns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7057,7 +7057,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7068,7 +7068,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.Security() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7084,7 +7084,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.IsTransactional2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistransactional = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistransactional, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7095,7 +7095,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorldReadable2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisworldreadable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisworldreadable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7106,7 +7106,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.MulticastAddress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmulticastaddress = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmulticastaddress, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7122,7 +7122,7 @@ impl IMSMQQueueInfo4_Vtbl {
             let this = (*this).get_impl();
             match this.ADsPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstradspath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstradspath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7195,7 +7195,7 @@ impl IMSMQQueueInfos_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfonext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfonext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7232,7 +7232,7 @@ impl IMSMQQueueInfos2_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfonext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfonext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7243,7 +7243,7 @@ impl IMSMQQueueInfos2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7281,7 +7281,7 @@ impl IMSMQQueueInfos3_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfonext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfonext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7292,7 +7292,7 @@ impl IMSMQQueueInfos3_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7330,7 +7330,7 @@ impl IMSMQQueueInfos4_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqinfonext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqinfonext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7341,7 +7341,7 @@ impl IMSMQQueueInfos4_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7374,7 +7374,7 @@ impl IMSMQQueueManagement_Vtbl {
             let this = (*this).get_impl();
             match this.JournalMessageCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pljournalmessagecount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pljournalmessagecount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7385,7 +7385,7 @@ impl IMSMQQueueManagement_Vtbl {
             let this = (*this).get_impl();
             match this.BytesInJournal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbytesinjournal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbytesinjournal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7396,7 +7396,7 @@ impl IMSMQQueueManagement_Vtbl {
             let this = (*this).get_impl();
             match this.EodGetReceiveInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7429,7 +7429,7 @@ impl IMSMQTransaction_Vtbl {
             let this = (*this).get_impl();
             match this.Transaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pltransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pltransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7476,7 +7476,7 @@ impl IMSMQTransaction2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7506,7 +7506,7 @@ impl IMSMQTransaction3_Vtbl {
             let this = (*this).get_impl();
             match this.ITransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaritransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaritransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7532,7 +7532,7 @@ impl IMSMQTransactionDispenser_Vtbl {
             let this = (*this).get_impl();
             match this.BeginTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7559,7 +7559,7 @@ impl IMSMQTransactionDispenser2_Vtbl {
             let this = (*this).get_impl();
             match this.BeginTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7570,7 +7570,7 @@ impl IMSMQTransactionDispenser2_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7601,7 +7601,7 @@ impl IMSMQTransactionDispenser3_Vtbl {
             let this = (*this).get_impl();
             match this.BeginTransaction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptransaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptransaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7612,7 +7612,7 @@ impl IMSMQTransactionDispenser3_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
@@ -33,7 +33,7 @@ impl Column_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -44,7 +44,7 @@ impl Column_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *width = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(width, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -60,7 +60,7 @@ impl Column_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -76,7 +76,7 @@ impl Column_Vtbl {
             let this = (*this).get_impl();
             match this.Hidden() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hidden = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hidden, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -97,7 +97,7 @@ impl Column_Vtbl {
             let this = (*this).get_impl();
             match this.IsSortColumn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *issortcolumn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issortcolumn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -136,7 +136,7 @@ impl Columns_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *column = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(column, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -147,7 +147,7 @@ impl Columns_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -158,7 +158,7 @@ impl Columns_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -191,7 +191,7 @@ impl ContextMenu_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -202,7 +202,7 @@ impl ContextMenu_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&indexorpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *menuitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(menuitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -213,7 +213,7 @@ impl ContextMenu_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -274,7 +274,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.Views() {
                 ::core::result::Result::Ok(ok__) => {
-                    *views = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(views, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -285,7 +285,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.SnapIns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *snapins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(snapins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -296,7 +296,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.ActiveView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *view = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(view, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -307,7 +307,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -323,7 +323,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.Location() {
                 ::core::result::Result::Ok(ok__) => {
-                    *location = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(location, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -334,7 +334,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.IsSaved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *issaved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issaved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -345,7 +345,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.Mode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -361,7 +361,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.RootNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *node = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(node, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -372,7 +372,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.ScopeNamespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scopenamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scopenamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -383,7 +383,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *properties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(properties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -394,7 +394,7 @@ impl Document_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *application = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(application, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -444,7 +444,7 @@ impl Extension_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -455,7 +455,7 @@ impl Extension_Vtbl {
             let this = (*this).get_impl();
             match this.Vendor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *vendor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(vendor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -466,7 +466,7 @@ impl Extension_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *version = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(version, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -477,7 +477,7 @@ impl Extension_Vtbl {
             let this = (*this).get_impl();
             match this.Extensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *extensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(extensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -488,7 +488,7 @@ impl Extension_Vtbl {
             let this = (*this).get_impl();
             match this.SnapinCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *snapinclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(snapinclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -535,7 +535,7 @@ impl Extensions_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -546,7 +546,7 @@ impl Extensions_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *extension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(extension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -557,7 +557,7 @@ impl Extensions_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -613,7 +613,7 @@ impl Frame_Vtbl {
             let this = (*this).get_impl();
             match this.Top() {
                 ::core::result::Result::Ok(ok__) => {
-                    *top = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(top, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -629,7 +629,7 @@ impl Frame_Vtbl {
             let this = (*this).get_impl();
             match this.Bottom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bottom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bottom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -645,7 +645,7 @@ impl Frame_Vtbl {
             let this = (*this).get_impl();
             match this.Left() {
                 ::core::result::Result::Ok(ok__) => {
-                    *left = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(left, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -661,7 +661,7 @@ impl Frame_Vtbl {
             let this = (*this).get_impl();
             match this.Right() {
                 ::core::result::Result::Ok(ok__) => {
-                    *right = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(right, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -710,7 +710,7 @@ impl IColumnData_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnConfigData(::core::mem::transmute_copy(&pcolid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolsetdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolsetdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -726,7 +726,7 @@ impl IColumnData_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnSortData(::core::mem::transmute_copy(&pcolid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolsortdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolsortdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -779,7 +779,7 @@ impl IComponent_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDataObject(::core::mem::transmute_copy(&cookie), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -831,7 +831,7 @@ impl IComponent2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDispatch(::core::mem::transmute_copy(&cookie), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdispatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdispatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -883,7 +883,7 @@ impl IComponentData_Vtbl {
             let this = (*this).get_impl();
             match this.CreateComponent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomponent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomponent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -904,7 +904,7 @@ impl IComponentData_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDataObject(::core::mem::transmute_copy(&cookie), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -949,7 +949,7 @@ impl IComponentData2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryDispatch(::core::mem::transmute_copy(&cookie), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdispatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdispatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -995,7 +995,7 @@ impl IConsole_Vtbl {
             let this = (*this).get_impl();
             match this.QueryResultView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1006,7 +1006,7 @@ impl IConsole_Vtbl {
             let this = (*this).get_impl();
             match this.QueryScopeImageList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimagelist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimagelist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1017,7 +1017,7 @@ impl IConsole_Vtbl {
             let this = (*this).get_impl();
             match this.QueryResultImageList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimagelist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimagelist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1033,7 +1033,7 @@ impl IConsole_Vtbl {
             let this = (*this).get_impl();
             match this.MessageBox(::core::mem::transmute(&lpsztext), ::core::mem::transmute(&lpsztitle), ::core::mem::transmute_copy(&fustyle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1044,7 +1044,7 @@ impl IConsole_Vtbl {
             let this = (*this).get_impl();
             match this.QueryConsoleVerb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconsoleverb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconsoleverb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1060,7 +1060,7 @@ impl IConsole_Vtbl {
             let this = (*this).get_impl();
             match this.GetMainWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1283,7 +1283,7 @@ impl IConsolePowerSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnPowerBroadcast(::core::mem::transmute_copy(&nevent), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plreturn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plreturn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1312,7 +1312,7 @@ impl IConsoleVerb_Vtbl {
             let this = (*this).get_impl();
             match this.GetVerbState(::core::mem::transmute_copy(&ecmdid), ::core::mem::transmute_copy(&nstate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1333,7 +1333,7 @@ impl IConsoleVerb_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultVerb() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pecmdid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pecmdid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1417,7 +1417,7 @@ impl IContextMenuProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ShowContextMenu(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&xpos), ::core::mem::transmute_copy(&ypos)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plselected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plselected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1448,7 +1448,7 @@ impl IControlbar_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&ntype), ::core::mem::transmute(&pextendcontrolbar)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1521,7 +1521,7 @@ impl IEnumTASK_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1673,7 +1673,7 @@ impl IExtendTaskPad_Vtbl {
             let this = (*this).get_impl();
             match this.EnumTasks(::core::mem::transmute(&pdo), ::core::mem::transmute(&sztaskgroup)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumtask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumtask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1684,7 +1684,7 @@ impl IExtendTaskPad_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitle(::core::mem::transmute(&pszgroup)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psztitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psztitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1695,7 +1695,7 @@ impl IExtendTaskPad_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescriptiveText(::core::mem::transmute(&pszgroup)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdescriptivetext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdescriptivetext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1706,7 +1706,7 @@ impl IExtendTaskPad_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackground(::core::mem::transmute(&pszgroup)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptdo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptdo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1717,7 +1717,7 @@ impl IExtendTaskPad_Vtbl {
             let this = (*this).get_impl();
             match this.GetListPadInfo(::core::mem::transmute(&pszgroup)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplistpadinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplistpadinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1788,7 +1788,7 @@ impl IHeaderCtrl_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnText(::core::mem::transmute_copy(&ncol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1804,7 +1804,7 @@ impl IHeaderCtrl_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnWidth(::core::mem::transmute_copy(&ncol)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1994,7 +1994,7 @@ impl INodeProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&pdataobject), ::core::mem::transmute(&szpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2105,7 +2105,7 @@ impl IRequiredExtensions_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2116,7 +2116,7 @@ impl IRequiredExtensions_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pextclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pextclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2171,7 +2171,7 @@ impl IResultData_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemByLParam(::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2217,7 +2217,7 @@ impl IResultData_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lviewmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lviewmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2320,7 +2320,7 @@ impl IResultDataCompareEx_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute_copy(&prdc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2348,7 +2348,7 @@ impl IResultOwnerData_Vtbl {
             let this = (*this).get_impl();
             match this.FindItem(::core::mem::transmute_copy(&pfindinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnfoundindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnfoundindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2393,7 +2393,7 @@ impl ISnapinAbout_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapinDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2404,7 +2404,7 @@ impl ISnapinAbout_Vtbl {
             let this = (*this).get_impl();
             match this.GetProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2415,7 +2415,7 @@ impl ISnapinAbout_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapinVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2426,7 +2426,7 @@ impl ISnapinAbout_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapinImage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *happicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(happicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2461,7 +2461,7 @@ impl ISnapinHelp_Vtbl {
             let this = (*this).get_impl();
             match this.GetHelpTopic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpcompiledhelpfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpcompiledhelpfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2484,7 +2484,7 @@ impl ISnapinHelp2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkedTopics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpcompiledhelpfiles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpcompiledhelpfiles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2570,7 +2570,7 @@ impl IStringTable_Vtbl {
             let this = (*this).get_impl();
             match this.AddString(::core::mem::transmute(&pszadd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstringid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstringid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2586,7 +2586,7 @@ impl IStringTable_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringLength(::core::mem::transmute_copy(&stringid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2607,7 +2607,7 @@ impl IStringTable_Vtbl {
             let this = (*this).get_impl();
             match this.FindString(::core::mem::transmute(&pszfind)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstringid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstringid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2618,7 +2618,7 @@ impl IStringTable_Vtbl {
             let this = (*this).get_impl();
             match this.Enumerate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2678,7 +2678,7 @@ impl IToolbar_Vtbl {
             let this = (*this).get_impl();
             match this.GetButtonState(::core::mem::transmute_copy(&idcommand), ::core::mem::transmute_copy(&nstate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2742,7 +2742,7 @@ impl MenuItem_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2753,7 +2753,7 @@ impl MenuItem_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageIndependentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *languageindependentname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(languageindependentname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2764,7 +2764,7 @@ impl MenuItem_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2775,7 +2775,7 @@ impl MenuItem_Vtbl {
             let this = (*this).get_impl();
             match this.LanguageIndependentPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *languageindependentpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(languageindependentpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2791,7 +2791,7 @@ impl MenuItem_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2829,7 +2829,7 @@ impl Node_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2840,7 +2840,7 @@ impl Node_Vtbl {
             let this = (*this).get_impl();
             match this.get_Property(::core::mem::transmute(&propertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2851,7 +2851,7 @@ impl Node_Vtbl {
             let this = (*this).get_impl();
             match this.Bookmark() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bookmark = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bookmark, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2862,7 +2862,7 @@ impl Node_Vtbl {
             let this = (*this).get_impl();
             match this.IsScopeNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isscopenode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isscopenode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2873,7 +2873,7 @@ impl Node_Vtbl {
             let this = (*this).get_impl();
             match this.Nodetype() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nodetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nodetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2908,7 +2908,7 @@ impl Nodes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2919,7 +2919,7 @@ impl Nodes_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *node = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(node, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2930,7 +2930,7 @@ impl Nodes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2964,7 +2964,7 @@ impl Properties_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2975,7 +2975,7 @@ impl Properties_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *property = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(property, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2986,7 +2986,7 @@ impl Properties_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3025,7 +3025,7 @@ impl Property_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3041,7 +3041,7 @@ impl Property_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3076,7 +3076,7 @@ impl ScopeNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.GetParent(::core::mem::transmute(&node)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *parent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3087,7 +3087,7 @@ impl ScopeNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.GetChild(::core::mem::transmute(&node)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *child = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(child, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3098,7 +3098,7 @@ impl ScopeNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.GetNext(::core::mem::transmute(&node)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *next = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(next, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3109,7 +3109,7 @@ impl ScopeNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.GetRoot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *root = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(root, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3153,7 +3153,7 @@ impl SnapIn_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3164,7 +3164,7 @@ impl SnapIn_Vtbl {
             let this = (*this).get_impl();
             match this.Vendor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *vendor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(vendor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3175,7 +3175,7 @@ impl SnapIn_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *version = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(version, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3186,7 +3186,7 @@ impl SnapIn_Vtbl {
             let this = (*this).get_impl();
             match this.Extensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *extensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(extensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3197,7 +3197,7 @@ impl SnapIn_Vtbl {
             let this = (*this).get_impl();
             match this.SnapinCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *snapinclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(snapinclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3208,7 +3208,7 @@ impl SnapIn_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *properties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(properties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3252,7 +3252,7 @@ impl SnapIns_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3263,7 +3263,7 @@ impl SnapIns_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *snapin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(snapin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3274,7 +3274,7 @@ impl SnapIns_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3285,7 +3285,7 @@ impl SnapIns_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&snapinnameorclsid), ::core::mem::transmute(&parentsnapin), ::core::mem::transmute(&properties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *snapin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(snapin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3364,7 +3364,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.ActiveScopeNode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *node = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(node, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3380,7 +3380,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.Selection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3391,7 +3391,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.ListItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *nodes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nodes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3402,7 +3402,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.SnapinScopeObject(::core::mem::transmute(&scopenode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *scopenodeobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scopenodeobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3413,7 +3413,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.SnapinSelectionObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selectionobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selectionobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3424,7 +3424,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.Is(::core::mem::transmute(&view)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *thesame = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(thesame, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3435,7 +3435,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.Document() {
                 ::core::result::Result::Ok(ok__) => {
-                    *document = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(document, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3461,7 +3461,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.IsSelected(::core::mem::transmute(&node)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isselected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isselected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.get_ScopeNodeContextMenu(::core::mem::transmute(&scopenode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contextmenu = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contextmenu, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.SelectionContextMenu() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contextmenu = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contextmenu, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3559,7 +3559,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.Frame() {
                 ::core::result::Result::Ok(ok__) => {
-                    *frame = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(frame, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3575,7 +3575,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.ScopeTreeVisible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3606,7 +3606,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.Memento() {
                 ::core::result::Result::Ok(ok__) => {
-                    *memento = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(memento, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3622,7 +3622,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.Columns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3633,7 +3633,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.get_CellContents(::core::mem::transmute(&node), ::core::mem::transmute_copy(&column)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cellcontents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cellcontents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3649,7 +3649,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.ListViewMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3665,7 +3665,7 @@ impl View_Vtbl {
             let this = (*this).get_impl();
             match this.ControlObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *control = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(control, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3738,7 +3738,7 @@ impl Views_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *view = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(view, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3749,7 +3749,7 @@ impl Views_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3765,7 +3765,7 @@ impl Views_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3918,7 +3918,7 @@ impl _Application_Vtbl {
             let this = (*this).get_impl();
             match this.Document() {
                 ::core::result::Result::Ok(ok__) => {
-                    *document = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(document, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3934,7 +3934,7 @@ impl _Application_Vtbl {
             let this = (*this).get_impl();
             match this.Frame() {
                 ::core::result::Result::Ok(ok__) => {
-                    *frame = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(frame, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3945,7 +3945,7 @@ impl _Application_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3966,7 +3966,7 @@ impl _Application_Vtbl {
             let this = (*this).get_impl();
             match this.UserControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usercontrol = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usercontrol, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3982,7 +3982,7 @@ impl _Application_Vtbl {
             let this = (*this).get_impl();
             match this.VersionMajor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *versionmajor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(versionmajor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3993,7 +3993,7 @@ impl _Application_Vtbl {
             let this = (*this).get_impl();
             match this.VersionMinor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *versionminor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(versionminor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
@@ -59,7 +59,7 @@ impl IClassFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.RequestLicKey(::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -494,7 +494,7 @@ impl ICreateTypeLib_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTypeInfo(::core::mem::transmute(&szname), ::core::mem::transmute_copy(&tkind)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppctinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppctinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -626,7 +626,7 @@ impl IDispError_Vtbl {
             let this = (*this).get_impl();
             match this.QueryErrorInfo(::core::mem::transmute(&guiderrortype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppde = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppde, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -637,7 +637,7 @@ impl IDispError_Vtbl {
             let this = (*this).get_impl();
             match this.GetNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppde = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppde, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl IDispError_Vtbl {
             let this = (*this).get_impl();
             match this.GetHresult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -659,7 +659,7 @@ impl IDispError_Vtbl {
             let this = (*this).get_impl();
             match this.GetSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -675,7 +675,7 @@ impl IDispError_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -716,7 +716,7 @@ impl IDispatchEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetDispID(::core::mem::transmute(&bstrname), ::core::mem::transmute_copy(&grfdex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -742,7 +742,7 @@ impl IDispatchEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetMemberProperties(::core::mem::transmute_copy(&id), ::core::mem::transmute_copy(&grfdexfetch)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgrfdex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgrfdex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -753,7 +753,7 @@ impl IDispatchEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetMemberName(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -764,7 +764,7 @@ impl IDispatchEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextDispID(::core::mem::transmute_copy(&grfdex), ::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -775,7 +775,7 @@ impl IDispatchEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameSpaceParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -921,7 +921,7 @@ impl IEnterpriseDropTarget_Vtbl {
             let this = (*this).get_impl();
             match this.IsEvaluatingEdpPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -966,7 +966,7 @@ impl IEnumOLEVERB_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1013,7 +1013,7 @@ impl IEnumOleDocumentViews_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1060,7 +1060,7 @@ impl IEnumOleUndoUnits_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1110,7 +1110,7 @@ impl IEnumVARIANT_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1165,7 +1165,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1181,7 +1181,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1197,7 +1197,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Bold() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbold = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbold, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1213,7 +1213,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Italic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitalic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitalic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1229,7 +1229,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Underline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punderline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punderline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1245,7 +1245,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Strikethrough() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrikethrough = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrikethrough, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1261,7 +1261,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Weight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pweight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pweight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1277,7 +1277,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Charset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcharset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcharset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1293,7 +1293,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.hFont() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1304,7 +1304,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1325,7 +1325,7 @@ impl IFont_Vtbl {
             let this = (*this).get_impl();
             match this.QueryTextMetrics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1501,7 +1501,7 @@ impl IOleAdviseHolder_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&padvise)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1517,7 +1517,7 @@ impl IOleAdviseHolder_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAdvise() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumadvise = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumadvise, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1570,7 +1570,7 @@ impl IOleCache_Vtbl {
             let this = (*this).get_impl();
             match this.Cache(::core::mem::transmute_copy(&pformatetc), ::core::mem::transmute_copy(&advf)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1586,7 +1586,7 @@ impl IOleCache_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCache() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstatdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstatdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1699,7 +1699,7 @@ impl IOleClientSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetMoniker(::core::mem::transmute_copy(&dwassign), ::core::mem::transmute_copy(&dwwhichmoniker)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1710,7 +1710,7 @@ impl IOleClientSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontainer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontainer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1790,7 +1790,7 @@ impl IOleContainer_Vtbl {
             let this = (*this).get_impl();
             match this.EnumObjects(::core::mem::transmute_copy(&grfflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1885,7 +1885,7 @@ impl IOleControlSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtendedControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1942,7 +1942,7 @@ impl IOleDocument_Vtbl {
             let this = (*this).get_impl();
             match this.CreateView(::core::mem::transmute(&pipsite), ::core::mem::transmute(&pstm), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1953,7 +1953,7 @@ impl IOleDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocMiscStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2023,7 +2023,7 @@ impl IOleDocumentView_Vtbl {
             let this = (*this).get_impl();
             match this.GetInPlaceSite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipsite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipsite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2034,7 +2034,7 @@ impl IOleDocumentView_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocument() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2050,7 +2050,7 @@ impl IOleDocumentView_Vtbl {
             let this = (*this).get_impl();
             match this.GetRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prcview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prcview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2096,7 +2096,7 @@ impl IOleDocumentView_Vtbl {
             let this = (*this).get_impl();
             match this.Clone(::core::mem::transmute(&pipsitenew)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppviewnew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppviewnew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2291,7 +2291,7 @@ impl IOleInPlaceObjectWindowless_Vtbl {
             let this = (*this).get_impl();
             match this.OnWindowMessage(::core::mem::transmute_copy(&msg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2302,7 +2302,7 @@ impl IOleInPlaceObjectWindowless_Vtbl {
             let this = (*this).get_impl();
             match this.GetDropTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdroptarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdroptarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2491,7 +2491,7 @@ impl IOleInPlaceSiteWindowless_Vtbl {
             let this = (*this).get_impl();
             match this.GetDC(::core::mem::transmute_copy(&prect), ::core::mem::transmute_copy(&grfflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2527,7 +2527,7 @@ impl IOleInPlaceSiteWindowless_Vtbl {
             let this = (*this).get_impl();
             match this.OnDefWindowMessage(::core::mem::transmute_copy(&msg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2570,7 +2570,7 @@ impl IOleInPlaceUIWindow_Vtbl {
             let this = (*this).get_impl();
             match this.GetBorder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lprectborder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lprectborder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2669,7 +2669,7 @@ impl IOleLink_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdateOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwupdateopt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwupdateopt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2685,7 +2685,7 @@ impl IOleLink_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceMoniker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2701,7 +2701,7 @@ impl IOleLink_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2722,7 +2722,7 @@ impl IOleLink_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoundSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2796,7 +2796,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientSite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclientsite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclientsite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2822,7 +2822,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetMoniker(::core::mem::transmute_copy(&dwassign), ::core::mem::transmute_copy(&dwwhichmoniker)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2838,7 +2838,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetClipboardData(::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2854,7 +2854,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumVerbs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumoleverb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumoleverb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2875,7 +2875,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserClassID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2886,7 +2886,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserType(::core::mem::transmute_copy(&dwformoftype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszusertype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszusertype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2902,7 +2902,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtent(::core::mem::transmute_copy(&dwdrawaspect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psizel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psizel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2913,7 +2913,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&padvsink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2929,7 +2929,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.EnumAdvise() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumadvise = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumadvise, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2940,7 +2940,7 @@ impl IOleObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetMiscStatus(::core::mem::transmute_copy(&dwaspect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3018,7 +3018,7 @@ impl IOleParentUndoUnit_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3068,7 +3068,7 @@ impl IOleUILinkContainerA_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkUpdateOptions(::core::mem::transmute_copy(&dwlink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwupdateopt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwupdateopt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3146,7 +3146,7 @@ impl IOleUILinkContainerW_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkUpdateOptions(::core::mem::transmute_copy(&dwlink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwupdateopt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwupdateopt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3207,7 +3207,7 @@ impl IOleUILinkInfoA_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastUpdate(::core::mem::transmute_copy(&dwlink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplastupdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplastupdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3233,7 +3233,7 @@ impl IOleUILinkInfoW_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastUpdate(::core::mem::transmute_copy(&dwlink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplastupdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplastupdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3387,7 +3387,7 @@ impl IOleUndoManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetOpenParentState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3413,7 +3413,7 @@ impl IOleUndoManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumUndoable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3424,7 +3424,7 @@ impl IOleUndoManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRedoable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3435,7 +3435,7 @@ impl IOleUndoManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastUndoDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3446,7 +3446,7 @@ impl IOleUndoManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastRedoDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3499,7 +3499,7 @@ impl IOleUndoUnit_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3542,7 +3542,7 @@ impl IOleWindow_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3600,7 +3600,7 @@ impl IPerPropertyBrowsing_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayString(::core::mem::transmute_copy(&dispid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3611,7 +3611,7 @@ impl IPerPropertyBrowsing_Vtbl {
             let this = (*this).get_impl();
             match this.MapPropertyToPage(::core::mem::transmute_copy(&dispid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3627,7 +3627,7 @@ impl IPerPropertyBrowsing_Vtbl {
             let this = (*this).get_impl();
             match this.GetPredefinedValue(::core::mem::transmute_copy(&dispid), ::core::mem::transmute_copy(&dwcookie)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3753,7 +3753,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3764,7 +3764,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.hPal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3775,7 +3775,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3786,7 +3786,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3797,7 +3797,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3818,7 +3818,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.CurDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3834,7 +3834,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.KeepOriginalFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkeep = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkeep, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3855,7 +3855,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.SaveAsFile(::core::mem::transmute(&pstream), ::core::mem::transmute_copy(&fsavememcopy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3866,7 +3866,7 @@ impl IPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwattr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwattr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3921,7 +3921,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3932,7 +3932,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.hPal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3943,7 +3943,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3954,7 +3954,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3965,7 +3965,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3986,7 +3986,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.CurDC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4002,7 +4002,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.KeepOriginalFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkeep = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkeep, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4023,7 +4023,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.SaveAsFile(::core::mem::transmute(&pstream), ::core::mem::transmute_copy(&fsavememcopy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4034,7 +4034,7 @@ impl IPicture2_Vtbl {
             let this = (*this).get_impl();
             match this.Attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwattr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwattr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4091,7 +4091,7 @@ impl IPointerInactive_Vtbl {
             let this = (*this).get_impl();
             match this.GetActivationPolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwpolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwpolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4221,7 +4221,7 @@ impl IPropertyPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppageinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppageinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4323,7 +4323,7 @@ impl IPropertyPageSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocaleID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plocaleid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plocaleid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4334,7 +4334,7 @@ impl IPropertyPageSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4371,7 +4371,7 @@ impl IProtectFocus_Vtbl {
             let this = (*this).get_impl();
             match this.AllowFocusChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4399,7 +4399,7 @@ impl IProtectedModeMenuServices_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMenu() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phmenu = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phmenu, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4410,7 +4410,7 @@ impl IProtectedModeMenuServices_Vtbl {
             let this = (*this).get_impl();
             match this.LoadMenu(::core::mem::transmute(&pszmodulename), ::core::mem::transmute(&pszmenuname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phmenu = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phmenu, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4421,7 +4421,7 @@ impl IProtectedModeMenuServices_Vtbl {
             let this = (*this).get_impl();
             match this.LoadMenuID(::core::mem::transmute(&pszmodulename), ::core::mem::transmute_copy(&wresourceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phmenu = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phmenu, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4452,7 +4452,7 @@ impl IProvideClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetClassInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppti = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppti, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4478,7 +4478,7 @@ impl IProvideClassInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUID(::core::mem::transmute_copy(&dwguidkind)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4505,7 +4505,7 @@ impl IProvideMultipleClassInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMultiTypeInfoCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcti = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcti, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4569,7 +4569,7 @@ impl IQuickActivate_Vtbl {
             let this = (*this).get_impl();
             match this.GetContentExtent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psizel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psizel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4630,7 +4630,7 @@ impl IRecordInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4641,7 +4641,7 @@ impl IRecordInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4652,7 +4652,7 @@ impl IRecordInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4663,7 +4663,7 @@ impl IRecordInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptypeinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptypeinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4674,7 +4674,7 @@ impl IRecordInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetField(::core::mem::transmute_copy(&pvdata), ::core::mem::transmute(&szfieldname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarfield = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarfield, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4785,7 +4785,7 @@ impl ISpecifyPropertyPages_Vtbl {
             let this = (*this).get_impl();
             match this.GetPages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4812,7 +4812,7 @@ impl ITypeChangeEvents_Vtbl {
             let this = (*this).get_impl();
             match this.RequestTypeChange(::core::mem::transmute_copy(&changekind), ::core::mem::transmute(&ptinfobefore), ::core::mem::transmute(&pstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcancel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcancel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4847,7 +4847,7 @@ impl ITypeFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFromTypeInfo(::core::mem::transmute(&ptypeinfo), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4873,7 +4873,7 @@ impl ITypeMarshal_Vtbl {
             let this = (*this).get_impl();
             match this.Size(::core::mem::transmute_copy(&pvtype), ::core::mem::transmute_copy(&dwdestcontext), ::core::mem::transmute_copy(&pvdestcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4940,7 +4940,7 @@ impl IVBGetControl_Vtbl {
             let this = (*this).get_impl();
             match this.EnumControls(::core::mem::transmute_copy(&dwolecontf), ::core::mem::transmute_copy(&dwwhich)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5044,7 +5044,7 @@ impl IViewObject2_Vtbl {
             let this = (*this).get_impl();
             match this.GetExtent(::core::mem::transmute_copy(&dwdrawaspect), ::core::mem::transmute_copy(&lindex), ::core::mem::transmute_copy(&ptd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpsizel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpsizel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5074,7 +5074,7 @@ impl IViewObjectEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetRect(::core::mem::transmute_copy(&dwaspect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5085,7 +5085,7 @@ impl IViewObjectEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5096,7 +5096,7 @@ impl IViewObjectEx_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHitPoint(::core::mem::transmute_copy(&dwaspect), ::core::mem::transmute_copy(&prectbounds), ::core::mem::transmute(&ptlloc), ::core::mem::transmute_copy(&lclosehint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phitresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phitresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5107,7 +5107,7 @@ impl IViewObjectEx_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHitRect(::core::mem::transmute_copy(&dwaspect), ::core::mem::transmute_copy(&prectbounds), ::core::mem::transmute_copy(&prectloc), ::core::mem::transmute_copy(&lclosehint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phitresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phitresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5118,7 +5118,7 @@ impl IViewObjectEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetNaturalExtent(::core::mem::transmute_copy(&dwaspect), ::core::mem::transmute_copy(&lindex), ::core::mem::transmute_copy(&ptd), ::core::mem::transmute_copy(&hictargetdev), ::core::mem::transmute_copy(&pextentinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psizel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psizel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
@@ -12,7 +12,7 @@ impl IWPCGamesSettings_Vtbl {
             let this = (*this).get_impl();
             match this.IsBlocked(::core::mem::transmute(&guidappid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwreasons = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwreasons, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -40,7 +40,7 @@ impl IWPCProviderConfig_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserSummary(::core::mem::transmute(&bstrsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrusersummary = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrusersummary, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -105,7 +105,7 @@ impl IWPCProviderSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl IWPCSettings_Vtbl {
             let this = (*this).get_impl();
             match this.IsLoggingRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrequired = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrequired, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -144,7 +144,7 @@ impl IWPCSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastSettingsChangeTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -155,7 +155,7 @@ impl IWPCSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrestrictions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrestrictions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -187,7 +187,7 @@ impl IWPCWebSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -198,7 +198,7 @@ impl IWPCWebSettings_Vtbl {
             let this = (*this).get_impl();
             match this.RequestURLOverride(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&pcszurl), ::core::mem::transmute_copy(&curls), ::core::mem::transmute_copy(&ppcszsuburls)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfchanged = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfchanged, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -225,7 +225,7 @@ impl IWindowsParentalControls_Vtbl {
             let this = (*this).get_impl();
             match this.GetGamesSettings(::core::mem::transmute(&pcszsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -251,7 +251,7 @@ impl IWindowsParentalControlsCore_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisibility() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pevisibility = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pevisibility, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -262,7 +262,7 @@ impl IWindowsParentalControlsCore_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserSettings(::core::mem::transmute(&pcszsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -273,7 +273,7 @@ impl IWindowsParentalControlsCore_Vtbl {
             let this = (*this).get_impl();
             match this.GetWebSettings(::core::mem::transmute(&pcszsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
@@ -92,7 +92,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.AlertThresholds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *alerts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(alerts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -108,7 +108,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.EventLog() {
                 ::core::result::Result::Ok(ok__) => {
-                    *log = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(log, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SampleInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -140,7 +140,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Task() {
                 ::core::result::Result::Ok(ok__) => {
-                    *task = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(task, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -156,7 +156,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.TaskRunAsSelf() {
                 ::core::result::Result::Ok(ok__) => {
-                    *runasself = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(runasself, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -172,7 +172,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.TaskArguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *task = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(task, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -188,7 +188,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.TaskUserTextArguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *task = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(task, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl IAlertDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.TriggerDataCollectorSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -266,7 +266,7 @@ impl IApiTracingDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LogApiNamesOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *logapinames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(logapinames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -282,7 +282,7 @@ impl IApiTracingDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LogApisRecursively() {
                 ::core::result::Result::Ok(ok__) => {
-                    *logrecursively = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(logrecursively, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IApiTracingDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.ExePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *exepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IApiTracingDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LogFilePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *logfilepath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(logfilepath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IApiTracingDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.IncludeModules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *includemodules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(includemodules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -346,7 +346,7 @@ impl IApiTracingDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.IncludeApis() {
                 ::core::result::Result::Ok(ok__) => {
-                    *includeapis = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(includeapis, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -362,7 +362,7 @@ impl IApiTracingDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.ExcludeApis() {
                 ::core::result::Result::Ok(ok__) => {
-                    *excludeapis = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(excludeapis, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -426,7 +426,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FileMaxCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -442,7 +442,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FileMaxRecursiveDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *depth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(depth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -458,7 +458,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FileMaxTotalSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -474,7 +474,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Files() {
                 ::core::result::Result::Ok(ok__) => {
-                    *files = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(files, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -490,7 +490,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.ManagementQueries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *queries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(queries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -506,7 +506,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.QueryNetworkAdapters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *network = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(network, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -522,7 +522,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.RegistryKeys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *query = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(query, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -538,7 +538,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.RegistryMaxRecursiveDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *depth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(depth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -554,7 +554,7 @@ impl IConfigurationDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SystemStateFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -616,7 +616,7 @@ impl ICounterItem_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdblvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdblvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -632,7 +632,7 @@ impl ICounterItem_Vtbl {
             let this = (*this).get_impl();
             match this.Color() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl ICounterItem_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -664,7 +664,7 @@ impl ICounterItem_Vtbl {
             let this = (*this).get_impl();
             match this.LineStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -680,7 +680,7 @@ impl ICounterItem_Vtbl {
             let this = (*this).get_impl();
             match this.ScaleFactor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -691,7 +691,7 @@ impl ICounterItem_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -750,7 +750,7 @@ impl ICounterItem2_Vtbl {
             let this = (*this).get_impl();
             match this.Selected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -766,7 +766,7 @@ impl ICounterItem2_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -777,7 +777,7 @@ impl ICounterItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataAt(::core::mem::transmute_copy(&iindex), ::core::mem::transmute_copy(&iwhich)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -814,7 +814,7 @@ impl ICounters_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plong = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plong, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -825,7 +825,7 @@ impl ICounters_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -836,7 +836,7 @@ impl ICounters_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -847,7 +847,7 @@ impl ICounters_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&pathname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -909,7 +909,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.DataCollectorSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *group = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(group, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -925,7 +925,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.DataCollectorType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -936,7 +936,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -952,7 +952,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FileNameFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -968,7 +968,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FileNameFormatPattern() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattern = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattern, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -984,7 +984,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LatestOutputLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1000,7 +1000,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LogAppend() {
                 ::core::result::Result::Ok(ok__) => {
-                    *append = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(append, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1016,7 +1016,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LogCircular() {
                 ::core::result::Result::Ok(ok__) => {
-                    *circular = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(circular, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1032,7 +1032,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LogOverwrite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *overwrite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(overwrite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1048,7 +1048,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1064,7 +1064,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.OutputLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1075,7 +1075,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Index() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1091,7 +1091,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Xml() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1102,7 +1102,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SetXml(::core::mem::transmute(&xml)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *validation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(validation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1113,7 +1113,7 @@ impl IDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.CreateOutputLocation(::core::mem::transmute_copy(&latest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *location = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(location, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1174,7 +1174,7 @@ impl IDataCollectorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1185,7 +1185,7 @@ impl IDataCollectorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *collector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1196,7 +1196,7 @@ impl IDataCollectorCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1232,7 +1232,7 @@ impl IDataCollectorCollection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDataCollector(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *collector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1328,7 +1328,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.DataCollectors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collectors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collectors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1339,7 +1339,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Duration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1355,7 +1355,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1371,7 +1371,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.DescriptionUnresolved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *descr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1382,7 +1382,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1398,7 +1398,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayNameUnresolved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1409,7 +1409,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Keywords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keywords = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keywords, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1425,7 +1425,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.LatestOutputLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1441,7 +1441,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1452,7 +1452,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.OutputLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1463,7 +1463,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.RootPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *folder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(folder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1479,7 +1479,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Segment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *segment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(segment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1495,7 +1495,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.SegmentMaxDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1511,7 +1511,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.SegmentMaxSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1527,7 +1527,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.SerialNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *index = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(index, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1543,7 +1543,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Server() {
                 ::core::result::Result::Ok(ok__) => {
-                    *server = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(server, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1554,7 +1554,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1565,7 +1565,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Subdirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *folder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(folder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1581,7 +1581,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.SubdirectoryFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1597,7 +1597,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.SubdirectoryFormatPattern() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pattern = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pattern, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1613,7 +1613,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Task() {
                 ::core::result::Result::Ok(ok__) => {
-                    *task = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(task, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1629,7 +1629,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.TaskRunAsSelf() {
                 ::core::result::Result::Ok(ok__) => {
-                    *runasself = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(runasself, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1645,7 +1645,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.TaskArguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *task = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(task, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1661,7 +1661,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.TaskUserTextArguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usertext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usertext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1677,7 +1677,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Schedules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppschedules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppschedules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1688,7 +1688,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.SchedulesEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1704,7 +1704,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.UserAccount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *user = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(user, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1715,7 +1715,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Xml() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1726,7 +1726,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Security() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1742,7 +1742,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.StopOnCompletion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1758,7 +1758,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.DataManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *datamanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(datamanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1779,7 +1779,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.Commit(::core::mem::transmute(&name), ::core::mem::transmute(&server), ::core::mem::transmute_copy(&mode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *validation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(validation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1805,7 +1805,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.SetXml(::core::mem::transmute(&xml)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *validation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(validation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1821,7 +1821,7 @@ impl IDataCollectorSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1916,7 +1916,7 @@ impl IDataCollectorSetCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1927,7 +1927,7 @@ impl IDataCollectorSetCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *set = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(set, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1938,7 +1938,7 @@ impl IDataCollectorSetCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2023,7 +2023,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2039,7 +2039,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.CheckBeforeRunning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcheck = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcheck, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2055,7 +2055,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.MinFreeDisk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minfreedisk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minfreedisk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2071,7 +2071,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.MaxSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulmaxsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulmaxsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2087,7 +2087,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.MaxFolderCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulmaxfoldercount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulmaxfoldercount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2103,7 +2103,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.ResourcePolicy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppolicy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppolicy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2119,7 +2119,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.FolderActions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *actions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2130,7 +2130,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.ReportSchema() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reportschema = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reportschema, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2146,7 +2146,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.ReportFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2162,7 +2162,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.RuleTargetFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2178,7 +2178,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.EventsFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2194,7 +2194,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.Rules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrxml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrxml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2210,7 +2210,7 @@ impl IDataManager_Vtbl {
             let this = (*this).get_impl();
             match this.Run(::core::mem::transmute_copy(&steps), ::core::mem::transmute(&bstrfolder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *errors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2275,7 +2275,7 @@ impl IFolderAction_Vtbl {
             let this = (*this).get_impl();
             match this.Age() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2291,7 +2291,7 @@ impl IFolderAction_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2307,7 +2307,7 @@ impl IFolderAction_Vtbl {
             let this = (*this).get_impl();
             match this.Actions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *steps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(steps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2323,7 +2323,7 @@ impl IFolderAction_Vtbl {
             let this = (*this).get_impl();
             match this.SendCabTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdestination = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdestination, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2371,7 +2371,7 @@ impl IFolderActionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2382,7 +2382,7 @@ impl IFolderActionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *action = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(action, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2393,7 +2393,7 @@ impl IFolderActionCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#enum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#enum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2424,7 +2424,7 @@ impl IFolderActionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolderAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *folderaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(folderaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2460,7 +2460,7 @@ impl ILogFileItem_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2490,7 +2490,7 @@ impl ILogFiles_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plong = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plong, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2501,7 +2501,7 @@ impl ILogFiles_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2512,7 +2512,7 @@ impl ILogFiles_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2523,7 +2523,7 @@ impl ILogFiles_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&pathname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2570,7 +2570,7 @@ impl IPerformanceCounterDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.DataSourceName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dsn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dsn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2586,7 +2586,7 @@ impl IPerformanceCounterDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.PerformanceCounters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *counters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(counters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2602,7 +2602,7 @@ impl IPerformanceCounterDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.LogFileFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *format = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(format, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2618,7 +2618,7 @@ impl IPerformanceCounterDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SampleInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *interval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2634,7 +2634,7 @@ impl IPerformanceCounterDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SegmentMaxRecords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *records = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(records, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2684,7 +2684,7 @@ impl ISchedule_Vtbl {
             let this = (*this).get_impl();
             match this.StartDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *start = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(start, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2700,7 +2700,7 @@ impl ISchedule_Vtbl {
             let this = (*this).get_impl();
             match this.EndDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *end = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(end, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2716,7 +2716,7 @@ impl ISchedule_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *start = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(start, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2732,7 +2732,7 @@ impl ISchedule_Vtbl {
             let this = (*this).get_impl();
             match this.Days() {
                 ::core::result::Result::Ok(ok__) => {
-                    *days = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(days, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2780,7 +2780,7 @@ impl IScheduleCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2791,7 +2791,7 @@ impl IScheduleCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppschedule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppschedule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2802,7 +2802,7 @@ impl IScheduleCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2833,7 +2833,7 @@ impl IScheduleCollection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSchedule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *schedule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(schedule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2944,7 +2944,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.Appearance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iappearance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iappearance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2960,7 +2960,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.BackColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2976,7 +2976,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.BorderStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iborderstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iborderstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2992,7 +2992,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ForeColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3008,7 +3008,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.Font() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3024,7 +3024,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.Counters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppicounters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppicounters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3040,7 +3040,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ShowVerticalGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3056,7 +3056,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ShowHorizontalGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3072,7 +3072,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ShowLegend() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3088,7 +3088,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ShowScaleLabels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3104,7 +3104,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ShowValueBar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3120,7 +3120,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.MaximumScale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3136,7 +3136,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.MinimumScale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3152,7 +3152,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3168,7 +3168,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pedisplaytype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pedisplaytype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3184,7 +3184,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ManualUpdate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3200,7 +3200,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.GraphTitle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3216,7 +3216,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.YAxisLabel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3247,7 +3247,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.Counter(::core::mem::transmute_copy(&iindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppicounter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppicounter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3258,7 +3258,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.AddCounter(::core::mem::transmute(&bspath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppicounter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppicounter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3274,7 +3274,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.BackColorCtl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3295,7 +3295,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.LogFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bsfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bsfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3311,7 +3311,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.LogViewStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *starttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(starttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3327,7 +3327,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.LogViewStop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stoptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stoptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3338,7 +3338,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.GridColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3354,7 +3354,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.TimeBarColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3370,7 +3370,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.Highlight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3386,7 +3386,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ShowToolbar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3422,7 +3422,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3438,7 +3438,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.ReportValueType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pereportvaluetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pereportvaluetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3454,7 +3454,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.MonitorDuplicateInstances() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3470,7 +3470,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3481,7 +3481,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.LogFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppilogfiles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppilogfiles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3497,7 +3497,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.DataSourceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pedatasourcetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pedatasourcetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3513,7 +3513,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.SqlDsnName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bssqldsnname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bssqldsnname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3529,7 +3529,7 @@ impl ISystemMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.SqlLogSetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bssqllogsetname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bssqllogsetname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3657,7 +3657,7 @@ impl ISystemMonitor2_Vtbl {
             let this = (*this).get_impl();
             match this.EnableDigitGrouping() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3673,7 +3673,7 @@ impl ISystemMonitor2_Vtbl {
             let this = (*this).get_impl();
             match this.EnableToolTips() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3689,7 +3689,7 @@ impl ISystemMonitor2_Vtbl {
             let this = (*this).get_impl();
             match this.ShowTimeAxisLabels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3705,7 +3705,7 @@ impl ISystemMonitor2_Vtbl {
             let this = (*this).get_impl();
             match this.ChartScroll() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbscroll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbscroll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3721,7 +3721,7 @@ impl ISystemMonitor2_Vtbl {
             let this = (*this).get_impl();
             match this.DataPointCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pidatapointcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pidatapointcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3752,7 +3752,7 @@ impl ISystemMonitor2_Vtbl {
             let this = (*this).get_impl();
             match this.LogSourceStartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3763,7 +3763,7 @@ impl ISystemMonitor2_Vtbl {
             let this = (*this).get_impl();
             match this.LogSourceStopTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3918,7 +3918,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.BufferSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *size = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(size, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3934,7 +3934,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.BuffersLost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3950,7 +3950,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.BuffersWritten() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3966,7 +3966,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.ClockType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clock = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clock, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3982,7 +3982,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.EventsLost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *events = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(events, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3998,7 +3998,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedModes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4014,7 +4014,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FlushTimer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4030,7 +4030,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.FreeBuffers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4046,7 +4046,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4062,7 +4062,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.IsKernelTrace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *kernel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(kernel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4073,7 +4073,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.MaximumBuffers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4089,7 +4089,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.MinimumBuffers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4105,7 +4105,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfBuffers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4121,7 +4121,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.PreallocateFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allocate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allocate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4137,7 +4137,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *process = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(process, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4153,7 +4153,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.RealTimeBuffersLost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buffers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buffers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4169,7 +4169,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SessionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4185,7 +4185,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SessionName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4201,7 +4201,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SessionThreadId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4217,7 +4217,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.StreamMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4233,7 +4233,7 @@ impl ITraceDataCollector_Vtbl {
             let this = (*this).get_impl();
             match this.TraceDataProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *providers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(providers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4319,7 +4319,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4335,7 +4335,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4351,7 +4351,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Level() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4362,7 +4362,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.KeywordsAny() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeywords = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeywords, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4373,7 +4373,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.KeywordsAll() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkeywords = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkeywords, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4384,7 +4384,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Properties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4395,7 +4395,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FilterEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filterenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filterenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4411,7 +4411,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FilterType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pultype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pultype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4427,7 +4427,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FilterData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4458,7 +4458,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurity(::core::mem::transmute_copy(&securityinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sddl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sddl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4469,7 +4469,7 @@ impl ITraceDataProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegisteredProcesses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *processes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(processes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4525,7 +4525,7 @@ impl ITraceDataProviderCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4536,7 +4536,7 @@ impl ITraceDataProviderCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4547,7 +4547,7 @@ impl ITraceDataProviderCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4578,7 +4578,7 @@ impl ITraceDataProviderCollection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTraceDataProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *provider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(provider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4639,7 +4639,7 @@ impl IValueMap_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4650,7 +4650,7 @@ impl IValueMap_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4661,7 +4661,7 @@ impl IValueMap_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4672,7 +4672,7 @@ impl IValueMap_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4688,7 +4688,7 @@ impl IValueMap_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4704,7 +4704,7 @@ impl IValueMap_Vtbl {
             let this = (*this).get_impl();
             match this.ValueMapType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4740,7 +4740,7 @@ impl IValueMap_Vtbl {
             let this = (*this).get_impl();
             match this.CreateValueMapItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4791,7 +4791,7 @@ impl IValueMapItem_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4807,7 +4807,7 @@ impl IValueMapItem_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4823,7 +4823,7 @@ impl IValueMapItem_Vtbl {
             let this = (*this).get_impl();
             match this.Key() {
                 ::core::result::Result::Ok(ok__) => {
-                    *key = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(key, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4839,7 +4839,7 @@ impl IValueMapItem_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4855,7 +4855,7 @@ impl IValueMapItem_Vtbl {
             let this = (*this).get_impl();
             match this.ValueMapType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4914,7 +4914,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdblvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdblvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4930,7 +4930,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Color() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4946,7 +4946,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4962,7 +4962,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.LineStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4978,7 +4978,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ScaleFactor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4989,7 +4989,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5015,7 +5015,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Selected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5031,7 +5031,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5042,7 +5042,7 @@ impl _ICounterItemUnion_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataAt(::core::mem::transmute_copy(&iindex), ::core::mem::transmute_copy(&iwhich)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5182,7 +5182,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Appearance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iappearance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iappearance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5198,7 +5198,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.BackColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5214,7 +5214,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.BorderStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iborderstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iborderstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5230,7 +5230,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ForeColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5246,7 +5246,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Font() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5262,7 +5262,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Counters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppicounters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppicounters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5278,7 +5278,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ShowVerticalGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5294,7 +5294,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ShowHorizontalGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5310,7 +5310,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ShowLegend() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5326,7 +5326,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ShowScaleLabels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5342,7 +5342,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ShowValueBar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5358,7 +5358,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.MaximumScale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5374,7 +5374,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.MinimumScale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5390,7 +5390,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5406,7 +5406,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pedisplaytype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pedisplaytype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5422,7 +5422,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ManualUpdate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5438,7 +5438,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.GraphTitle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5454,7 +5454,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.YAxisLabel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5485,7 +5485,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Counter(::core::mem::transmute_copy(&iindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppicounter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppicounter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5496,7 +5496,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.AddCounter(::core::mem::transmute(&bspath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppicounter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppicounter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5512,7 +5512,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.BackColorCtl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5533,7 +5533,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.LogFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bsfilename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bsfilename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5549,7 +5549,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.LogViewStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *starttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(starttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5565,7 +5565,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.LogViewStop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *stoptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stoptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5576,7 +5576,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.GridColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5592,7 +5592,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.TimeBarColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5608,7 +5608,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.Highlight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5624,7 +5624,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ShowToolbar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5660,7 +5660,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5676,7 +5676,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ReportValueType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pereportvaluetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pereportvaluetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5692,7 +5692,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.MonitorDuplicateInstances() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5708,7 +5708,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5719,7 +5719,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.LogFiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppilogfiles = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppilogfiles, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5735,7 +5735,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.DataSourceType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pedatasourcetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pedatasourcetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5751,7 +5751,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.SqlDsnName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bssqldsnname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bssqldsnname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5767,7 +5767,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.SqlLogSetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bssqllogsetname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bssqllogsetname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5783,7 +5783,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.EnableDigitGrouping() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5799,7 +5799,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.EnableToolTips() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5815,7 +5815,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ShowTimeAxisLabels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5831,7 +5831,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.ChartScroll() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbscroll = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbscroll, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5847,7 +5847,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.DataPointCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pidatapointcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pidatapointcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5878,7 +5878,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.LogSourceStartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5889,7 +5889,7 @@ impl _ISystemMonitorUnion_Vtbl {
             let this = (*this).get_impl();
             match this.LogSourceStopTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
@@ -70,7 +70,7 @@ impl IRTCBuddy_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -81,7 +81,7 @@ impl IRTCBuddy_Vtbl {
             let this = (*this).get_impl();
             match this.Notes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnotes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnotes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -118,7 +118,7 @@ impl IRTCBuddy2_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -134,7 +134,7 @@ impl IRTCBuddy2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -145,7 +145,7 @@ impl IRTCBuddy2_Vtbl {
             let this = (*this).get_impl();
             match this.Groups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -156,7 +156,7 @@ impl IRTCBuddy2_Vtbl {
             let this = (*this).get_impl();
             match this.get_PresenceProperty(::core::mem::transmute_copy(&enproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -167,7 +167,7 @@ impl IRTCBuddy2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumeratePresenceDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumdevices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumdevices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -178,7 +178,7 @@ impl IRTCBuddy2_Vtbl {
             let this = (*this).get_impl();
             match this.PresenceDevices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdevicescollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdevicescollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -189,7 +189,7 @@ impl IRTCBuddy2_Vtbl {
             let this = (*this).get_impl();
             match this.SubscriptionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pensubscriptiontype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pensubscriptiontype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -225,7 +225,7 @@ impl IRTCBuddyEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Buddy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuddy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuddy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -253,7 +253,7 @@ impl IRTCBuddyEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -264,7 +264,7 @@ impl IRTCBuddyEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -275,7 +275,7 @@ impl IRTCBuddyEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -314,7 +314,7 @@ impl IRTCBuddyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrgroupname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrgroupname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -340,7 +340,7 @@ impl IRTCBuddyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateBuddies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -351,7 +351,7 @@ impl IRTCBuddyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Buddies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -362,7 +362,7 @@ impl IRTCBuddyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -378,7 +378,7 @@ impl IRTCBuddyGroup_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -418,7 +418,7 @@ impl IRTCBuddyGroupEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -429,7 +429,7 @@ impl IRTCBuddyGroupEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Group() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -440,7 +440,7 @@ impl IRTCBuddyGroupEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Buddy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuddy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuddy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -451,7 +451,7 @@ impl IRTCBuddyGroupEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -544,7 +544,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.EventFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -560,7 +560,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredMediaTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -571,7 +571,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.MediaCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -582,7 +582,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession(::core::mem::transmute_copy(&entype), ::core::mem::transmute(&bstrlocalphoneuri), ::core::mem::transmute(&pprofile), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -598,7 +598,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.ListenForIncomingSessions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penlisten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penlisten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -609,7 +609,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.get_NetworkAddresses(::core::mem::transmute_copy(&ftcp), ::core::mem::transmute_copy(&fexternal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvaddresses = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvaddresses, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -625,7 +625,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.get_Volume(::core::mem::transmute_copy(&endevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -641,7 +641,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.get_AudioMuted(::core::mem::transmute_copy(&endevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmuted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmuted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -652,7 +652,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.get_IVideoWindow(::core::mem::transmute_copy(&endevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppivideowindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppivideowindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -668,7 +668,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.get_PreferredAudioDevice(::core::mem::transmute_copy(&endevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -684,7 +684,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.get_PreferredVolume(::core::mem::transmute_copy(&endevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvolume = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvolume, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -700,7 +700,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredAEC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -716,7 +716,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredVideoDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdevicename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdevicename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -727,7 +727,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.ActiveMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -743,7 +743,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.MaxBitrate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxbitrate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxbitrate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -759,7 +759,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.TemporalSpatialTradeOff() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -770,7 +770,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkQuality() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plnetworkquality = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plnetworkquality, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -791,7 +791,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.get_IsT120AppletRunning(::core::mem::transmute_copy(&enapplet)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrunning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrunning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -802,7 +802,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.LocalUserURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruseruri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruseruri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -818,7 +818,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.LocalUserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -849,7 +849,7 @@ impl IRTCClient_Vtbl {
             let this = (*this).get_impl();
             match this.IsTuned() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftuned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftuned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -936,7 +936,7 @@ impl IRTCClient2_Vtbl {
             let this = (*this).get_impl();
             match this.get_AnswerMode(::core::mem::transmute_copy(&entype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -952,7 +952,7 @@ impl IRTCClient2_Vtbl {
             let this = (*this).get_impl();
             match this.Version() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -978,7 +978,7 @@ impl IRTCClient2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSessionWithDescription(::core::mem::transmute(&bstrcontenttype), ::core::mem::transmute(&bstrsessiondescription), ::core::mem::transmute(&pprofile), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -999,7 +999,7 @@ impl IRTCClient2_Vtbl {
             let this = (*this).get_impl();
             match this.get_PreferredSecurityLevel(::core::mem::transmute_copy(&ensecuritytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pensecuritylevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pensecuritylevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1015,7 +1015,7 @@ impl IRTCClient2_Vtbl {
             let this = (*this).get_impl();
             match this.get_AllowedPorts(::core::mem::transmute_copy(&ltransport)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penlistenmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penlistenmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1057,7 +1057,7 @@ impl IRTCClientEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peneventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peneventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1068,7 +1068,7 @@ impl IRTCClientEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Client() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclient = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclient, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1167,7 +1167,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateBuddies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1178,7 +1178,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.Buddies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1189,7 +1189,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.get_Buddy(::core::mem::transmute(&bstrpresentityuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuddy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuddy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1200,7 +1200,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.AddBuddy(::core::mem::transmute(&bstrpresentityuri), ::core::mem::transmute(&bstrusername), ::core::mem::transmute(&bstrdata), ::core::mem::transmute_copy(&fpersistent), ::core::mem::transmute(&pprofile), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuddy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuddy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1216,7 +1216,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateWatchers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1227,7 +1227,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.Watchers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1238,7 +1238,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.get_Watcher(::core::mem::transmute(&bstrpresentityuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwatcher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwatcher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1249,7 +1249,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.AddWatcher(::core::mem::transmute(&bstrpresentityuri), ::core::mem::transmute(&bstrusername), ::core::mem::transmute(&bstrdata), ::core::mem::transmute_copy(&fblocked), ::core::mem::transmute_copy(&fpersistent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwatcher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwatcher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1270,7 +1270,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.OfferWatcherMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1286,7 +1286,7 @@ impl IRTCClientPresence_Vtbl {
             let this = (*this).get_impl();
             match this.PrivacyMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1361,7 +1361,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.AddGroup(::core::mem::transmute(&bstrgroupname), ::core::mem::transmute(&bstrdata), ::core::mem::transmute(&pprofile), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1377,7 +1377,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateGroups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1388,7 +1388,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.Groups() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1399,7 +1399,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.get_Group(::core::mem::transmute(&bstrgroupname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppgroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1410,7 +1410,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.AddWatcherEx(::core::mem::transmute(&bstrpresentityuri), ::core::mem::transmute(&bstrusername), ::core::mem::transmute(&bstrdata), ::core::mem::transmute_copy(&enstate), ::core::mem::transmute_copy(&fpersistent), ::core::mem::transmute_copy(&enscope), ::core::mem::transmute(&pprofile), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwatcher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwatcher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1421,7 +1421,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.get_WatcherEx(::core::mem::transmute_copy(&enmode), ::core::mem::transmute(&bstrpresentityuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwatcher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwatcher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1437,7 +1437,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.get_PresenceProperty(::core::mem::transmute_copy(&enproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1463,7 +1463,7 @@ impl IRTCClientPresence2_Vtbl {
             let this = (*this).get_impl();
             match this.AddBuddyEx(::core::mem::transmute(&bstrpresentityuri), ::core::mem::transmute(&bstrusername), ::core::mem::transmute(&bstrdata), ::core::mem::transmute_copy(&fpersistent), ::core::mem::transmute_copy(&ensubscriptiontype), ::core::mem::transmute(&pprofile), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbuddy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbuddy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1512,7 +1512,7 @@ impl IRTCClientProvisioning_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProfile(::core::mem::transmute(&bstrprofilexml)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1533,7 +1533,7 @@ impl IRTCClientProvisioning_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateProfiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1544,7 +1544,7 @@ impl IRTCClientProvisioning_Vtbl {
             let this = (*this).get_impl();
             match this.Profiles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1560,7 +1560,7 @@ impl IRTCClientProvisioning_Vtbl {
             let this = (*this).get_impl();
             match this.SessionCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsupportedsessions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsupportedsessions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1617,7 +1617,7 @@ impl IRTCCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1628,7 +1628,7 @@ impl IRTCCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvariant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvariant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1639,7 +1639,7 @@ impl IRTCCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1698,7 +1698,7 @@ impl IRTCEnumBuddies_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1745,7 +1745,7 @@ impl IRTCEnumGroups_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1792,7 +1792,7 @@ impl IRTCEnumParticipants_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1839,7 +1839,7 @@ impl IRTCEnumPresenceDevices_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1886,7 +1886,7 @@ impl IRTCEnumProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1933,7 +1933,7 @@ impl IRTCEnumUserSearchResults_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1980,7 +1980,7 @@ impl IRTCEnumWatchers_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2035,7 +2035,7 @@ impl IRTCInfoEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2046,7 +2046,7 @@ impl IRTCInfoEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Participant() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparticipant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparticipant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2057,7 +2057,7 @@ impl IRTCInfoEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Info() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2068,7 +2068,7 @@ impl IRTCInfoEvent_Vtbl {
             let this = (*this).get_impl();
             match this.InfoHeader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrinfoheader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrinfoheader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2103,7 +2103,7 @@ impl IRTCIntensityEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Level() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2114,7 +2114,7 @@ impl IRTCIntensityEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Min() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2125,7 +2125,7 @@ impl IRTCIntensityEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Max() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2136,7 +2136,7 @@ impl IRTCIntensityEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Direction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pendirection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pendirection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2170,7 +2170,7 @@ impl IRTCMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.MediaType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2181,7 +2181,7 @@ impl IRTCMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peneventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peneventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2192,7 +2192,7 @@ impl IRTCMediaEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventReason() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peneventreason = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peneventreason, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2229,7 +2229,7 @@ impl IRTCMediaRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2240,7 +2240,7 @@ impl IRTCMediaRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.ProposedMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2251,7 +2251,7 @@ impl IRTCMediaRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentMedia() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmediatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmediatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2267,7 +2267,7 @@ impl IRTCMediaRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.get_RemotePreferredSecurityLevel(::core::mem::transmute_copy(&ensecuritytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pensecuritylevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pensecuritylevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2283,7 +2283,7 @@ impl IRTCMediaRequestEvent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2323,7 +2323,7 @@ impl IRTCMessagingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2334,7 +2334,7 @@ impl IRTCMessagingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Participant() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparticipant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparticipant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2345,7 +2345,7 @@ impl IRTCMessagingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peneventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peneventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2356,7 +2356,7 @@ impl IRTCMessagingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2367,7 +2367,7 @@ impl IRTCMessagingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.MessageHeader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrmessageheader = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrmessageheader, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2378,7 +2378,7 @@ impl IRTCMessagingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.UserStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penuserstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penuserstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2416,7 +2416,7 @@ impl IRTCParticipant_Vtbl {
             let this = (*this).get_impl();
             match this.UserURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruseruri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruseruri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2427,7 +2427,7 @@ impl IRTCParticipant_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2438,7 +2438,7 @@ impl IRTCParticipant_Vtbl {
             let this = (*this).get_impl();
             match this.Removable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfremovable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfremovable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2449,7 +2449,7 @@ impl IRTCParticipant_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2460,7 +2460,7 @@ impl IRTCParticipant_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2495,7 +2495,7 @@ impl IRTCParticipantStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Participant() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparticipant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparticipant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2506,7 +2506,7 @@ impl IRTCParticipantStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2517,7 +2517,7 @@ impl IRTCParticipantStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2592,7 +2592,7 @@ impl IRTCPresenceContact_Vtbl {
             let this = (*this).get_impl();
             match this.PresentityURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrpresentityuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrpresentityuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2608,7 +2608,7 @@ impl IRTCPresenceContact_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2624,7 +2624,7 @@ impl IRTCPresenceContact_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2640,7 +2640,7 @@ impl IRTCPresenceContact_Vtbl {
             let this = (*this).get_impl();
             match this.Persistent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfpersistent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfpersistent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2683,7 +2683,7 @@ impl IRTCPresenceDataEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2694,7 +2694,7 @@ impl IRTCPresenceDataEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2733,7 +2733,7 @@ impl IRTCPresenceDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2744,7 +2744,7 @@ impl IRTCPresenceDevice_Vtbl {
             let this = (*this).get_impl();
             match this.Notes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnotes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnotes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2755,7 +2755,7 @@ impl IRTCPresenceDevice_Vtbl {
             let this = (*this).get_impl();
             match this.get_PresenceProperty(::core::mem::transmute_copy(&enproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2795,7 +2795,7 @@ impl IRTCPresencePropertyEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2806,7 +2806,7 @@ impl IRTCPresencePropertyEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2817,7 +2817,7 @@ impl IRTCPresencePropertyEvent_Vtbl {
             let this = (*this).get_impl();
             match this.PresenceProperty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penpresprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penpresprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2828,7 +2828,7 @@ impl IRTCPresencePropertyEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2862,7 +2862,7 @@ impl IRTCPresenceStatusEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2873,7 +2873,7 @@ impl IRTCPresenceStatusEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2926,7 +2926,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.Key() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2937,7 +2937,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2948,7 +2948,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.XML() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrxml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrxml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2959,7 +2959,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2970,7 +2970,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.get_ProviderURI(::core::mem::transmute_copy(&enuri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2981,7 +2981,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2992,7 +2992,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ClientName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3003,7 +3003,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ClientBanner() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfbanner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfbanner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3014,7 +3014,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ClientMinVer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrminver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrminver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3025,7 +3025,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ClientCurVer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcurver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcurver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3036,7 +3036,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ClientUpdateURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrupdateuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrupdateuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3047,7 +3047,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.ClientData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3058,7 +3058,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.UserURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruseruri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruseruri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3069,7 +3069,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.UserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3080,7 +3080,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.UserAccount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruseraccount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruseraccount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3096,7 +3096,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.SessionCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsupportedsessions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsupportedsessions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3107,7 +3107,7 @@ impl IRTCProfile_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3156,7 +3156,7 @@ impl IRTCProfile2_Vtbl {
             let this = (*this).get_impl();
             match this.Realm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrrealm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrrealm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3172,7 +3172,7 @@ impl IRTCProfile2_Vtbl {
             let this = (*this).get_impl();
             match this.AllowedAuth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plallowedauth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plallowedauth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3211,7 +3211,7 @@ impl IRTCProfileEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3222,7 +3222,7 @@ impl IRTCProfileEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Cookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3233,7 +3233,7 @@ impl IRTCProfileEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3264,7 +3264,7 @@ impl IRTCProfileEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3294,7 +3294,7 @@ impl IRTCReInviteEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession2 = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession2, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3315,7 +3315,7 @@ impl IRTCReInviteEvent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3356,7 +3356,7 @@ impl IRTCRegistrationStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3367,7 +3367,7 @@ impl IRTCRegistrationStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3378,7 +3378,7 @@ impl IRTCRegistrationStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3389,7 +3389,7 @@ impl IRTCRegistrationStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3424,7 +3424,7 @@ impl IRTCRoamingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3435,7 +3435,7 @@ impl IRTCRoamingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3446,7 +3446,7 @@ impl IRTCRoamingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3457,7 +3457,7 @@ impl IRTCRoamingEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3508,7 +3508,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.Client() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclient = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclient, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3519,7 +3519,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3530,7 +3530,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pentype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pentype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3541,7 +3541,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3552,7 +3552,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.Participants() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3578,7 +3578,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.AddParticipant(::core::mem::transmute(&bstraddress), ::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparticipant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparticipant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3594,7 +3594,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateParticipants() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3605,7 +3605,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.CanAddParticipants() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcanadd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcanadd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3616,7 +3616,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectedUserURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruseruri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruseruri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3627,7 +3627,7 @@ impl IRTCSession_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectedUserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3720,7 +3720,7 @@ impl IRTCSession2_Vtbl {
             let this = (*this).get_impl();
             match this.get_PreferredSecurityLevel(::core::mem::transmute_copy(&ensecuritytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pensecuritylevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pensecuritylevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3731,7 +3731,7 @@ impl IRTCSession2_Vtbl {
             let this = (*this).get_impl();
             match this.IsSecurityEnabled(::core::mem::transmute_copy(&ensecuritytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsecurityenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsecurityenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3808,7 +3808,7 @@ impl IRTCSessionCallControl_Vtbl {
             let this = (*this).get_impl();
             match this.ReferredByURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrreferredbyuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrreferredbyuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3824,7 +3824,7 @@ impl IRTCSessionCallControl_Vtbl {
             let this = (*this).get_impl();
             match this.ReferCookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrrefercookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrrefercookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3835,7 +3835,7 @@ impl IRTCSessionCallControl_Vtbl {
             let this = (*this).get_impl();
             match this.IsReferred() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisreferred = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisreferred, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3898,7 +3898,7 @@ impl IRTCSessionOperationCompleteEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3909,7 +3909,7 @@ impl IRTCSessionOperationCompleteEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Cookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3920,7 +3920,7 @@ impl IRTCSessionOperationCompleteEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3931,7 +3931,7 @@ impl IRTCSessionOperationCompleteEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3964,7 +3964,7 @@ impl IRTCSessionOperationCompleteEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.Participant() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparticipant = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparticipant, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4019,7 +4019,7 @@ impl IRTCSessionReferStatusEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4030,7 +4030,7 @@ impl IRTCSessionReferStatusEvent_Vtbl {
             let this = (*this).get_impl();
             match this.ReferStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penreferstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penreferstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4041,7 +4041,7 @@ impl IRTCSessionReferStatusEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4052,7 +4052,7 @@ impl IRTCSessionReferStatusEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4090,7 +4090,7 @@ impl IRTCSessionReferredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4101,7 +4101,7 @@ impl IRTCSessionReferredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.ReferredByURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrreferredbyuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrreferredbyuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4112,7 +4112,7 @@ impl IRTCSessionReferredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.ReferToURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrreferouri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrreferouri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4123,7 +4123,7 @@ impl IRTCSessionReferredEvent_Vtbl {
             let this = (*this).get_impl();
             match this.ReferCookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrrefercookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrrefercookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4176,7 +4176,7 @@ impl IRTCSessionStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Session() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4187,7 +4187,7 @@ impl IRTCSessionStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4198,7 +4198,7 @@ impl IRTCSessionStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4209,7 +4209,7 @@ impl IRTCSessionStateChangeEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrstatustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrstatustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4244,7 +4244,7 @@ impl IRTCSessionStateChangeEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.MediaTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmediatypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmediatypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4255,7 +4255,7 @@ impl IRTCSessionStateChangeEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.get_RemotePreferredSecurityLevel(::core::mem::transmute_copy(&ensecuritytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pensecuritylevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pensecuritylevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4266,7 +4266,7 @@ impl IRTCSessionStateChangeEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.IsForked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisforked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisforked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4301,7 +4301,7 @@ impl IRTCUserSearch_Vtbl {
             let this = (*this).get_impl();
             match this.CreateQuery() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4347,7 +4347,7 @@ impl IRTCUserSearchQuery_Vtbl {
             let this = (*this).get_impl();
             match this.get_SearchTerm(::core::mem::transmute(&bstrname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4358,7 +4358,7 @@ impl IRTCUserSearchQuery_Vtbl {
             let this = (*this).get_impl();
             match this.SearchTerms() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrnames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrnames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4374,7 +4374,7 @@ impl IRTCUserSearchQuery_Vtbl {
             let this = (*this).get_impl();
             match this.get_SearchPreference(::core::mem::transmute_copy(&enpreference)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4390,7 +4390,7 @@ impl IRTCUserSearchQuery_Vtbl {
             let this = (*this).get_impl();
             match this.SearchDomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdomain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdomain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4425,7 +4425,7 @@ impl IRTCUserSearchResult_Vtbl {
             let this = (*this).get_impl();
             match this.get_Value(::core::mem::transmute_copy(&encolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4457,7 +4457,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4468,7 +4468,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Results() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4479,7 +4479,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4490,7 +4490,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Query() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppquery = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppquery, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4501,7 +4501,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Cookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4512,7 +4512,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4523,7 +4523,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
             let this = (*this).get_impl();
             match this.MoreAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmoreavailable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmoreavailable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4559,7 +4559,7 @@ impl IRTCWatcher_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4595,7 +4595,7 @@ impl IRTCWatcher2_Vtbl {
             let this = (*this).get_impl();
             match this.Profile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4606,7 +4606,7 @@ impl IRTCWatcher2_Vtbl {
             let this = (*this).get_impl();
             match this.Scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4632,7 +4632,7 @@ impl IRTCWatcherEvent_Vtbl {
             let this = (*this).get_impl();
             match this.Watcher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwatcher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwatcher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4659,7 +4659,7 @@ impl IRTCWatcherEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.EventType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *peventtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peventtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4670,7 +4670,7 @@ impl IRTCWatcherEvent2_Vtbl {
             let this = (*this).get_impl();
             match this.StatusCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatuscode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatuscode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
@@ -46,7 +46,7 @@ impl IRendezvousSession_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psessionstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psessionstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -57,7 +57,7 @@ impl IRendezvousSession_Vtbl {
             let this = (*this).get_impl();
             match this.RemoteUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrusername = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrusername, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -68,7 +68,7 @@ impl IRendezvousSession_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
@@ -41,7 +41,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalServicesProfilePath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -57,7 +57,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalServicesHomeDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -73,7 +73,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalServicesHomeDrive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -89,7 +89,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.AllowLogon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -105,7 +105,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnableRemoteControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -121,7 +121,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.MaxDisconnectionTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -137,7 +137,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.MaxConnectionTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -153,7 +153,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.MaxIdleTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -169,7 +169,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.ReconnectionAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnewval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnewval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -185,7 +185,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.BrokenConnectionAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnewval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnewval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectClientDrivesAtLogon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnewval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnewval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -217,7 +217,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectClientPrintersAtLogon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -233,7 +233,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultToMainPrinter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -249,7 +249,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalServicesWorkDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -265,7 +265,7 @@ impl IADsTSUserEx_Vtbl {
             let this = (*this).get_impl();
             match this.TerminalServicesInitialProgram() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -336,7 +336,7 @@ impl IAudioDeviceEndpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetRTCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbisrtcapable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbisrtcapable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -347,7 +347,7 @@ impl IAudioDeviceEndpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventDrivenCapable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbiseventcapable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbiseventcapable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -388,7 +388,7 @@ impl IAudioEndpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -399,7 +399,7 @@ impl IAudioEndpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetFramesPerPacket() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pframesperpacket = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pframesperpacket, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -410,7 +410,7 @@ impl IAudioEndpoint_Vtbl {
             let this = (*this).get_impl();
             match this.GetLatency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *platency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(platency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -626,7 +626,7 @@ impl IRemoteDesktopClient_Vtbl {
             let this = (*this).get_impl();
             match this.Settings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *settings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(settings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -637,7 +637,7 @@ impl IRemoteDesktopClient_Vtbl {
             let this = (*this).get_impl();
             match this.Actions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *actions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(actions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl IRemoteDesktopClient_Vtbl {
             let this = (*this).get_impl();
             match this.TouchPointer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *touchpointer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(touchpointer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -724,7 +724,7 @@ impl IRemoteDesktopClientActions_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapshot(::core::mem::transmute_copy(&snapshotencoding), ::core::mem::transmute_copy(&snapshotformat), ::core::mem::transmute_copy(&snapshotwidth), ::core::mem::transmute_copy(&snapshotheight)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *snapshotdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(snapshotdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -764,7 +764,7 @@ impl IRemoteDesktopClientSettings_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rdpfilecontents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rdpfilecontents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -775,7 +775,7 @@ impl IRemoteDesktopClientSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetRdpProperty(::core::mem::transmute(&propertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -822,7 +822,7 @@ impl IRemoteDesktopClientTouchPointer_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -838,7 +838,7 @@ impl IRemoteDesktopClientTouchPointer_Vtbl {
             let this = (*this).get_impl();
             match this.EventsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventsenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventsenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -854,7 +854,7 @@ impl IRemoteDesktopClientTouchPointer_Vtbl {
             let this = (*this).get_impl();
             match this.PointerSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pointerspeed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pointerspeed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1065,7 +1065,7 @@ impl ITSGPolicyEngine_Vtbl {
             let this = (*this).get_impl();
             match this.IsQuarantineEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *quarantineenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(quarantineenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1138,7 +1138,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.UserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1149,7 +1149,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Domain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1160,7 +1160,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.InitialProgram() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1171,7 +1171,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.LoadBalanceResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1182,7 +1182,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.FarmName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1193,7 +1193,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.PutContext(::core::mem::transmute(&contextid), ::core::mem::transmute(&context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *existingcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(existingcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1204,7 +1204,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext(::core::mem::transmute(&contextid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *context = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(context, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1215,7 +1215,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.Environment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenvironment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenvironment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1231,7 +1231,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.SamUserAccount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1242,7 +1242,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.ClientConnectionPropertySet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1253,7 +1253,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.IsFirstAssignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1264,7 +1264,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.RdFarmType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prdfarmtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prdfarmtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1275,7 +1275,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.UserSidString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszusersidstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszusersidstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1286,7 +1286,7 @@ impl ITsSbClientConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisconnectedSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1345,7 +1345,7 @@ impl ITsSbEnvironment_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1356,7 +1356,7 @@ impl ITsSbEnvironment_Vtbl {
             let this = (*this).get_impl();
             match this.ServerWeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1367,7 +1367,7 @@ impl ITsSbEnvironment_Vtbl {
             let this = (*this).get_impl();
             match this.EnvironmentPropertySet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1424,7 +1424,7 @@ impl ITsSbFilterPluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1466,7 +1466,7 @@ impl ITsSbGenericNotifySink_Vtbl {
             let this = (*this).get_impl();
             match this.GetWaitTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfttimeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfttimeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1502,7 +1502,7 @@ impl ITsSbGlobalStore_Vtbl {
             let this = (*this).get_impl();
             match this.QueryTarget(::core::mem::transmute(&providername), ::core::mem::transmute(&targetname), ::core::mem::transmute(&farmname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1513,7 +1513,7 @@ impl ITsSbGlobalStore_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySessionBySessionId(::core::mem::transmute(&providername), ::core::mem::transmute_copy(&dwsessionid), ::core::mem::transmute(&targetname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1573,7 +1573,7 @@ impl ITsSbLoadBalanceResult_Vtbl {
             let this = (*this).get_impl();
             match this.TargetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1810,7 +1810,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTargetObject(::core::mem::transmute(&targetname), ::core::mem::transmute(&environmentname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1821,7 +1821,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLoadBalanceResultObject(::core::mem::transmute(&targetname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplbresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplbresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1832,7 +1832,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSessionObject(::core::mem::transmute(&targetname), ::core::mem::transmute(&username), ::core::mem::transmute(&domain), ::core::mem::transmute_copy(&sessionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1843,7 +1843,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePluginPropertySet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1854,7 +1854,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTargetPropertySetObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1865,7 +1865,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEnvironmentObject(::core::mem::transmute(&name), ::core::mem::transmute_copy(&serverweight)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenvironment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenvironment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1876,7 +1876,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourcePluginStore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1887,7 +1887,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterPluginStore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1908,7 +1908,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceOfGlobalStore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppglobalstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppglobalstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1919,7 +1919,7 @@ impl ITsSbProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEnvironmentPropertySetObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2172,7 +2172,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.QueryTarget(::core::mem::transmute(&targetname), ::core::mem::transmute(&farmname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2183,7 +2183,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySessionBySessionId(::core::mem::transmute_copy(&dwsessionid), ::core::mem::transmute(&targetname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2219,7 +2219,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.QueryEnvironment(::core::mem::transmute(&environmentname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenvironment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenvironment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2260,7 +2260,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.SetTargetState(::core::mem::transmute(&targetname), ::core::mem::transmute_copy(&newstate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *poldstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poldstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2306,7 +2306,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.AcquireTargetLock(::core::mem::transmute(&targetname), ::core::mem::transmute_copy(&dwtimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2322,7 +2322,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.TestAndSetServerState(::core::mem::transmute(&poolname), ::core::mem::transmute(&serverfqdn), ::core::mem::transmute_copy(&newstate), ::core::mem::transmute_copy(&teststate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinitstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinitstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2338,7 +2338,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetServerState(::core::mem::transmute(&poolname), ::core::mem::transmute(&serverfqdn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2442,7 +2442,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.SessionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2453,7 +2453,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.TargetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2469,7 +2469,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.Username() {
                 ::core::result::Result::Ok(ok__) => {
-                    *username = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(username, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2480,7 +2480,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.Domain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *domain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(domain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2491,7 +2491,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2507,7 +2507,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2523,7 +2523,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.DisconnectTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2539,7 +2539,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.InitialProgram() {
                 ::core::result::Result::Ok(ok__) => {
-                    *app = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(app, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2555,7 +2555,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.ClientDisplay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclientdisplay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclientdisplay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2571,7 +2571,7 @@ impl ITsSbSession_Vtbl {
             let this = (*this).get_impl();
             match this.ProtocolType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2639,7 +2639,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.TargetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2655,7 +2655,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.FarmName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2671,7 +2671,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.TargetFQDN() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetfqdnname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetfqdnname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2687,7 +2687,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.TargetNetbios() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetnetbiosname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetnetbiosname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2713,7 +2713,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.TargetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2729,7 +2729,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.TargetPropertySet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2745,7 +2745,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.EnvironmentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2761,7 +2761,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.NumSessions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumsessions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumsessions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2772,7 +2772,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.NumPendingConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumpendingconnections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumpendingconnections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2783,7 +2783,7 @@ impl ITsSbTarget_Vtbl {
             let this = (*this).get_impl();
             match this.TargetLoad() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptargetload = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptargetload, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2851,7 +2851,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TargetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2862,7 +2862,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.StartTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstarttime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstarttime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2873,7 +2873,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.EndTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pendtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pendtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2884,7 +2884,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Deadline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdeadline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdeadline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2895,7 +2895,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Identifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pidentifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pidentifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2906,7 +2906,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Label() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2917,7 +2917,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Context() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2928,7 +2928,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Plugin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplugin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplugin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2939,7 +2939,7 @@ impl ITsSbTaskInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3047,7 +3047,7 @@ impl IWRdsEnhancedFastReconnectArbitrator_Vtbl {
             let this = (*this).get_impl();
             match this.GetSessionForEnhancedFastReconnect(::core::mem::transmute_copy(&psessionidarray), ::core::mem::transmute_copy(&dwsessioncount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presultsessionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presultsessionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3158,7 +3158,7 @@ impl IWRdsGraphicsChannelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateChannel(::core::mem::transmute_copy(&pszchannelname), ::core::mem::transmute_copy(&channeltype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvirtualchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvirtualchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3207,7 +3207,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogonErrorRedirector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplogonerrorredir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplogonerrorredir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3223,7 +3223,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclientdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclientdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3239,7 +3239,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserCredentials() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pusercreds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pusercreds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3250,7 +3250,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetLicenseConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplicenseconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplicenseconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3261,7 +3261,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticateClientToSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sessionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sessionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3282,7 +3282,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetVideoHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvideohandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvideohandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3328,7 +3328,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotocolstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotocolstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3339,7 +3339,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastInputTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plastinputtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plastinputtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3355,7 +3355,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVirtualChannel(::core::mem::transmute(&szendpointname), ::core::mem::transmute_copy(&bstatic), ::core::mem::transmute_copy(&requestedpriority)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3371,7 +3371,7 @@ impl IWRdsProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetShadowConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshadowconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshadowconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3449,7 +3449,7 @@ impl IWRdsProtocolConnectionCallback_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconnectionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconnectionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3485,7 +3485,7 @@ impl IWRdsProtocolConnectionSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnectionSetting(::core::mem::transmute(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropertyentriesout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropertyentriesout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3558,7 +3558,7 @@ impl IWRdsProtocolListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettings(::core::mem::transmute_copy(&wrdslistenersettinglevel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwrdslistenersettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwrdslistenersettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3599,7 +3599,7 @@ impl IWRdsProtocolListenerCallback_Vtbl {
             let this = (*this).get_impl();
             match this.OnConnected(::core::mem::transmute(&pconnection), ::core::mem::transmute_copy(&pwrdsconnectionsettings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3630,7 +3630,7 @@ impl IWRdsProtocolLogonErrorRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectStatus(::core::mem::transmute(&pszmessage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3641,7 +3641,7 @@ impl IWRdsProtocolLogonErrorRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectMessage(::core::mem::transmute(&pszcaption), ::core::mem::transmute(&pszmessage), ::core::mem::transmute_copy(&utype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3652,7 +3652,7 @@ impl IWRdsProtocolLogonErrorRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectLogonError(::core::mem::transmute_copy(&ntsstatus), ::core::mem::transmute_copy(&ntssubstatus), ::core::mem::transmute(&pszcaption), ::core::mem::transmute(&pszmessage), ::core::mem::transmute_copy(&utype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3696,7 +3696,7 @@ impl IWRdsProtocolManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateListener(::core::mem::transmute(&wszlistenername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotocollistener = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotocollistener, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3763,7 +3763,7 @@ impl IWRdsProtocolSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettings(::core::mem::transmute_copy(&wrdssettingtype), ::core::mem::transmute_copy(&wrdssettinglevel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwrdssettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwrdssettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3901,7 +3901,7 @@ impl IWTSBitmapRenderService_Vtbl {
             let this = (*this).get_impl();
             match this.GetMappedRenderer(::core::mem::transmute_copy(&mappingid), ::core::mem::transmute(&pmappedrenderercallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmappedrenderer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmappedrenderer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3931,7 +3931,7 @@ impl IWTSBitmapRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.GetRendererStatistics() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatistics = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatistics, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3987,7 +3987,7 @@ impl IWTSListener_Vtbl {
             let this = (*this).get_impl();
             match this.GetConfiguration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropertybag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropertybag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4071,7 +4071,7 @@ impl IWTSPluginServiceProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetService(::core::mem::transmute(&serviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4119,7 +4119,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetLogonErrorRedirector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplogonerrorredir = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplogonerrorredir, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4140,7 +4140,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclientdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclientdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4151,7 +4151,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserCredentials() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pusercreds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pusercreds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4162,7 +4162,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetLicenseConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplicenseconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplicenseconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4173,7 +4173,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticateClientToSession() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sessionid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sessionid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4229,7 +4229,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtocolStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotocolstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotocolstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4240,7 +4240,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastInputTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plastinputtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plastinputtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4261,7 +4261,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.CreateVirtualChannel(::core::mem::transmute(&szendpointname), ::core::mem::transmute_copy(&bstatic), ::core::mem::transmute_copy(&requestedpriority)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phchannel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phchannel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4277,7 +4277,7 @@ impl IWTSProtocolConnection_Vtbl {
             let this = (*this).get_impl();
             match this.GetShadowConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshadowconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshadowconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4444,7 +4444,7 @@ impl IWTSProtocolListenerCallback_Vtbl {
             let this = (*this).get_impl();
             match this.OnConnected(::core::mem::transmute(&pconnection)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4475,7 +4475,7 @@ impl IWTSProtocolLogonErrorRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectStatus(::core::mem::transmute(&pszmessage)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4486,7 +4486,7 @@ impl IWTSProtocolLogonErrorRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectMessage(::core::mem::transmute(&pszcaption), ::core::mem::transmute(&pszmessage), ::core::mem::transmute_copy(&utype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4497,7 +4497,7 @@ impl IWTSProtocolLogonErrorRedirector_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectLogonError(::core::mem::transmute_copy(&ntsstatus), ::core::mem::transmute_copy(&ntssubstatus), ::core::mem::transmute(&pszcaption), ::core::mem::transmute(&pszmessage), ::core::mem::transmute_copy(&utype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4530,7 +4530,7 @@ impl IWTSProtocolManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateListener(::core::mem::transmute(&wszlistenername)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprotocollistener = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprotocollistener, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4650,7 +4650,7 @@ impl IWTSSBPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.Initialize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plugincapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plugincapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4756,7 +4756,7 @@ impl IWTSVirtualChannelManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateListener(::core::mem::transmute_copy(&pszchannelname), ::core::mem::transmute_copy(&uflags), ::core::mem::transmute(&plistenercallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplistener = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplistener, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4784,7 +4784,7 @@ impl IWorkspace_Vtbl {
             let this = (*this).get_impl();
             match this.GetWorkspaceNames() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psawkspnames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psawkspnames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4800,7 +4800,7 @@ impl IWorkspace_Vtbl {
             let this = (*this).get_impl();
             match this.GetProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulprocessid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulprocessid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4852,7 +4852,7 @@ impl IWorkspace3_Vtbl {
             let this = (*this).get_impl();
             match this.GetClaimsToken2(::core::mem::transmute(&bstrclaimshint), ::core::mem::transmute(&bstruserhint), ::core::mem::transmute_copy(&claimcookie), ::core::mem::transmute_copy(&hwndcreduiparent), ::core::mem::transmute(&rectcreduiparent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstraccesstoken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstraccesstoken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4889,7 +4889,7 @@ impl IWorkspaceClientExt_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrworkspaceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrworkspaceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4900,7 +4900,7 @@ impl IWorkspaceClientExt_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrworkspacedisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrworkspacedisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4934,7 +4934,7 @@ impl IWorkspaceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.AddResource(::core::mem::transmute(&punk)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5006,7 +5006,7 @@ impl IWorkspaceReportMessage_Vtbl {
             let this = (*this).get_impl();
             match this.IsErrorMessageRegistered(::core::mem::transmute(&bstrwkspid), ::core::mem::transmute_copy(&dwerrortype), ::core::mem::transmute(&bstrerrormessagetype), ::core::mem::transmute_copy(&dwerrorcode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pferrorexist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pferrorexist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5056,7 +5056,7 @@ impl IWorkspaceResTypeRegistry_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegisteredFileExtensions(::core::mem::transmute_copy(&fmachinewide)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psafileextensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psafileextensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5067,7 +5067,7 @@ impl IWorkspaceResTypeRegistry_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceTypeInfo(::core::mem::transmute_copy(&fmachinewide), ::core::mem::transmute(&bstrfileextension)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlauncher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlauncher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5121,7 +5121,7 @@ impl IWorkspaceScriptable_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorkspaceCredentialSpecified(::core::mem::transmute(&bstrworkspaceid), ::core::mem::transmute_copy(&bcountunauthenticatedcredentials)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbcredexist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbcredexist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5132,7 +5132,7 @@ impl IWorkspaceScriptable_Vtbl {
             let this = (*this).get_impl();
             match this.IsWorkspaceSSOEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbssoenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbssoenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5256,7 +5256,7 @@ impl ItsPubPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.GetResource(::core::mem::transmute(&alias), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5267,7 +5267,7 @@ impl ItsPubPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.GetCacheLastUpdateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lastupdatetime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lastupdatetime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5278,7 +5278,7 @@ impl ItsPubPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.pluginName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5289,7 +5289,7 @@ impl ItsPubPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.pluginVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5336,7 +5336,7 @@ impl ItsPubPlugin2_Vtbl {
             let this = (*this).get_impl();
             match this.GetResource2(::core::mem::transmute(&alias), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
@@ -15,7 +15,7 @@ impl IWSMan_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession(::core::mem::transmute(&connection), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&connectionoptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *session = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(session, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26,7 +26,7 @@ impl IWSMan_Vtbl {
             let this = (*this).get_impl();
             match this.CreateConnectionOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *connectionoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(connectionoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37,7 +37,7 @@ impl IWSMan_Vtbl {
             let this = (*this).get_impl();
             match this.CommandLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -48,7 +48,7 @@ impl IWSMan_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -82,7 +82,7 @@ impl IWSManConnectionOptions_Vtbl {
             let this = (*this).get_impl();
             match this.UserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IWSManConnectionOptionsEx_Vtbl {
             let this = (*this).get_impl();
             match this.CertificateThumbprint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *thumbprint = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(thumbprint, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -171,7 +171,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyIEConfig() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -182,7 +182,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyWinHttpConfig() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -193,7 +193,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyAutoDetect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyNoProxyServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -215,7 +215,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyAuthenticationUseNegotiate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -226,7 +226,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyAuthenticationUseBasic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -237,7 +237,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyAuthenticationUseDigest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -275,7 +275,7 @@ impl IWSManEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.ReadItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *resource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -286,7 +286,7 @@ impl IWSManEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.AtEndOfStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -297,7 +297,7 @@ impl IWSManEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -347,7 +347,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.CreateResourceLocator(::core::mem::transmute(&strresourcelocator)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newresourcelocator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newresourcelocator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUTF8() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -369,7 +369,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagCredUsernamePassword() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -380,7 +380,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagSkipCACheck() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -391,7 +391,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagSkipCNCheck() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -402,7 +402,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseDigest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -413,7 +413,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseNegotiate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -424,7 +424,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseBasic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -435,7 +435,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseKerberos() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -446,7 +446,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagNoEncryption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -457,7 +457,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagEnableSPNServerPort() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -468,7 +468,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseNoAuthentication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -479,7 +479,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagNonXmlText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -490,7 +490,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagReturnEPR() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -501,7 +501,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagReturnObjectAndEPR() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -512,7 +512,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorMessage(::core::mem::transmute_copy(&errornumber)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *errormessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(errormessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -523,7 +523,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagHierarchyDeep() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -534,7 +534,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagHierarchyShallow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -545,7 +545,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagHierarchyDeepBasePropsOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IWSManEx_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagReturnObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -604,7 +604,7 @@ impl IWSManEx2_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseClientCertificate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -639,7 +639,7 @@ impl IWSManEx3_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUTF16() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -650,7 +650,7 @@ impl IWSManEx3_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseCredSsp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -661,7 +661,7 @@ impl IWSManEx3_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagAssociationInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -672,7 +672,7 @@ impl IWSManEx3_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationFlagAssociatedInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -683,7 +683,7 @@ impl IWSManEx3_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagSkipRevocationCheck() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -694,7 +694,7 @@ impl IWSManEx3_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagAllowNegotiateImplicitCredentials() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -705,7 +705,7 @@ impl IWSManEx3_Vtbl {
             let this = (*this).get_impl();
             match this.SessionFlagUseSsl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -740,7 +740,7 @@ impl IWSManInternal_Vtbl {
             let this = (*this).get_impl();
             match this.ConfigSDDL(::core::mem::transmute(&session), ::core::mem::transmute(&resourceuri), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -783,7 +783,7 @@ impl IWSManResourceLocator_Vtbl {
             let this = (*this).get_impl();
             match this.ResourceURI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *uri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(uri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -804,7 +804,7 @@ impl IWSManResourceLocator_Vtbl {
             let this = (*this).get_impl();
             match this.FragmentPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -820,7 +820,7 @@ impl IWSManResourceLocator_Vtbl {
             let this = (*this).get_impl();
             match this.FragmentDialect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -846,7 +846,7 @@ impl IWSManResourceLocator_Vtbl {
             let this = (*this).get_impl();
             match this.MustUnderstandOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mustunderstand = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mustunderstand, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -862,7 +862,7 @@ impl IWSManResourceLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -924,7 +924,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Get(::core::mem::transmute(&resourceuri), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -935,7 +935,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Put(::core::mem::transmute(&resourceuri), ::core::mem::transmute(&resource), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -946,7 +946,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&resourceuri), ::core::mem::transmute(&resource), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newuri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newuri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -962,7 +962,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Invoke2(::core::mem::transmute(&actionuri), ::core::mem::transmute(&resourceuri), ::core::mem::transmute(&parameters), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -973,7 +973,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Enumerate(::core::mem::transmute(&resourceuri), ::core::mem::transmute(&filter), ::core::mem::transmute(&dialect), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resultset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resultset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -984,7 +984,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Identify(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -995,7 +995,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Error() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1006,7 +1006,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.BatchItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1022,7 +1022,7 @@ impl IWSManSession_Vtbl {
             let this = (*this).get_impl();
             match this.Timeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
@@ -13,7 +13,7 @@ impl DataSource_Vtbl {
             let this = (*this).get_impl();
             match this.getDataMember(::core::mem::transmute_copy(&bstrdm), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24,7 +24,7 @@ impl DataSource_Vtbl {
             let this = (*this).get_impl();
             match this.getDataMemberName(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -35,7 +35,7 @@ impl DataSource_Vtbl {
             let this = (*this).get_impl();
             match this.getDataMemberCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -128,7 +128,7 @@ impl IAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.AddRefAccessor(::core::mem::transmute_copy(&haccessor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrefcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrefcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -149,7 +149,7 @@ impl IAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.ReleaseAccessor(::core::mem::transmute_copy(&haccessor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrefcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrefcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -249,7 +249,7 @@ impl IChapteredRowset_Vtbl {
             let this = (*this).get_impl();
             match this.AddRefChapter(::core::mem::transmute_copy(&hchapter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrefcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrefcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -260,7 +260,7 @@ impl IChapteredRowset_Vtbl {
             let this = (*this).get_impl();
             match this.ReleaseChapter(::core::mem::transmute_copy(&hchapter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrefcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrefcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -331,7 +331,7 @@ impl IColumnMapperCreator_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnMapper(::core::mem::transmute(&wcsmachinename), ::core::mem::transmute(&wcscatalogname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolumnmapper = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolumnmapper, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -446,7 +446,7 @@ impl ICommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetDBSession(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -757,7 +757,7 @@ impl ICondition_Vtbl {
             let this = (*this).get_impl();
             match this.GetConditionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnodetype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnodetype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -778,7 +778,7 @@ impl ICondition_Vtbl {
             let this = (*this).get_impl();
             match this.GetValueType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszvaluetypename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszvaluetypename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -789,7 +789,7 @@ impl ICondition_Vtbl {
             let this = (*this).get_impl();
             match this.GetValueNormalization() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsznormalization = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsznormalization, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -805,7 +805,7 @@ impl ICondition_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -841,7 +841,7 @@ impl ICondition2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLocale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszlocalename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszlocalename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -879,7 +879,7 @@ impl IConditionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.MakeNot(::core::mem::transmute(&pcsub), ::core::mem::transmute_copy(&fsimplify)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -890,7 +890,7 @@ impl IConditionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.MakeAndOr(::core::mem::transmute_copy(&ct), ::core::mem::transmute(&peusubs), ::core::mem::transmute_copy(&fsimplify)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -901,7 +901,7 @@ impl IConditionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.MakeLeaf(::core::mem::transmute(&pszpropertyname), ::core::mem::transmute_copy(&cop), ::core::mem::transmute(&pszvaluetype), ::core::mem::transmute_copy(&ppropvar), ::core::mem::transmute(&ppropertynameterm), ::core::mem::transmute(&poperationterm), ::core::mem::transmute(&pvalueterm), ::core::mem::transmute_copy(&fexpand)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -912,7 +912,7 @@ impl IConditionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.Resolve(::core::mem::transmute(&pc), ::core::mem::transmute_copy(&sqro), ::core::mem::transmute_copy(&pstreferencetime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcresolved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcresolved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1055,7 +1055,7 @@ impl IConditionGenerator_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultPhrase(::core::mem::transmute(&pszvaluetype), ::core::mem::transmute_copy(&ppropvar), ::core::mem::transmute_copy(&fuseenglish)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszphrase = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszphrase, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1202,7 +1202,7 @@ impl IDBCreateCommand_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCommand(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcommand = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcommand, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1225,7 +1225,7 @@ impl IDBCreateSession_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdbsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdbsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1296,7 +1296,7 @@ impl IDBInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeywords() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszkeywords = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszkeywords, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1364,7 +1364,7 @@ impl IDBPromptInitialize_Vtbl {
             let this = (*this).get_impl();
             match this.PromptFileName(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&dwpromptoptions), ::core::mem::transmute(&pwszinitialdirectory), ::core::mem::transmute(&pwszinitialfile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszselectedfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszselectedfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1429,7 +1429,7 @@ impl IDBSchemaCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetCommand(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&rguidschema)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcommand = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcommand, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1582,7 +1582,7 @@ impl IDataInitialize_Vtbl {
             let this = (*this).get_impl();
             match this.GetInitializationString(::core::mem::transmute(&pdatasource), ::core::mem::transmute_copy(&fincludepassword)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszinitstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszinitstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1593,7 +1593,7 @@ impl IDataInitialize_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDBInstance(::core::mem::transmute_copy(&clsidprovider), ::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&dwclsctx), ::core::mem::transmute(&pwszreserved), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdatasource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdatasource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1609,7 +1609,7 @@ impl IDataInitialize_Vtbl {
             let this = (*this).get_impl();
             match this.LoadStringFromStorage(::core::mem::transmute(&pwszfilename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszinitializationstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszinitializationstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1651,7 +1651,7 @@ impl IDataSourceLocator_Vtbl {
             let this = (*this).get_impl();
             match this.hWnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1667,7 +1667,7 @@ impl IDataSourceLocator_Vtbl {
             let this = (*this).get_impl();
             match this.PromptNew() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppadoconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppadoconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1708,7 +1708,7 @@ impl IEntity_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1719,7 +1719,7 @@ impl IEntity_Vtbl {
             let this = (*this).get_impl();
             match this.Base() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbaseentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbaseentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1735,7 +1735,7 @@ impl IEntity_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelationship(::core::mem::transmute(&pszrelationname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prelationship = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prelationship, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1756,7 +1756,7 @@ impl IEntity_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamedEntity(::core::mem::transmute(&pszvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamedentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamedentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1767,7 +1767,7 @@ impl IEntity_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultPhrase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszphrase = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszphrase, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1822,7 +1822,7 @@ impl IEnumItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1833,7 +1833,7 @@ impl IEnumItemProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1881,7 +1881,7 @@ impl IEnumSearchRoots_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1928,7 +1928,7 @@ impl IEnumSearchScopeRules_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1976,7 +1976,7 @@ impl IEnumSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1987,7 +1987,7 @@ impl IEnumSubscription_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2067,7 +2067,7 @@ impl IErrorRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetBasicErrorInfo(::core::mem::transmute_copy(&ulrecordnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *perrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(perrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2078,7 +2078,7 @@ impl IErrorRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetCustomErrorObject(::core::mem::transmute_copy(&ulrecordnum), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2089,7 +2089,7 @@ impl IErrorRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorInfo(::core::mem::transmute_copy(&ulrecordnum), ::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pperrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pperrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2100,7 +2100,7 @@ impl IErrorRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorParameters(::core::mem::transmute_copy(&ulrecordnum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdispparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdispparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2111,7 +2111,7 @@ impl IErrorRecords_Vtbl {
             let this = (*this).get_impl();
             match this.GetRecordCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrecords = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrecords, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2142,7 +2142,7 @@ impl IGetDataSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataSource(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdatasource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdatasource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2166,7 +2166,7 @@ impl IGetRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetRowFromHROW(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&hrow), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2177,7 +2177,7 @@ impl IGetRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetURLFromHROW(::core::mem::transmute_copy(&hrow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2204,7 +2204,7 @@ impl IGetSession_Vtbl {
             let this = (*this).get_impl();
             match this.GetSession(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2227,7 +2227,7 @@ impl IGetSourceRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceRow(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2387,7 +2387,7 @@ impl IMDDataset_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpecification(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppspecification = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppspecification, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2499,7 +2499,7 @@ impl INamedEntity_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2510,7 +2510,7 @@ impl INamedEntity_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultPhrase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszphrase = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszphrase, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2610,7 +2610,7 @@ impl IOpLockStatus_Vtbl {
             let this = (*this).get_impl();
             match this.IsOplockValid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisoplockvalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisoplockvalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2621,7 +2621,7 @@ impl IOpLockStatus_Vtbl {
             let this = (*this).get_impl();
             match this.IsOplockBroken() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisoplockbroken = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisoplockbroken, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2632,7 +2632,7 @@ impl IOpLockStatus_Vtbl {
             let this = (*this).get_impl();
             match this.GetOplockEventHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phoplockev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phoplockev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2680,7 +2680,7 @@ impl IParentRowset_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildRowset(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&iordinal), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprowset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprowset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2726,7 +2726,7 @@ impl IProvideMoniker_Vtbl {
             let this = (*this).get_impl();
             match this.GetMoniker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimoniker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimoniker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2759,7 +2759,7 @@ impl IQueryParser_Vtbl {
             let this = (*this).get_impl();
             match this.Parse(::core::mem::transmute(&pszinputstring), ::core::mem::transmute(&pcustomproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsolution = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsolution, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2775,7 +2775,7 @@ impl IQueryParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetOption(::core::mem::transmute_copy(&option)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *poptionvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poptionvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2791,7 +2791,7 @@ impl IQueryParser_Vtbl {
             let this = (*this).get_impl();
             match this.GetSchemaProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppschemaprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppschemaprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2802,7 +2802,7 @@ impl IQueryParser_Vtbl {
             let this = (*this).get_impl();
             match this.RestateToString(::core::mem::transmute(&pcondition), ::core::mem::transmute_copy(&fuseenglish)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszquerystring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszquerystring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2813,7 +2813,7 @@ impl IQueryParser_Vtbl {
             let this = (*this).get_impl();
             match this.ParsePropertyValue(::core::mem::transmute(&pszpropertyname), ::core::mem::transmute(&pszinputstring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsolution = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsolution, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2954,7 +2954,7 @@ impl IRegisterProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetURLMapping(::core::mem::transmute(&pwszurl), ::core::mem::transmute_copy(&dwreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsidprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsidprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2999,7 +2999,7 @@ impl IRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3010,7 +3010,7 @@ impl IRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.IsReal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisreal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisreal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3021,7 +3021,7 @@ impl IRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.Destination() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdestinationentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdestinationentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3037,7 +3037,7 @@ impl IRelationship_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultPhrase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszphrase = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszphrase, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3102,7 +3102,7 @@ impl IRow_Vtbl {
             let this = (*this).get_impl();
             match this.Open(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&pcolumnid), ::core::mem::transmute_copy(&rguidcolumntype), ::core::mem::transmute_copy(&dwbindflags), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3164,7 +3164,7 @@ impl IRowPosition_Vtbl {
             let this = (*this).get_impl();
             match this.GetRowset(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprowset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprowset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3653,7 +3653,7 @@ impl IRowsetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetReferencedRowset(::core::mem::transmute_copy(&iordinal), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreferencedrowset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreferencedrowset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3664,7 +3664,7 @@ impl IRowsetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpecification(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppspecification = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppspecification, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3767,7 +3767,7 @@ impl IRowsetNextRowset_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextRowset(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnextrowset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnextrowset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4021,7 +4021,7 @@ impl IRowsetView_Vtbl {
             let this = (*this).get_impl();
             match this.CreateView(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4263,7 +4263,7 @@ impl ISchemaLocalizerSupport_Vtbl {
             let this = (*this).get_impl();
             match this.Localize(::core::mem::transmute(&pszglobalstring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszlocalstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszlocalstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4327,7 +4327,7 @@ impl ISchemaProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RootEntity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prootentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prootentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4338,7 +4338,7 @@ impl ISchemaProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntity(::core::mem::transmute(&pszentityname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pentity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pentity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4462,7 +4462,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4473,7 +4473,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameter(::core::mem::transmute(&pszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4519,7 +4519,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwconnecttimeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwconnecttimeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4535,7 +4535,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.DataTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwdatatimeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwdatatimeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4546,7 +4546,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4562,7 +4562,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.URLBeingIndexed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4573,7 +4573,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetURLIndexingState(::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4584,7 +4584,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetPersistentItemsChangedSink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppisearchpersistentitemschangedsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppisearchpersistentitemschangedsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4595,7 +4595,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterViewForNotification(::core::mem::transmute(&pszview), ::core::mem::transmute(&pviewchangedsink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4621,7 +4621,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateExcludedExtensions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppextensions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppextensions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4632,7 +4632,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetQueryHelper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsearchqueryhelper = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsearchqueryhelper, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4648,7 +4648,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.DiacriticSensitivity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdiacriticsensitive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdiacriticsensitive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4659,7 +4659,7 @@ impl ISearchCatalogManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetCrawlScopeManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcrawlscopemanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcrawlscopemanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4763,7 +4763,7 @@ impl ISearchCrawlScopeManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateRoots() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsearchroots = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsearchroots, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4789,7 +4789,7 @@ impl ISearchCrawlScopeManager_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateScopeRules() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsearchscoperules = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsearchscoperules, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4800,7 +4800,7 @@ impl ISearchCrawlScopeManager_Vtbl {
             let this = (*this).get_impl();
             match this.HasParentScopeRule(::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfhasparentrule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfhasparentrule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4811,7 +4811,7 @@ impl ISearchCrawlScopeManager_Vtbl {
             let this = (*this).get_impl();
             match this.HasChildScopeRule(::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfhaschildrule = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfhaschildrule, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4822,7 +4822,7 @@ impl ISearchCrawlScopeManager_Vtbl {
             let this = (*this).get_impl();
             match this.IncludedInCrawlScope(::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisincluded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisincluded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4848,7 +4848,7 @@ impl ISearchCrawlScopeManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentScopeVersionId(::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plscopeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plscopeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4963,7 +4963,7 @@ impl ISearchLanguageSupport_Vtbl {
             let this = (*this).get_impl();
             match this.GetDiacriticSensitivity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdiacriticsensitive = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdiacriticsensitive, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4984,7 +4984,7 @@ impl ISearchLanguageSupport_Vtbl {
             let this = (*this).get_impl();
             match this.IsPrefixNormalized(::core::mem::transmute(&pwcsquerytoken), ::core::mem::transmute_copy(&cwcquerytoken), ::core::mem::transmute(&pwcsdocumenttoken), ::core::mem::transmute_copy(&cwcdocumenttoken)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulprefixlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulprefixlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5029,7 +5029,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndexerVersionStr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszversionstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszversionstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5045,7 +5045,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameter(::core::mem::transmute(&pszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5061,7 +5061,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszproxyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszproxyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5072,7 +5072,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.BypassList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszbypasslist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszbypasslist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5088,7 +5088,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetCatalog(::core::mem::transmute(&pszcatalog)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5099,7 +5099,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.UserAgent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszuseragent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszuseragent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5115,7 +5115,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.UseProxy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puseproxy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puseproxy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5126,7 +5126,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.LocalBypass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflocalbypass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflocalbypass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5137,7 +5137,7 @@ impl ISearchManager_Vtbl {
             let this = (*this).get_impl();
             match this.PortNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwportnumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwportnumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5179,7 +5179,7 @@ impl ISearchManager2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCatalog(::core::mem::transmute(&pszcatalog)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogmanager = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogmanager, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5393,7 +5393,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszconnectionstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszconnectionstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5409,7 +5409,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QueryContentLocale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5425,7 +5425,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QueryKeywordLocale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5441,7 +5441,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QueryTermExpansion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pexpandterms = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pexpandterms, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5457,7 +5457,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySyntax() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pquerysyntax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pquerysyntax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5473,7 +5473,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QueryContentProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcontentproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcontentproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5489,7 +5489,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySelectColumns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszselectcolumns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszselectcolumns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5505,7 +5505,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QueryWhereRestrictions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszrestrictions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszrestrictions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5521,7 +5521,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QuerySorting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszsorting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszsorting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5532,7 +5532,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GenerateSQLFromUserQuery(::core::mem::transmute(&pszquery)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszsql = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszsql, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5553,7 +5553,7 @@ impl ISearchQueryHelper_Vtbl {
             let this = (*this).get_impl();
             match this.QueryMaxResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmaxresults = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmaxresults, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5665,7 +5665,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.Schedule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztaskarg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztaskarg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5681,7 +5681,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.RootURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5697,7 +5697,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.IsHierarchical() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfishierarchical = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfishierarchical, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5713,7 +5713,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.ProvidesNotifications() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfprovidesnotifications = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfprovidesnotifications, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5729,7 +5729,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.UseNotificationsOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfusenotificationsonly = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfusenotificationsonly, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5745,7 +5745,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerationDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwdepth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwdepth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5761,7 +5761,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.HostDepth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwdepth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwdepth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5777,7 +5777,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.FollowDirectories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pffollowdirectories = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pffollowdirectories, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5793,7 +5793,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pauthtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pauthtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5809,7 +5809,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.User() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszuser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszuser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5825,7 +5825,7 @@ impl ISearchRoot_Vtbl {
             let this = (*this).get_impl();
             match this.Password() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpassword = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpassword, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5878,7 +5878,7 @@ impl ISearchScopeRule_Vtbl {
             let this = (*this).get_impl();
             match this.PatternOrURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpatternorurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpatternorurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5889,7 +5889,7 @@ impl ISearchScopeRule_Vtbl {
             let this = (*this).get_impl();
             match this.IsIncluded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisincluded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisincluded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5900,7 +5900,7 @@ impl ISearchScopeRule_Vtbl {
             let this = (*this).get_impl();
             match this.IsDefault() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisdefault = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisdefault, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5911,7 +5911,7 @@ impl ISearchScopeRule_Vtbl {
             let this = (*this).get_impl();
             match this.FollowFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfollowflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfollowflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6144,7 +6144,7 @@ impl ISubscriptionItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetCookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6155,7 +6155,7 @@ impl ISubscriptionItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscriptionItemInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psubscriptioniteminfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psubscriptioniteminfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6181,7 +6181,7 @@ impl ISubscriptionItem_Vtbl {
             let this = (*this).get_impl();
             match this.EnumProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumitemproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumitemproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6243,7 +6243,7 @@ impl ISubscriptionMgr_Vtbl {
             let this = (*this).get_impl();
             match this.IsSubscribed(::core::mem::transmute(&pwszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsubscribed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsubscribed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6254,7 +6254,7 @@ impl ISubscriptionMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscriptionInfo(::core::mem::transmute(&pwszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6265,7 +6265,7 @@ impl ISubscriptionMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultInfo(::core::mem::transmute_copy(&subtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6317,7 +6317,7 @@ impl ISubscriptionMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemFromURL(::core::mem::transmute(&pwszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubscriptionitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubscriptionitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6328,7 +6328,7 @@ impl ISubscriptionMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemFromCookie(::core::mem::transmute_copy(&psubscriptioncookie)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsubscriptionitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsubscriptionitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6344,7 +6344,7 @@ impl ISubscriptionMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumSubscriptions(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumsubscriptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumsubscriptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6427,7 +6427,7 @@ impl ITableDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.AddColumn(::core::mem::transmute_copy(&ptableid), ::core::mem::transmute_copy(&pcolumndesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolumnid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolumnid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6560,7 +6560,7 @@ impl ITransactionJoin_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionsObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6596,7 +6596,7 @@ impl ITransactionLocal_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptionsObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6607,7 +6607,7 @@ impl ITransactionLocal_Vtbl {
             let this = (*this).get_impl();
             match this.StartTransaction(::core::mem::transmute_copy(&isolevel), ::core::mem::transmute_copy(&isoflags), ::core::mem::transmute(&potheroptions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pultransactionlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pultransactionlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6637,7 +6637,7 @@ impl ITransactionObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransactionObject(::core::mem::transmute_copy(&ultransactionlevel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransactionobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransactionobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6854,7 +6854,7 @@ impl IUrlAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6875,7 +6875,7 @@ impl IUrlAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pllsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pllsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6886,7 +6886,7 @@ impl IUrlAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastModified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftlastmodified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftlastmodified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6912,7 +6912,7 @@ impl IUrlAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pspclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pspclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6923,7 +6923,7 @@ impl IUrlAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.BindToStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6934,7 +6934,7 @@ impl IUrlAccessor_Vtbl {
             let this = (*this).get_impl();
             match this.BindToFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7033,7 +7033,7 @@ impl IUrlAccessor4_Vtbl {
             let this = (*this).get_impl();
             match this.ShouldIndexItemContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfindexcontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfindexcontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7044,7 +7044,7 @@ impl IUrlAccessor4_Vtbl {
             let this = (*this).get_impl();
             match this.ShouldIndexProperty(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfindexproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfindexproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7072,7 +7072,7 @@ impl IViewChapter_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpecification(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprowset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprowset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7083,7 +7083,7 @@ impl IViewChapter_Vtbl {
             let this = (*this).get_impl();
             match this.OpenViewChapter(::core::mem::transmute_copy(&hsource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phviewchapter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phviewchapter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7148,7 +7148,7 @@ impl IViewRowset_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpecification(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7159,7 +7159,7 @@ impl IViewRowset_Vtbl {
             let this = (*this).get_impl();
             match this.OpenViewRowset(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprowset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprowset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7351,7 +7351,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.getRowCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrows = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrows, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7362,7 +7362,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.getColumnCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccolumns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccolumns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7373,7 +7373,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.getRWStatus(::core::mem::transmute_copy(&irow), ::core::mem::transmute_copy(&icolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7384,7 +7384,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.getVariant(::core::mem::transmute_copy(&irow), ::core::mem::transmute_copy(&icolumn), ::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7400,7 +7400,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.getLocale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrlocale = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrlocale, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7411,7 +7411,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.deleteRows(::core::mem::transmute_copy(&irow), ::core::mem::transmute_copy(&crows)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrowsdeleted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrowsdeleted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7422,7 +7422,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.insertRows(::core::mem::transmute_copy(&irow), ::core::mem::transmute_copy(&crows)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcrowsinserted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcrowsinserted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7433,7 +7433,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.find(::core::mem::transmute_copy(&irowstart), ::core::mem::transmute_copy(&icolumn), ::core::mem::transmute(&val), ::core::mem::transmute_copy(&findflags), ::core::mem::transmute_copy(&comptype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pirowfound = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pirowfound, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7454,7 +7454,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.isAsync() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbasynch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbasynch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7465,7 +7465,7 @@ impl OLEDBSimpleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.getEstimatedRows() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pirows = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pirows, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/impl.rs
@@ -39,7 +39,7 @@ impl IWSCProductList_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -50,7 +50,7 @@ impl IWSCProductList_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -87,7 +87,7 @@ impl IWscProduct_Vtbl {
             let this = (*this).get_impl();
             match this.ProductName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl IWscProduct_Vtbl {
             let this = (*this).get_impl();
             match this.ProductState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -109,7 +109,7 @@ impl IWscProduct_Vtbl {
             let this = (*this).get_impl();
             match this.SignatureStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -120,7 +120,7 @@ impl IWscProduct_Vtbl {
             let this = (*this).get_impl();
             match this.RemediationPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -131,7 +131,7 @@ impl IWscProduct_Vtbl {
             let this = (*this).get_impl();
             match this.ProductStateTimestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -142,7 +142,7 @@ impl IWscProduct_Vtbl {
             let this = (*this).get_impl();
             match this.ProductGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -153,7 +153,7 @@ impl IWscProduct_Vtbl {
             let this = (*this).get_impl();
             match this.ProductIsDefault() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -193,7 +193,7 @@ impl IWscProduct2_Vtbl {
             let this = (*this).get_impl();
             match this.AntivirusScanSubstatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl IWscProduct2_Vtbl {
             let this = (*this).get_impl();
             match this.AntivirusSettingsSubstatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -215,7 +215,7 @@ impl IWscProduct2_Vtbl {
             let this = (*this).get_impl();
             match this.AntivirusProtectionUpdateSubstatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -226,7 +226,7 @@ impl IWscProduct2_Vtbl {
             let this = (*this).get_impl();
             match this.FirewallDomainProfileSubstatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -237,7 +237,7 @@ impl IWscProduct2_Vtbl {
             let this = (*this).get_impl();
             match this.FirewallPrivateProfileSubstatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -248,7 +248,7 @@ impl IWscProduct2_Vtbl {
             let this = (*this).get_impl();
             match this.FirewallPublicProfileSubstatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -282,7 +282,7 @@ impl IWscProduct3_Vtbl {
             let this = (*this).get_impl();
             match this.AntivirusDaysUntilExpired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwdays = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwdays, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
@@ -10,7 +10,7 @@ impl IWsbApplicationAsync_Vtbl {
             let this = (*this).get_impl();
             match this.QueryStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IWsbApplicationBackupSupport_Vtbl {
             let this = (*this).get_impl();
             match this.CheckConsistency(::core::mem::transmute(&wszwritermetadata), ::core::mem::transmute(&wszcomponentname), ::core::mem::transmute(&wszcomponentlogicalpath), ::core::mem::transmute_copy(&cvolumes), ::core::mem::transmute_copy(&rgwszsourcevolumepath), ::core::mem::transmute_copy(&rgwszsnapshotvolumepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -86,7 +86,7 @@ impl IWsbApplicationRestoreSupport_Vtbl {
             let this = (*this).get_impl();
             match this.IsRollForwardSupported() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbrollforwardsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbrollforwardsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
@@ -14,7 +14,7 @@ impl IItemEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.Current() {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25,7 +25,7 @@ impl IItemEnumerator_Vtbl {
             let this = (*this).get_impl();
             match this.MoveNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemvalid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemvalid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -82,7 +82,7 @@ impl ISettingsContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puserdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puserdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -93,7 +93,7 @@ impl ISettingsContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamespaces() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamespaceids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamespaceids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -153,7 +153,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamespaces(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&reserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaces = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaces, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -164,7 +164,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamespace(::core::mem::transmute(&settingsid), ::core::mem::transmute_copy(&access), ::core::mem::transmute_copy(&reserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *namespaceitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(namespaceitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -175,7 +175,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorDescription(::core::mem::transmute_copy(&hresult)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *message = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(message, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -186,7 +186,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSettingsIdentity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *settingsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(settingsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -197,7 +197,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoreStatus(::core::mem::transmute_copy(&reserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -218,7 +218,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterNamespace(::core::mem::transmute(&settingsid), ::core::mem::transmute(&stream), ::core::mem::transmute_copy(&pushsettings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *results = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(results, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTargetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *target = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(target, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *target = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(target, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -261,7 +261,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSettingsContext(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&reserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *settingscontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(settingscontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -282,7 +282,7 @@ impl ISettingsEngine_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettingsContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *settingscontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(settingscontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -329,7 +329,7 @@ impl ISettingsIdentity_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttribute(::core::mem::transmute_copy(&reserved), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -345,7 +345,7 @@ impl ISettingsIdentity_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -403,7 +403,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -414,7 +414,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -430,7 +430,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettingType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -441,7 +441,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -462,7 +462,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.HasChild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *itemhaschild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(itemhaschild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -473,7 +473,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.Children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *children = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(children, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -484,7 +484,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetChild(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *child = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(child, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -495,7 +495,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettingByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *setting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(setting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -506,7 +506,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSettingByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *setting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(setting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -527,7 +527,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.CreateListElement(::core::mem::transmute_copy(&keydata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *child = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(child, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -543,7 +543,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.Attributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -554,7 +554,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttribute(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -565,7 +565,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -576,7 +576,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictionFacets() {
                 ::core::result::Result::Ok(ok__) => {
-                    *restrictionfacets = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(restrictionfacets, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -587,7 +587,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestriction(::core::mem::transmute_copy(&restrictionfacet)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *facetdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(facetdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -598,7 +598,7 @@ impl ISettingsItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -654,7 +654,7 @@ impl ISettingsNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.GetIdentity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *settingsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(settingsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -665,7 +665,7 @@ impl ISettingsNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Settings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *settings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(settings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -676,7 +676,7 @@ impl ISettingsNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.Save(::core::mem::transmute_copy(&pushsettings)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -687,7 +687,7 @@ impl ISettingsNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.GetSettingByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *setting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(setting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -698,7 +698,7 @@ impl ISettingsNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSettingByPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *setting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(setting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -714,7 +714,7 @@ impl ISettingsNamespace_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttribute(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -754,7 +754,7 @@ impl ISettingsResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -765,7 +765,7 @@ impl ISettingsResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hrout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hrout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -776,7 +776,7 @@ impl ISettingsResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetContextDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *description = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(description, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -787,7 +787,7 @@ impl ISettingsResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -798,7 +798,7 @@ impl ISettingsResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwcolumn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwcolumn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -809,7 +809,7 @@ impl ISettingsResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *file = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(file, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -863,7 +863,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -879,7 +879,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTemporaryStoreLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *temporarystorelocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(temporarystorelocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -895,7 +895,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -911,7 +911,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetProcessorArchitecture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *processorarchitecture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(processorarchitecture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -927,7 +927,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&offline), ::core::mem::transmute(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumerator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumerator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -954,7 +954,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ExpandTarget(::core::mem::transmute_copy(&offline), ::core::mem::transmute(&location)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *expandedlocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expandedlocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -965,7 +965,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.ExpandTargetPath(::core::mem::transmute_copy(&offline), ::core::mem::transmute(&location)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *expandedlocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expandedlocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -981,7 +981,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.LoadModule(::core::mem::transmute(&module)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *modulehandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modulehandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -997,7 +997,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.TranslateWow64(::core::mem::transmute(&clientarchitecture), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *translatedvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(translatedvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1013,7 +1013,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSchemaHiveLocation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phivelocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phivelocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1029,7 +1029,7 @@ impl ITargetInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSchemaHiveMountName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmountname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmountname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
@@ -50,7 +50,7 @@ impl ISideShowCapabilitiesCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -61,7 +61,7 @@ impl ISideShowCapabilitiesCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&in_dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ppcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ppcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -98,7 +98,7 @@ impl ISideShowContent_Vtbl {
             let this = (*this).get_impl();
             match this.ContentId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_pcontentid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_pcontentid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -109,7 +109,7 @@ impl ISideShowContent_Vtbl {
             let this = (*this).get_impl();
             match this.DifferentiateContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_pfdifferentiatecontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_pfdifferentiatecontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -161,7 +161,7 @@ impl ISideShowContentManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetDeviceCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ppcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ppcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -194,7 +194,7 @@ impl ISideShowEvents_Vtbl {
             let this = (*this).get_impl();
             match this.ContentMissing(::core::mem::transmute_copy(&in_contentid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ppicontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ppicontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -301,7 +301,7 @@ impl ISideShowNotification_Vtbl {
             let this = (*this).get_impl();
             match this.NotificationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_pnotificationid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_pnotificationid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl ISideShowNotification_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ppwsztitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ppwsztitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -333,7 +333,7 @@ impl ISideShowNotification_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ppwszmessage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ppwszmessage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -349,7 +349,7 @@ impl ISideShowNotification_Vtbl {
             let this = (*this).get_impl();
             match this.Image() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_phicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_phicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -365,7 +365,7 @@ impl ISideShowNotification_Vtbl {
             let this = (*this).get_impl();
             match this.ExpirationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ptime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ptime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -491,7 +491,7 @@ impl ISideShowSession_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterContent(::core::mem::transmute_copy(&in_applicationid), ::core::mem::transmute_copy(&in_endpointid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ppicontent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ppicontent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -502,7 +502,7 @@ impl ISideShowSession_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterNotifications(::core::mem::transmute_copy(&in_applicationid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *out_ppinotification = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(out_ppinotification, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
@@ -63,7 +63,7 @@ impl IActionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -74,7 +74,7 @@ impl IActionCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -95,7 +95,7 @@ impl IActionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -356,7 +356,7 @@ impl IEmailAction_Vtbl {
             let this = (*this).get_impl();
             match this.HeaderFields() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppheaderfields = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppheaderfields, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -444,7 +444,7 @@ impl IEnumWorkItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumworkitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumworkitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -501,7 +501,7 @@ impl IEventTrigger_Vtbl {
             let this = (*this).get_impl();
             match this.ValueQueries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamedxpaths = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamedxpaths, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1168,7 +1168,7 @@ impl IProvideTaskPage_Vtbl {
             let this = (*this).get_impl();
             match this.GetPage(::core::mem::transmute_copy(&tptype), ::core::mem::transmute_copy(&fpersistchanges)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1211,7 +1211,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1222,7 +1222,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1233,7 +1233,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1244,7 +1244,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1260,7 +1260,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.Run(::core::mem::transmute(&params)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprunningtask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprunningtask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1271,7 +1271,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.RunEx(::core::mem::transmute(&params), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&sessionid), ::core::mem::transmute(&user)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprunningtask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprunningtask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1282,7 +1282,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstances(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprunningtasks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprunningtasks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1293,7 +1293,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.LastRunTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plastruntime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plastruntime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1304,7 +1304,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.LastTaskResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plasttaskresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plasttaskresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1315,7 +1315,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.NumberOfMissedRuns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumberofmissedruns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumberofmissedruns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1326,7 +1326,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.NextRunTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnextruntime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnextruntime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1337,7 +1337,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.Definition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdefinition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdefinition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1348,7 +1348,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.Xml() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pxml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pxml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1359,7 +1359,7 @@ impl IRegisteredTask_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityDescriptor(::core::mem::transmute_copy(&securityinformation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psddl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psddl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1422,7 +1422,7 @@ impl IRegisteredTaskCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1433,7 +1433,7 @@ impl IRegisteredTaskCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppregisteredtask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppregisteredtask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1444,7 +1444,7 @@ impl IRegisteredTaskCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1708,7 +1708,7 @@ impl IRunningTask_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1719,7 +1719,7 @@ impl IRunningTask_Vtbl {
             let this = (*this).get_impl();
             match this.InstanceGuid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1730,7 +1730,7 @@ impl IRunningTask_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1741,7 +1741,7 @@ impl IRunningTask_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1752,7 +1752,7 @@ impl IRunningTask_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1773,7 +1773,7 @@ impl IRunningTask_Vtbl {
             let this = (*this).get_impl();
             match this.EnginePID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1811,7 +1811,7 @@ impl IRunningTaskCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1822,7 +1822,7 @@ impl IRunningTaskCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprunningtask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprunningtask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1833,7 +1833,7 @@ impl IRunningTaskCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1902,7 +1902,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetTriggerCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1913,7 +1913,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrigger(::core::mem::transmute_copy(&itrigger)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptrigger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptrigger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1924,7 +1924,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetTriggerString(::core::mem::transmute_copy(&itrigger)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwsztrigger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwsztrigger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1970,7 +1970,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetMostRecentRunTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstlastrun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstlastrun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1981,7 +1981,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1992,7 +1992,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetExitCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwexitcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwexitcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2008,7 +2008,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetComment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszcomment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszcomment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2024,7 +2024,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetCreator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszcreator = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszcreator, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2050,7 +2050,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorRetryCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwretrycount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwretrycount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2066,7 +2066,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorRetryInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwretryinterval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwretryinterval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2082,7 +2082,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2098,7 +2098,7 @@ impl IScheduledWorkItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccountInformation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszaccountname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszaccountname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2273,7 +2273,7 @@ impl ITask_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszapplicationname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszapplicationname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2289,7 +2289,7 @@ impl ITask_Vtbl {
             let this = (*this).get_impl();
             match this.GetParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2305,7 +2305,7 @@ impl ITask_Vtbl {
             let this = (*this).get_impl();
             match this.GetWorkingDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszworkingdirectory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszworkingdirectory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2321,7 +2321,7 @@ impl ITask_Vtbl {
             let this = (*this).get_impl();
             match this.GetPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwpriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwpriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2337,7 +2337,7 @@ impl ITask_Vtbl {
             let this = (*this).get_impl();
             match this.GetTaskFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2353,7 +2353,7 @@ impl ITask_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxRunTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwmaxruntimems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwmaxruntimems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2406,7 +2406,7 @@ impl ITaskDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.RegistrationInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppregistrationinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppregistrationinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2422,7 +2422,7 @@ impl ITaskDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Triggers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptriggers = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptriggers, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2438,7 +2438,7 @@ impl ITaskDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Settings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2464,7 +2464,7 @@ impl ITaskDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Principal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprincipal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprincipal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2480,7 +2480,7 @@ impl ITaskDefinition_Vtbl {
             let this = (*this).get_impl();
             match this.Actions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppactions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppactions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2549,7 +2549,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2560,7 +2560,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2571,7 +2571,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolder(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2582,7 +2582,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolders(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfolders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfolders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2593,7 +2593,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFolder(::core::mem::transmute(&subfoldername), ::core::mem::transmute(&sddl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2609,7 +2609,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetTask(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2620,7 +2620,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetTasks(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptasks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptasks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2636,7 +2636,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterTask(::core::mem::transmute(&path), ::core::mem::transmute(&xmltext), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&userid), ::core::mem::transmute(&password), ::core::mem::transmute_copy(&logontype), ::core::mem::transmute(&sddl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2647,7 +2647,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterTaskDefinition(::core::mem::transmute(&path), ::core::mem::transmute(&pdefinition), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&userid), ::core::mem::transmute(&password), ::core::mem::transmute_copy(&logontype), ::core::mem::transmute(&sddl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptask = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptask, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2658,7 +2658,7 @@ impl ITaskFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetSecurityDescriptor(::core::mem::transmute_copy(&securityinformation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psddl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psddl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2706,7 +2706,7 @@ impl ITaskFolderCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2717,7 +2717,7 @@ impl ITaskFolderCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2728,7 +2728,7 @@ impl ITaskFolderCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2767,7 +2767,7 @@ impl ITaskHandler_Vtbl {
             let this = (*this).get_impl();
             match this.Stop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2849,7 +2849,7 @@ impl ITaskNamedValueCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppair = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppair, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2860,7 +2860,7 @@ impl ITaskNamedValueCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2871,7 +2871,7 @@ impl ITaskNamedValueCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&name), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppair = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppair, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2968,7 +2968,7 @@ impl ITaskScheduler_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetComputer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwszcomputer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwszcomputer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2979,7 +2979,7 @@ impl ITaskScheduler_Vtbl {
             let this = (*this).get_impl();
             match this.Enum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumworkitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumworkitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2990,7 +2990,7 @@ impl ITaskScheduler_Vtbl {
             let this = (*this).get_impl();
             match this.Activate(::core::mem::transmute(&pwszname), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3006,7 +3006,7 @@ impl ITaskScheduler_Vtbl {
             let this = (*this).get_impl();
             match this.NewWorkItem(::core::mem::transmute(&pwsztaskname), ::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3060,7 +3060,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolder(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfolder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfolder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3071,7 +3071,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.GetRunningTasks(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprunningtasks = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprunningtasks, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3082,7 +3082,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.NewTask(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdefinition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdefinition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3098,7 +3098,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.Connected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3109,7 +3109,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.TargetServer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3120,7 +3120,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectedUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puser = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puser, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3131,7 +3131,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectedDomain() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdomain = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdomain, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3142,7 +3142,7 @@ impl ITaskService_Vtbl {
             let this = (*this).get_impl();
             match this.HighestVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3378,7 +3378,7 @@ impl ITaskSettings_Vtbl {
             let this = (*this).get_impl();
             match this.IdleSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidlesettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidlesettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3414,7 +3414,7 @@ impl ITaskSettings_Vtbl {
             let this = (*this).get_impl();
             match this.NetworkSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnetworksettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnetworksettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3559,7 +3559,7 @@ impl ITaskSettings3_Vtbl {
             let this = (*this).get_impl();
             match this.MaintenanceSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmaintenancesettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmaintenancesettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3575,7 +3575,7 @@ impl ITaskSettings3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateMaintenanceSettings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmaintenancesettings = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmaintenancesettings, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3626,7 +3626,7 @@ impl ITaskTrigger_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrigger() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptrigger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptrigger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3637,7 +3637,7 @@ impl ITaskTrigger_Vtbl {
             let this = (*this).get_impl();
             match this.GetTriggerString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwsztrigger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwsztrigger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3670,7 +3670,7 @@ impl ITaskVariables_Vtbl {
             let this = (*this).get_impl();
             match this.GetInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinput = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinput, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3686,7 +3686,7 @@ impl ITaskVariables_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3774,7 +3774,7 @@ impl ITrigger_Vtbl {
             let this = (*this).get_impl();
             match this.Repetition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprepeat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprepeat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3870,7 +3870,7 @@ impl ITriggerCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptrigger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptrigger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3881,7 +3881,7 @@ impl ITriggerCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3892,7 +3892,7 @@ impl ITriggerCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptrigger = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptrigger, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/TransactionServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TransactionServer/impl.rs
@@ -15,7 +15,7 @@ impl ICatalog_Vtbl {
             let this = (*this).get_impl();
             match this.GetCollection(::core::mem::transmute(&bstrcollname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26,7 +26,7 @@ impl ICatalog_Vtbl {
             let this = (*this).get_impl();
             match this.Connect(::core::mem::transmute(&bstrconnectstring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcatalogcollection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcatalogcollection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
@@ -38,7 +38,7 @@ impl IAutomaticUpdates_Vtbl {
             let this = (*this).get_impl();
             match this.Settings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -49,7 +49,7 @@ impl IAutomaticUpdates_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -89,7 +89,7 @@ impl IAutomaticUpdates2_Vtbl {
             let this = (*this).get_impl();
             match this.Results() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -116,7 +116,7 @@ impl IAutomaticUpdatesResults_Vtbl {
             let this = (*this).get_impl();
             match this.LastSearchSuccessDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -127,7 +127,7 @@ impl IAutomaticUpdatesResults_Vtbl {
             let this = (*this).get_impl();
             match this.LastInstallationSuccessDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -166,7 +166,7 @@ impl IAutomaticUpdatesSettings_Vtbl {
             let this = (*this).get_impl();
             match this.NotificationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -182,7 +182,7 @@ impl IAutomaticUpdatesSettings_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -193,7 +193,7 @@ impl IAutomaticUpdatesSettings_Vtbl {
             let this = (*this).get_impl();
             match this.Required() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl IAutomaticUpdatesSettings_Vtbl {
             let this = (*this).get_impl();
             match this.ScheduledInstallationDay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -220,7 +220,7 @@ impl IAutomaticUpdatesSettings_Vtbl {
             let this = (*this).get_impl();
             match this.ScheduledInstallationTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -275,7 +275,7 @@ impl IAutomaticUpdatesSettings2_Vtbl {
             let this = (*this).get_impl();
             match this.IncludeRecommendedUpdates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -291,7 +291,7 @@ impl IAutomaticUpdatesSettings2_Vtbl {
             let this = (*this).get_impl();
             match this.CheckPermission(::core::mem::transmute_copy(&usertype), ::core::mem::transmute_copy(&permissiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *userhaspermission = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(userhaspermission, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -325,7 +325,7 @@ impl IAutomaticUpdatesSettings3_Vtbl {
             let this = (*this).get_impl();
             match this.NonAdministratorsElevated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -341,7 +341,7 @@ impl IAutomaticUpdatesSettings3_Vtbl {
             let this = (*this).get_impl();
             match this.FeaturedUpdatesEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -386,7 +386,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -397,7 +397,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.CategoryID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -408,7 +408,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Children() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -419,7 +419,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -430,7 +430,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Image() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -441,7 +441,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Order() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -452,7 +452,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -463,7 +463,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -474,7 +474,7 @@ impl ICategory_Vtbl {
             let this = (*this).get_impl();
             match this.Updates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -513,7 +513,7 @@ impl ICategoryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -524,7 +524,7 @@ impl ICategoryCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -535,7 +535,7 @@ impl ICategoryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -604,7 +604,7 @@ impl IDownloadJob_Vtbl {
             let this = (*this).get_impl();
             match this.AsyncState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -615,7 +615,7 @@ impl IDownloadJob_Vtbl {
             let this = (*this).get_impl();
             match this.IsCompleted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -626,7 +626,7 @@ impl IDownloadJob_Vtbl {
             let this = (*this).get_impl();
             match this.Updates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -642,7 +642,7 @@ impl IDownloadJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -689,7 +689,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUpdateBytesDownloaded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -700,7 +700,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUpdateBytesToDownload() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -711,7 +711,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUpdateIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -722,7 +722,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.PercentComplete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -733,7 +733,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.TotalBytesDownloaded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -744,7 +744,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.TotalBytesToDownload() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -755,7 +755,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdateResult(::core::mem::transmute_copy(&updateindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -766,7 +766,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUpdateDownloadPhase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -777,7 +777,7 @@ impl IDownloadProgress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUpdatePercentComplete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -834,7 +834,7 @@ impl IDownloadProgressChangedCallbackArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Progress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -862,7 +862,7 @@ impl IDownloadResult_Vtbl {
             let this = (*this).get_impl();
             match this.HResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -873,7 +873,7 @@ impl IDownloadResult_Vtbl {
             let this = (*this).get_impl();
             match this.ResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -884,7 +884,7 @@ impl IDownloadResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdateResult(::core::mem::transmute_copy(&updateindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -918,7 +918,7 @@ impl IImageInformation_Vtbl {
             let this = (*this).get_impl();
             match this.AltText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -929,7 +929,7 @@ impl IImageInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -940,7 +940,7 @@ impl IImageInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Source() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -951,7 +951,7 @@ impl IImageInformation_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1009,7 +1009,7 @@ impl IInstallationBehavior_Vtbl {
             let this = (*this).get_impl();
             match this.CanRequestUserInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1020,7 +1020,7 @@ impl IInstallationBehavior_Vtbl {
             let this = (*this).get_impl();
             match this.Impact() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1031,7 +1031,7 @@ impl IInstallationBehavior_Vtbl {
             let this = (*this).get_impl();
             match this.RebootBehavior() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1042,7 +1042,7 @@ impl IInstallationBehavior_Vtbl {
             let this = (*this).get_impl();
             match this.RequiresNetworkConnectivity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1112,7 +1112,7 @@ impl IInstallationJob_Vtbl {
             let this = (*this).get_impl();
             match this.AsyncState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1123,7 +1123,7 @@ impl IInstallationJob_Vtbl {
             let this = (*this).get_impl();
             match this.IsCompleted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1134,7 +1134,7 @@ impl IInstallationJob_Vtbl {
             let this = (*this).get_impl();
             match this.Updates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1150,7 +1150,7 @@ impl IInstallationJob_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1192,7 +1192,7 @@ impl IInstallationProgress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUpdateIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1203,7 +1203,7 @@ impl IInstallationProgress_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentUpdatePercentComplete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1214,7 +1214,7 @@ impl IInstallationProgress_Vtbl {
             let this = (*this).get_impl();
             match this.PercentComplete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1225,7 +1225,7 @@ impl IInstallationProgress_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdateResult(::core::mem::transmute_copy(&updateindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1277,7 +1277,7 @@ impl IInstallationProgressChangedCallbackArgs_Vtbl {
             let this = (*this).get_impl();
             match this.Progress() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1306,7 +1306,7 @@ impl IInstallationResult_Vtbl {
             let this = (*this).get_impl();
             match this.HResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1317,7 +1317,7 @@ impl IInstallationResult_Vtbl {
             let this = (*this).get_impl();
             match this.RebootRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1328,7 +1328,7 @@ impl IInstallationResult_Vtbl {
             let this = (*this).get_impl();
             match this.ResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1339,7 +1339,7 @@ impl IInstallationResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdateResult(::core::mem::transmute_copy(&updateindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1371,7 +1371,7 @@ impl IInvalidProductLicenseException_Vtbl {
             let this = (*this).get_impl();
             match this.Product() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1433,7 +1433,7 @@ impl ISearchJob_Vtbl {
             let this = (*this).get_impl();
             match this.AsyncState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1444,7 +1444,7 @@ impl ISearchJob_Vtbl {
             let this = (*this).get_impl();
             match this.IsCompleted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1489,7 +1489,7 @@ impl ISearchResult_Vtbl {
             let this = (*this).get_impl();
             match this.ResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1500,7 +1500,7 @@ impl ISearchResult_Vtbl {
             let this = (*this).get_impl();
             match this.RootCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1511,7 +1511,7 @@ impl ISearchResult_Vtbl {
             let this = (*this).get_impl();
             match this.Updates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1522,7 +1522,7 @@ impl ISearchResult_Vtbl {
             let this = (*this).get_impl();
             match this.Warnings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1563,7 +1563,7 @@ impl IStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1579,7 +1579,7 @@ impl IStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1590,7 +1590,7 @@ impl IStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1601,7 +1601,7 @@ impl IStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1612,7 +1612,7 @@ impl IStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1628,7 +1628,7 @@ impl IStringCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Copy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1677,7 +1677,7 @@ impl ISystemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.OemHardwareSupportLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1688,7 +1688,7 @@ impl ISystemInformation_Vtbl {
             let this = (*this).get_impl();
             match this.RebootRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1762,7 +1762,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1773,7 +1773,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.AutoSelectOnWebSites() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1784,7 +1784,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.BundledUpdates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1795,7 +1795,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.CanRequireSource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1806,7 +1806,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Categories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1817,7 +1817,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Deadline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1828,7 +1828,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DeltaCompressedContentAvailable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1839,7 +1839,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DeltaCompressedContentPreferred() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1850,7 +1850,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1861,7 +1861,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.EulaAccepted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1872,7 +1872,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.EulaText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1883,7 +1883,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.HandlerID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1894,7 +1894,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Identity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1905,7 +1905,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Image() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1916,7 +1916,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.InstallationBehavior() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1927,7 +1927,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.IsBeta() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1938,7 +1938,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.IsDownloaded() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1949,7 +1949,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.IsHidden() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1965,7 +1965,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.IsInstalled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1976,7 +1976,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.IsMandatory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1987,7 +1987,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.IsUninstallable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1998,7 +1998,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Languages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2009,7 +2009,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.LastDeploymentChangeTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2020,7 +2020,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.MaxDownloadSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2031,7 +2031,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.MinDownloadSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2042,7 +2042,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.MoreInfoUrls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2053,7 +2053,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.MsrcSeverity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2064,7 +2064,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.RecommendedCpuSpeed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2075,7 +2075,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.RecommendedHardDiskSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2086,7 +2086,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.RecommendedMemory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2097,7 +2097,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.ReleaseNotes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2108,7 +2108,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.SecurityBulletinIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2119,7 +2119,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.SupersededUpdateIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2130,7 +2130,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.SupportUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2141,7 +2141,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2152,7 +2152,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.UninstallationNotes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2163,7 +2163,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.UninstallationBehavior() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2174,7 +2174,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.UninstallationSteps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2185,7 +2185,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.KBArticleIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2201,7 +2201,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DeploymentAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2217,7 +2217,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2228,7 +2228,7 @@ impl IUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadContents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2304,7 +2304,7 @@ impl IUpdate2_Vtbl {
             let this = (*this).get_impl();
             match this.RebootRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2315,7 +2315,7 @@ impl IUpdate2_Vtbl {
             let this = (*this).get_impl();
             match this.IsPresent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2326,7 +2326,7 @@ impl IUpdate2_Vtbl {
             let this = (*this).get_impl();
             match this.CveIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2363,7 +2363,7 @@ impl IUpdate3_Vtbl {
             let this = (*this).get_impl();
             match this.BrowseOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2389,7 +2389,7 @@ impl IUpdate4_Vtbl {
             let this = (*this).get_impl();
             match this.PerUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2416,7 +2416,7 @@ impl IUpdate5_Vtbl {
             let this = (*this).get_impl();
             match this.AutoSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2427,7 +2427,7 @@ impl IUpdate5_Vtbl {
             let this = (*this).get_impl();
             match this.AutoDownload() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2466,7 +2466,7 @@ impl IUpdateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2482,7 +2482,7 @@ impl IUpdateCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2493,7 +2493,7 @@ impl IUpdateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2504,7 +2504,7 @@ impl IUpdateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2515,7 +2515,7 @@ impl IUpdateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2531,7 +2531,7 @@ impl IUpdateCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Copy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2579,7 +2579,7 @@ impl IUpdateDownloadContent_Vtbl {
             let this = (*this).get_impl();
             match this.DownloadUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2605,7 +2605,7 @@ impl IUpdateDownloadContent2_Vtbl {
             let this = (*this).get_impl();
             match this.IsDeltaCompressedContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2636,7 +2636,7 @@ impl IUpdateDownloadContentCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2647,7 +2647,7 @@ impl IUpdateDownloadContentCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2658,7 +2658,7 @@ impl IUpdateDownloadContentCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2690,7 +2690,7 @@ impl IUpdateDownloadResult_Vtbl {
             let this = (*this).get_impl();
             match this.HResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2701,7 +2701,7 @@ impl IUpdateDownloadResult_Vtbl {
             let this = (*this).get_impl();
             match this.ResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2741,7 +2741,7 @@ impl IUpdateDownloader_Vtbl {
             let this = (*this).get_impl();
             match this.ClientApplicationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2757,7 +2757,7 @@ impl IUpdateDownloader_Vtbl {
             let this = (*this).get_impl();
             match this.IsForced() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2773,7 +2773,7 @@ impl IUpdateDownloader_Vtbl {
             let this = (*this).get_impl();
             match this.Priority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2789,7 +2789,7 @@ impl IUpdateDownloader_Vtbl {
             let this = (*this).get_impl();
             match this.Updates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2805,7 +2805,7 @@ impl IUpdateDownloader_Vtbl {
             let this = (*this).get_impl();
             match this.BeginDownload(::core::mem::transmute(&onprogresschanged), ::core::mem::transmute(&oncompleted), ::core::mem::transmute(&state)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2816,7 +2816,7 @@ impl IUpdateDownloader_Vtbl {
             let this = (*this).get_impl();
             match this.Download() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2827,7 +2827,7 @@ impl IUpdateDownloader_Vtbl {
             let this = (*this).get_impl();
             match this.EndDownload(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2868,7 +2868,7 @@ impl IUpdateException_Vtbl {
             let this = (*this).get_impl();
             match this.Message() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2879,7 +2879,7 @@ impl IUpdateException_Vtbl {
             let this = (*this).get_impl();
             match this.HResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2890,7 +2890,7 @@ impl IUpdateException_Vtbl {
             let this = (*this).get_impl();
             match this.Context() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2923,7 +2923,7 @@ impl IUpdateExceptionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2934,7 +2934,7 @@ impl IUpdateExceptionCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2945,7 +2945,7 @@ impl IUpdateExceptionCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2989,7 +2989,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Operation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3000,7 +3000,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3011,7 +3011,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.HResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3022,7 +3022,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Date() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3033,7 +3033,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateIdentity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3044,7 +3044,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3055,7 +3055,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3066,7 +3066,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.UnmappedResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3077,7 +3077,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ClientApplicationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3088,7 +3088,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ServerSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3099,7 +3099,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3110,7 +3110,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.UninstallationSteps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3121,7 +3121,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.UninstallationNotes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3132,7 +3132,7 @@ impl IUpdateHistoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.SupportUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3174,7 +3174,7 @@ impl IUpdateHistoryEntry2_Vtbl {
             let this = (*this).get_impl();
             match this.Categories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3202,7 +3202,7 @@ impl IUpdateHistoryEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3213,7 +3213,7 @@ impl IUpdateHistoryEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3224,7 +3224,7 @@ impl IUpdateHistoryEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3256,7 +3256,7 @@ impl IUpdateIdentity_Vtbl {
             let this = (*this).get_impl();
             match this.RevisionNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3267,7 +3267,7 @@ impl IUpdateIdentity_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3299,7 +3299,7 @@ impl IUpdateInstallationResult_Vtbl {
             let this = (*this).get_impl();
             match this.HResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3310,7 +3310,7 @@ impl IUpdateInstallationResult_Vtbl {
             let this = (*this).get_impl();
             match this.RebootRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3321,7 +3321,7 @@ impl IUpdateInstallationResult_Vtbl {
             let this = (*this).get_impl();
             match this.ResultCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3372,7 +3372,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.ClientApplicationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3388,7 +3388,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.IsForced() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3404,7 +3404,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.ParentHwnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3425,7 +3425,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.ParentWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3436,7 +3436,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.Updates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3452,7 +3452,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.BeginInstall(::core::mem::transmute(&onprogresschanged), ::core::mem::transmute(&oncompleted), ::core::mem::transmute(&state)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3463,7 +3463,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.BeginUninstall(::core::mem::transmute(&onprogresschanged), ::core::mem::transmute(&oncompleted), ::core::mem::transmute(&state)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3474,7 +3474,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.EndInstall(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3485,7 +3485,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.EndUninstall(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3496,7 +3496,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.Install() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3507,7 +3507,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.RunWizard(::core::mem::transmute(&dialogtitle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3518,7 +3518,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.IsBusy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3529,7 +3529,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.Uninstall() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3540,7 +3540,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.AllowSourcePrompts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3556,7 +3556,7 @@ impl IUpdateInstaller_Vtbl {
             let this = (*this).get_impl();
             match this.RebootRequiredBeforeInstallation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3606,7 +3606,7 @@ impl IUpdateInstaller2_Vtbl {
             let this = (*this).get_impl();
             match this.ForceQuiet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3642,7 +3642,7 @@ impl IUpdateInstaller3_Vtbl {
             let this = (*this).get_impl();
             match this.AttemptCloseAppsIfNecessary() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3731,7 +3731,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.CanAutomaticallyUpgradeService() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3747,7 +3747,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.ClientApplicationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3763,7 +3763,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.IncludePotentiallySupersededUpdates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3779,7 +3779,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.ServerSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3795,7 +3795,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.BeginSearch(::core::mem::transmute(&criteria), ::core::mem::transmute(&oncompleted), ::core::mem::transmute(&state)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3806,7 +3806,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.EndSearch(::core::mem::transmute(&searchjob)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3817,7 +3817,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.EscapeString(::core::mem::transmute(&unescaped)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3828,7 +3828,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHistory(::core::mem::transmute_copy(&startindex), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3839,7 +3839,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.Search(::core::mem::transmute(&criteria)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3850,7 +3850,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.Online() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3866,7 +3866,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.GetTotalHistoryCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3877,7 +3877,7 @@ impl IUpdateSearcher_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3929,7 +3929,7 @@ impl IUpdateSearcher2_Vtbl {
             let this = (*this).get_impl();
             match this.IgnoreDownloadPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3965,7 +3965,7 @@ impl IUpdateSearcher3_Vtbl {
             let this = (*this).get_impl();
             match this.SearchScope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4012,7 +4012,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4023,7 +4023,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.ContentValidationCert() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4034,7 +4034,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.ExpirationDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4045,7 +4045,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.IsManaged() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4056,7 +4056,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.IsRegisteredWithAU() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4067,7 +4067,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.IssueDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4078,7 +4078,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.OffersWindowsUpdates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4089,7 +4089,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.RedirectUrls() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4100,7 +4100,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4111,7 +4111,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.IsScanPackageService() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4122,7 +4122,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.CanRegisterWithAU() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4133,7 +4133,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4144,7 +4144,7 @@ impl IUpdateService_Vtbl {
             let this = (*this).get_impl();
             match this.SetupPrefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4185,7 +4185,7 @@ impl IUpdateService2_Vtbl {
             let this = (*this).get_impl();
             match this.IsDefaultAUService() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4213,7 +4213,7 @@ impl IUpdateServiceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4224,7 +4224,7 @@ impl IUpdateServiceCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4235,7 +4235,7 @@ impl IUpdateServiceCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4272,7 +4272,7 @@ impl IUpdateServiceManager_Vtbl {
             let this = (*this).get_impl();
             match this.Services() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4283,7 +4283,7 @@ impl IUpdateServiceManager_Vtbl {
             let this = (*this).get_impl();
             match this.AddService(::core::mem::transmute(&serviceid), ::core::mem::transmute(&authorizationcabpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4309,7 +4309,7 @@ impl IUpdateServiceManager_Vtbl {
             let this = (*this).get_impl();
             match this.AddScanPackageService(::core::mem::transmute(&servicename), ::core::mem::transmute(&scanfilelocation), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservice = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservice, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4352,7 +4352,7 @@ impl IUpdateServiceManager2_Vtbl {
             let this = (*this).get_impl();
             match this.ClientApplicationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4368,7 +4368,7 @@ impl IUpdateServiceManager2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryServiceRegistration(::core::mem::transmute(&serviceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4379,7 +4379,7 @@ impl IUpdateServiceManager2_Vtbl {
             let this = (*this).get_impl();
             match this.AddService2(::core::mem::transmute(&serviceid), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&authorizationcabpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4414,7 +4414,7 @@ impl IUpdateServiceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.RegistrationState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4425,7 +4425,7 @@ impl IUpdateServiceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4436,7 +4436,7 @@ impl IUpdateServiceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.IsPendingRegistrationWithAU() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4447,7 +4447,7 @@ impl IUpdateServiceRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.Service() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4486,7 +4486,7 @@ impl IUpdateSession_Vtbl {
             let this = (*this).get_impl();
             match this.ClientApplicationID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4502,7 +4502,7 @@ impl IUpdateSession_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4513,7 +4513,7 @@ impl IUpdateSession_Vtbl {
             let this = (*this).get_impl();
             match this.WebProxy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4529,7 +4529,7 @@ impl IUpdateSession_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUpdateSearcher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4540,7 +4540,7 @@ impl IUpdateSession_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUpdateDownloader() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4551,7 +4551,7 @@ impl IUpdateSession_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUpdateInstaller() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4588,7 +4588,7 @@ impl IUpdateSession2_Vtbl {
             let this = (*this).get_impl();
             match this.UserLocale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4624,7 +4624,7 @@ impl IUpdateSession3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateUpdateServiceManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4635,7 +4635,7 @@ impl IUpdateSession3_Vtbl {
             let this = (*this).get_impl();
             match this.QueryHistory(::core::mem::transmute(&criteria), ::core::mem::transmute_copy(&startindex), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4678,7 +4678,7 @@ impl IWebProxy_Vtbl {
             let this = (*this).get_impl();
             match this.Address() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4694,7 +4694,7 @@ impl IWebProxy_Vtbl {
             let this = (*this).get_impl();
             match this.BypassList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4710,7 +4710,7 @@ impl IWebProxy_Vtbl {
             let this = (*this).get_impl();
             match this.BypassProxyOnLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4726,7 +4726,7 @@ impl IWebProxy_Vtbl {
             let this = (*this).get_impl();
             match this.ReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4737,7 +4737,7 @@ impl IWebProxy_Vtbl {
             let this = (*this).get_impl();
             match this.UserName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4768,7 +4768,7 @@ impl IWebProxy_Vtbl {
             let this = (*this).get_impl();
             match this.AutoDetect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4822,7 +4822,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DriverClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4833,7 +4833,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DriverHardwareID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4844,7 +4844,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DriverManufacturer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4855,7 +4855,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DriverModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4866,7 +4866,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DriverProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4877,7 +4877,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DriverVerDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4888,7 +4888,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceProblemNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4899,7 +4899,7 @@ impl IWindowsDriverUpdate_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4938,7 +4938,7 @@ impl IWindowsDriverUpdate2_Vtbl {
             let this = (*this).get_impl();
             match this.RebootRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4949,7 +4949,7 @@ impl IWindowsDriverUpdate2_Vtbl {
             let this = (*this).get_impl();
             match this.IsPresent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4960,7 +4960,7 @@ impl IWindowsDriverUpdate2_Vtbl {
             let this = (*this).get_impl();
             match this.CveIDs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4997,7 +4997,7 @@ impl IWindowsDriverUpdate3_Vtbl {
             let this = (*this).get_impl();
             match this.BrowseOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5024,7 +5024,7 @@ impl IWindowsDriverUpdate4_Vtbl {
             let this = (*this).get_impl();
             match this.WindowsDriverUpdateEntries() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5035,7 +5035,7 @@ impl IWindowsDriverUpdate4_Vtbl {
             let this = (*this).get_impl();
             match this.PerUser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5066,7 +5066,7 @@ impl IWindowsDriverUpdate5_Vtbl {
             let this = (*this).get_impl();
             match this.AutoSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5077,7 +5077,7 @@ impl IWindowsDriverUpdate5_Vtbl {
             let this = (*this).get_impl();
             match this.AutoDownload() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5114,7 +5114,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DriverClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5125,7 +5125,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DriverHardwareID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5136,7 +5136,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DriverManufacturer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5147,7 +5147,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DriverModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5158,7 +5158,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DriverProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5169,7 +5169,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DriverVerDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5180,7 +5180,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceProblemNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5191,7 +5191,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5229,7 +5229,7 @@ impl IWindowsDriverUpdateEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.get_Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5240,7 +5240,7 @@ impl IWindowsDriverUpdateEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5251,7 +5251,7 @@ impl IWindowsDriverUpdateEntryCollection_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5282,7 +5282,7 @@ impl IWindowsUpdateAgentInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo(::core::mem::transmute(&varinfoidentifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
@@ -12,7 +12,7 @@ impl IWaaSAssessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetOSUpdateAssessment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/impl.rs
@@ -29,7 +29,7 @@ impl IWindowsDevicesAllJoynBusAttachmentInterop_Vtbl {
             let this = (*this).get_impl();
             match this.Win32Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -87,7 +87,7 @@ impl IWindowsDevicesAllJoynBusObjectInterop_Vtbl {
             let this = (*this).get_impl();
             match this.Win32Handle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
@@ -12,7 +12,7 @@ impl ICompositionCapabilitiesInteropFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetForWindow(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -117,7 +117,7 @@ impl ICompositionGraphicsDeviceInterop_Vtbl {
             let this = (*this).get_impl();
             match this.GetRenderingDevice() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -153,7 +153,7 @@ impl ICompositorDesktopInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDesktopWindowTarget(::core::mem::transmute_copy(&hwndtarget), ::core::mem::transmute_copy(&istopmost)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl ICompositorInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCompositionSurfaceForHandle(::core::mem::transmute_copy(&swapchain)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl ICompositorInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCompositionSurfaceForSwapChain(::core::mem::transmute(&swapchain)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -212,7 +212,7 @@ impl ICompositorInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateGraphicsDevice(::core::mem::transmute(&renderingdevice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -243,7 +243,7 @@ impl IDesktopWindowTargetInterop_Vtbl {
             let this = (*this).get_impl();
             match this.Hwnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
@@ -13,7 +13,7 @@ impl IDisplayDeviceInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSharedHandle(::core::mem::transmute(&pobject), ::core::mem::transmute_copy(&psecurityattributes), ::core::mem::transmute_copy(&access), ::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24,7 +24,7 @@ impl IDisplayDeviceInterop_Vtbl {
             let this = (*this).get_impl();
             match this.OpenSharedHandle(::core::mem::transmute_copy(&nthandle), ::core::mem::transmute(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -55,7 +55,7 @@ impl IDisplayPathInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSourcePresentationHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -66,7 +66,7 @@ impl IDisplayPathInterop_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psourceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psourceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
@@ -13,7 +13,7 @@ impl IGeometrySource2DInterop_Vtbl {
             let this = (*this).get_impl();
             match this.GetGeometry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -24,7 +24,7 @@ impl IGeometrySource2DInterop_Vtbl {
             let this = (*this).get_impl();
             match this.TryGetGeometryUsingFactory(::core::mem::transmute(&factory)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -59,7 +59,7 @@ impl IGraphicsEffectD2D1Interop_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -75,7 +75,7 @@ impl IGraphicsEffectD2D1Interop_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -86,7 +86,7 @@ impl IGraphicsEffectD2D1Interop_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -97,7 +97,7 @@ impl IGraphicsEffectD2D1Interop_Vtbl {
             let this = (*this).get_impl();
             match this.GetSource(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *source = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(source, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -108,7 +108,7 @@ impl IGraphicsEffectD2D1Interop_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/impl.rs
@@ -16,7 +16,7 @@ impl IHolographicCameraInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDirect3D12BackBufferResource(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&ptexture2ddesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcreatedtexture2dresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcreatedtexture2dresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -27,7 +27,7 @@ impl IHolographicCameraInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDirect3D12HardwareProtectedBackBufferResource(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&ptexture2ddesc), ::core::mem::transmute(&pprotectedresourcesession)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcreatedtexture2dresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcreatedtexture2dresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -109,7 +109,7 @@ impl IHolographicQuadLayerInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDirect3D12ContentBufferResource(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&ptexture2ddesc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptexture2dresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptexture2dresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -120,7 +120,7 @@ impl IHolographicQuadLayerInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDirect3D12HardwareProtectedContentBufferResource(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&ptexture2ddesc), ::core::mem::transmute(&pprotectedresourcesession)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcreatedtexture2dresource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcreatedtexture2dresource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
@@ -12,7 +12,7 @@ impl IIsolatedEnvironmentInterop_Vtbl {
             let this = (*this).get_impl();
             match this.GetHostHwndInterop(::core::mem::transmute_copy(&containerhwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *hosthwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hosthwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
@@ -12,7 +12,7 @@ impl ILearningModelDeviceFactoryNative_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFromD3D12CommandQueue(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -41,7 +41,7 @@ impl ILearningModelOperatorProviderNative_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegistry() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoperatorregistry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoperatorregistry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -93,7 +93,7 @@ impl ITensorNative_Vtbl {
             let this = (*this).get_impl();
             match this.GetD3D12Resource() {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
@@ -44,7 +44,7 @@ impl IPrintWorkflowConfigurationNative_Vtbl {
             let this = (*this).get_impl();
             match this.PrinterQueue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -55,7 +55,7 @@ impl IPrintWorkflowConfigurationNative_Vtbl {
             let this = (*this).get_impl();
             match this.DriverProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -66,7 +66,7 @@ impl IPrintWorkflowConfigurationNative_Vtbl {
             let this = (*this).get_impl();
             match this.UserProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -103,7 +103,7 @@ impl IPrintWorkflowObjectModelSourceFileContentNative_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectFactory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl IPrintWorkflowXpsObjectModelTargetPackageNative_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentPackageTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
@@ -26,7 +26,7 @@ impl IRandomAccessStreamFileAccessMode_Vtbl {
             let this = (*this).get_impl();
             match this.GetMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fileaccessmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fileaccessmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -52,7 +52,7 @@ impl IStorageFolderHandleAccess_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute(&filename), ::core::mem::transmute_copy(&creationoptions), ::core::mem::transmute_copy(&accessoptions), ::core::mem::transmute_copy(&sharingoptions), ::core::mem::transmute_copy(&options), ::core::mem::transmute(&oplockbreakinghandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *interophandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interophandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -78,7 +78,7 @@ impl IStorageItemHandleAccess_Vtbl {
             let this = (*this).get_impl();
             match this.Create(::core::mem::transmute_copy(&accessoptions), ::core::mem::transmute_copy(&sharingoptions), ::core::mem::transmute_copy(&options), ::core::mem::transmute(&oplockbreakinghandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *interophandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(interophandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -119,7 +119,7 @@ impl IUnbufferedFileHandleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.OpenUnbufferedFileHandle(::core::mem::transmute(&oplockbreakcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *filehandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filehandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Xaml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Xaml/impl.rs
@@ -18,7 +18,7 @@ impl IDesktopWindowXamlSourceNative_Vtbl {
             let this = (*this).get_impl();
             match this.WindowHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -103,7 +103,7 @@ impl IReferenceTracker_Vtbl {
             let this = (*this).get_impl();
             match this.GetReferenceTrackerManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -180,7 +180,7 @@ impl IReferenceTrackerHost_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrackerTarget(::core::mem::transmute(&unknown)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -474,7 +474,7 @@ impl ITrackerOwner_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTrackerHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *returnvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(returnvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -531,7 +531,7 @@ impl IVirtualSurfaceImageSourceNative_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdateRectCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -547,7 +547,7 @@ impl IVirtualSurfaceImageSourceNative_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisibleBounds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bounds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bounds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
@@ -46,7 +46,7 @@ impl IActivationFactory_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *instance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(instance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -126,7 +126,7 @@ impl IBufferByteAccess_Vtbl {
             let this = (*this).get_impl();
             match this.Buffer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -168,7 +168,7 @@ impl ICastingController_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&eventhandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl ICastingSourceInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetController() {
                 ::core::result::Result::Ok(ok__) => {
-                    *controller = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(controller, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl ICastingSourceInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *props = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(props, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -306,7 +306,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
             let this = (*this).get_impl();
             match this.AppActivationClientAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -317,7 +317,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
             let this = (*this).get_impl();
             match this.ApplicationViewClientAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -328,7 +328,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
             let this = (*this).get_impl();
             match this.CoreApplicationViewClientAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -339,7 +339,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
             let this = (*this).get_impl();
             match this.HoloViewClientAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -350,7 +350,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
             let this = (*this).get_impl();
             match this.PositionerClientAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -361,7 +361,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
             let this = (*this).get_impl();
             match this.SystemNavigationClientAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -372,7 +372,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
             let this = (*this).get_impl();
             match this.TitleBarClientAdapter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -419,7 +419,7 @@ impl ICoreWindowComponentInterop_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewInstanceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *componentviewinstanceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(componentviewinstanceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -450,7 +450,7 @@ impl ICoreWindowInterop_Vtbl {
             let this = (*this).get_impl();
             match this.WindowHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -484,7 +484,7 @@ impl ICorrelationVectorInformation_Vtbl {
             let this = (*this).get_impl();
             match this.LastCorrelationVectorForThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -495,7 +495,7 @@ impl ICorrelationVectorInformation_Vtbl {
             let this = (*this).get_impl();
             match this.NextCorrelationVectorForThread() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -528,7 +528,7 @@ impl ICorrelationVectorSource_Vtbl {
             let this = (*this).get_impl();
             match this.CorrelationVector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -617,7 +617,7 @@ impl ILanguageExceptionErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguageException() {
                 ::core::result::Result::Ok(ok__) => {
-                    *languageexception = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(languageexception, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -642,7 +642,7 @@ impl ILanguageExceptionErrorInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousLanguageExceptionErrorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *previouslanguageexceptionerrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previouslanguageexceptionerrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -658,7 +658,7 @@ impl ILanguageExceptionErrorInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropagationContextHead() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propagatedlanguageexceptionerrorinfohead = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propagatedlanguageexceptionerrorinfohead, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -703,7 +703,7 @@ impl ILanguageExceptionTransform_Vtbl {
             let this = (*this).get_impl();
             match this.GetTransformedRestrictedErrorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *restrictederrorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(restrictederrorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -802,7 +802,7 @@ impl IRestrictedErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *reference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -931,7 +931,7 @@ impl IShareWindowCommandEventArgsInterop_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1149,7 +1149,7 @@ impl IWeakReferenceSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetWeakReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *weakreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(weakreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
@@ -29,7 +29,7 @@ impl ICameraUIControl_Vtbl {
             let this = (*this).get_impl();
             match this.Suspend() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbdeferralrequired = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbdeferralrequired, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -45,7 +45,7 @@ impl ICameraUIControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentViewType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pviewtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pviewtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -56,7 +56,7 @@ impl ICameraUIControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstractiveitempath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstractiveitempath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -67,7 +67,7 @@ impl ICameraUIControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppselecteditempaths = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppselecteditempaths, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -173,7 +173,7 @@ impl IContainerActivationHelper_Vtbl {
             let this = (*this).get_impl();
             match this.CanActivateClientVM() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -284,7 +284,7 @@ impl IEditionUpgradeHelper_Vtbl {
             let this = (*this).get_impl();
             match this.CanUpgrade() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isallowed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isallowed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl IEditionUpgradeHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetOsProductContentId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IEditionUpgradeHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetGenuineLocalStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *isgenuine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isgenuine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -349,7 +349,7 @@ impl IWindowsLockModeHelper_Vtbl {
             let this = (*this).get_impl();
             match this.GetSMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *issmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(issmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
@@ -60,7 +60,7 @@ impl IChangeConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationProviderConflictingChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -71,7 +71,7 @@ impl IChangeConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceProviderConflictingChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -82,7 +82,7 @@ impl IChangeConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationProviderConflictingData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -93,7 +93,7 @@ impl IChangeConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceProviderConflictingData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -275,7 +275,7 @@ impl ICombinedFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterInfo(::core::mem::transmute_copy(&dwfilterindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifilterinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifilterinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -319,7 +319,7 @@ impl IConstraintConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationProviderConflictingChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IConstraintConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceProviderConflictingChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -341,7 +341,7 @@ impl IConstraintConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationProviderOriginalChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pporiginalchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pporiginalchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -352,7 +352,7 @@ impl IConstraintConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationProviderConflictingData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -363,7 +363,7 @@ impl IConstraintConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceProviderConflictingData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconflictingdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconflictingdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -374,7 +374,7 @@ impl IConstraintConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationProviderOriginalData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pporiginaldata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pporiginaldata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -533,7 +533,7 @@ impl ICustomFilterInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pisyncfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pisyncfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -601,7 +601,7 @@ impl IEnumChangeUnitExceptions_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl IEnumClockVector_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -695,7 +695,7 @@ impl IEnumFeedClockVector_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -759,7 +759,7 @@ impl IEnumRangeExceptions_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -806,7 +806,7 @@ impl IEnumSingleItemExceptions_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -853,7 +853,7 @@ impl IEnumSyncChangeUnits_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -900,7 +900,7 @@ impl IEnumSyncChanges_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -950,7 +950,7 @@ impl IEnumSyncProviderConfigUIInfos_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1000,7 +1000,7 @@ impl IEnumSyncProviderInfos_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1099,7 +1099,7 @@ impl IFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilter(::core::mem::transmute_copy(&dwfilterkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppisyncfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppisyncfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1311,7 +1311,7 @@ impl ILoadChangeContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1414,7 +1414,7 @@ impl IRecoverableError_Vtbl {
             let this = (*this).get_impl();
             match this.GetChangeWithRecoverableError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchangewithrecoverableerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchangewithrecoverableerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1498,7 +1498,7 @@ impl IRegisteredSyncProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidinstanceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidinstanceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1767,7 +1767,7 @@ impl ISyncChange_Vtbl {
             let this = (*this).get_impl();
             match this.GetChangeUnits() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1778,7 +1778,7 @@ impl ISyncChange_Vtbl {
             let this = (*this).get_impl();
             match this.GetMadeWithKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmadewithknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmadewithknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1789,7 +1789,7 @@ impl ISyncChange_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1844,7 +1844,7 @@ impl ISyncChangeBatch_Vtbl {
             let this = (*this).get_impl();
             match this.AddLoggedConflict(::core::mem::transmute_copy(&pbownerreplicaid), ::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pchangeversion), ::core::mem::transmute_copy(&pcreationversion), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dwworkforchange), ::core::mem::transmute(&pconflictknowledge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchangebuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchangebuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1876,7 +1876,7 @@ impl ISyncChangeBatch2_Vtbl {
             let this = (*this).get_impl();
             match this.AddMergeTombstoneMetadataToGroup(::core::mem::transmute_copy(&pbownerreplicaid), ::core::mem::transmute_copy(&pbwinneritemid), ::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pchangeversion), ::core::mem::transmute_copy(&pcreationversion), ::core::mem::transmute_copy(&dwworkforchange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchangebuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchangebuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1887,7 +1887,7 @@ impl ISyncChangeBatch2_Vtbl {
             let this = (*this).get_impl();
             match this.AddMergeTombstoneLoggedConflict(::core::mem::transmute_copy(&pbownerreplicaid), ::core::mem::transmute_copy(&pbwinneritemid), ::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pchangeversion), ::core::mem::transmute_copy(&pcreationversion), ::core::mem::transmute_copy(&dwworkforchange), ::core::mem::transmute(&pconflictknowledge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchangebuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchangebuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1920,7 +1920,7 @@ impl ISyncChangeBatchAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfilterinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfilterinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1931,7 +1931,7 @@ impl ISyncChangeBatchAdvanced_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertFullEnumerationChangeBatchToRegularChangeBatch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchangebatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchangebatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1986,7 +1986,7 @@ impl ISyncChangeBatchBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetChangeEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2022,7 +2022,7 @@ impl ISyncChangeBatchBase_Vtbl {
             let this = (*this).get_impl();
             match this.AddItemMetadataToGroup(::core::mem::transmute_copy(&pbownerreplicaid), ::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pchangeversion), ::core::mem::transmute_copy(&pcreationversion), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dwworkforchange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchangebuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchangebuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2033,7 +2033,7 @@ impl ISyncChangeBatchBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2044,7 +2044,7 @@ impl ISyncChangeBatchBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrerequisiteKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprerequisteknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprerequisteknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2055,7 +2055,7 @@ impl ISyncChangeBatchBase_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceForgottenKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsourceforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsourceforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2141,7 +2141,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterKeyMap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifilterkeymap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifilterkeymap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2162,7 +2162,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredReplicaLearnedKnowledge(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2173,7 +2173,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedFilterForgottenKnowledge(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins), ::core::mem::transmute_copy(&dwfilterkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedfilterforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedfilterforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2184,7 +2184,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredReplicaLearnedForgottenKnowledge(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2195,7 +2195,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredReplicaLearnedForgottenKnowledgeAfterRecoveryComplete(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2206,7 +2206,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedFilterForgottenKnowledgeAfterRecoveryComplete(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins), ::core::mem::transmute_copy(&dwfilterkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedfilterforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedfilterforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2249,7 +2249,7 @@ impl ISyncChangeBatchWithPrerequisite_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedKnowledgeWithPrerequisite(::core::mem::transmute(&pdestinationknowledge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedwithprerequisiteknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedwithprerequisiteknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2260,7 +2260,7 @@ impl ISyncChangeBatchWithPrerequisite_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedForgottenKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2307,7 +2307,7 @@ impl ISyncChangeUnit_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2371,7 +2371,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilterForgottenKnowledge(::core::mem::transmute_copy(&dwfilterkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppifilterforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppifilterforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2382,7 +2382,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredReplicaLearnedKnowledge(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2393,7 +2393,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedFilterForgottenKnowledge(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins), ::core::mem::transmute_copy(&dwfilterkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedfilterforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedfilterforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2404,7 +2404,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredReplicaLearnedForgottenKnowledge(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2415,7 +2415,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFilteredReplicaLearnedForgottenKnowledgeAfterRecoveryComplete(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2426,7 +2426,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedFilterForgottenKnowledgeAfterRecoveryComplete(::core::mem::transmute(&pdestinationknowledge), ::core::mem::transmute(&pnewmoveins), ::core::mem::transmute_copy(&dwfilterkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedfilterforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedfilterforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2461,7 +2461,7 @@ impl ISyncChangeWithPrerequisite_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrerequisiteKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprerequisiteknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprerequisiteknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2472,7 +2472,7 @@ impl ISyncChangeWithPrerequisite_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedKnowledgeWithPrerequisite(::core::mem::transmute(&pdestinationknowledge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedknowledgewithprerequisite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedknowledgewithprerequisite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2519,7 +2519,7 @@ impl ISyncDataConverter_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertDataRetrieverFromProviderFormat(::core::mem::transmute(&punkdataretrieverin), ::core::mem::transmute(&penumsyncchanges)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdataout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdataout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2530,7 +2530,7 @@ impl ISyncDataConverter_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertDataRetrieverToProviderFormat(::core::mem::transmute(&punkdataretrieverin), ::core::mem::transmute(&penumsyncchanges)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdataout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdataout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2541,7 +2541,7 @@ impl ISyncDataConverter_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertDataFromProviderFormat(::core::mem::transmute(&pdatacontext), ::core::mem::transmute(&punkdatain)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdataout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdataout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2552,7 +2552,7 @@ impl ISyncDataConverter_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertDataToProviderFormat(::core::mem::transmute(&pdatacontext), ::core::mem::transmute(&punkdataout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdataout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdataout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2608,7 +2608,7 @@ impl ISyncFilterDeserializer_Vtbl {
             let this = (*this).get_impl();
             match this.DeserializeSyncFilter(::core::mem::transmute_copy(&pbsyncfilter), ::core::mem::transmute_copy(&dwcbsyncfilter)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppisyncfilter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppisyncfilter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2666,7 +2666,7 @@ impl ISyncFullEnumerationChange_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedKnowledgeAfterRecoveryComplete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2677,7 +2677,7 @@ impl ISyncFullEnumerationChange_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedForgottenKnowledge() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedforgottenknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedforgottenknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2709,7 +2709,7 @@ impl ISyncFullEnumerationChangeBatch_Vtbl {
             let this = (*this).get_impl();
             match this.GetLearnedKnowledgeAfterRecoveryComplete() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplearnedknowledgeafterrecoverycomplete = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplearnedknowledgeafterrecoverycomplete, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2750,7 +2750,7 @@ impl ISyncFullEnumerationChangeBatch2_Vtbl {
             let this = (*this).get_impl();
             match this.AddMergeTombstoneMetadataToGroup(::core::mem::transmute_copy(&pbownerreplicaid), ::core::mem::transmute_copy(&pbwinneritemid), ::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pchangeversion), ::core::mem::transmute_copy(&pcreationversion), ::core::mem::transmute_copy(&dwworkforchange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchangebuilder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchangebuilder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2832,7 +2832,7 @@ impl ISyncKnowledge_Vtbl {
             let this = (*this).get_impl();
             match this.GetReplicaKeyMap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreplicakeymap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreplicakeymap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2843,7 +2843,7 @@ impl ISyncKnowledge_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclonedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclonedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2859,7 +2859,7 @@ impl ISyncKnowledge_Vtbl {
             let this = (*this).get_impl();
             match this.MapRemoteToLocal(::core::mem::transmute(&premoteknowledge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppmappedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppmappedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2875,7 +2875,7 @@ impl ISyncKnowledge_Vtbl {
             let this = (*this).get_impl();
             match this.ProjectOntoItem(::core::mem::transmute_copy(&pbitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppknowledgeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppknowledgeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2886,7 +2886,7 @@ impl ISyncKnowledge_Vtbl {
             let this = (*this).get_impl();
             match this.ProjectOntoChangeUnit(::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pbchangeunitid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppknowledgeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppknowledgeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2897,7 +2897,7 @@ impl ISyncKnowledge_Vtbl {
             let this = (*this).get_impl();
             match this.ProjectOntoRange(::core::mem::transmute_copy(&psrngsyncrange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppknowledgeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppknowledgeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3017,7 +3017,7 @@ impl ISyncKnowledge2_Vtbl {
             let this = (*this).get_impl();
             match this.ProjectOntoColumnSet(::core::mem::transmute_copy(&ppcolumns), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiknowledgeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiknowledgeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3063,7 +3063,7 @@ impl ISyncKnowledge2_Vtbl {
             let this = (*this).get_impl();
             match this.ProjectOntoKnowledgeWithPrerequisite(::core::mem::transmute(&pprerequisiteknowledge), ::core::mem::transmute(&ptemplateknowledge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprojectedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprojectedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3074,7 +3074,7 @@ impl ISyncKnowledge2_Vtbl {
             let this = (*this).get_impl();
             match this.Complement(::core::mem::transmute(&psyncknowledge)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomplementedknowledge = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomplementedknowledge, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3090,7 +3090,7 @@ impl ISyncKnowledge2_Vtbl {
             let this = (*this).get_impl();
             match this.GetKnowledgeCookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppknowledgecookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppknowledgecookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3182,7 +3182,7 @@ impl ISyncProviderConfigUI_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegisteredProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconfiguiproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconfiguiproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3193,7 +3193,7 @@ impl ISyncProviderConfigUI_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAndRegisterNewSyncProvider(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute(&punkcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproviderinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproviderinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3230,7 +3230,7 @@ impl ISyncProviderConfigUIInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderConfigUI(::core::mem::transmute_copy(&dwclscontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncproviderconfigui = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncproviderconfigui, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3259,7 +3259,7 @@ impl ISyncProviderInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProvider(::core::mem::transmute_copy(&dwclscontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3303,7 +3303,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSyncProviderConfigUIRegistrationInstance(::core::mem::transmute_copy(&pconfiguiconfig)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconfiguiinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconfiguiinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3319,7 +3319,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateSyncProviderConfigUIs(::core::mem::transmute_copy(&pguidcontenttype), ::core::mem::transmute_copy(&dwsupportedarchitecture)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumsyncproviderconfiguiinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumsyncproviderconfiguiinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3330,7 +3330,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSyncProviderRegistrationInstance(::core::mem::transmute_copy(&pproviderconfiguration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproviderinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproviderinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3346,7 +3346,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderConfigUIInfoforProvider(::core::mem::transmute_copy(&pguidproviderinstanceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproviderconfiguiinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproviderconfiguiinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3357,7 +3357,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.EnumerateSyncProviders(::core::mem::transmute_copy(&pguidcontenttype), ::core::mem::transmute_copy(&dwstateflagstofiltermask), ::core::mem::transmute_copy(&dwstateflagstofilter), ::core::mem::transmute_copy(&refproviderclsid), ::core::mem::transmute_copy(&dwsupportedarchitecture)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumsyncproviderinfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumsyncproviderinfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3368,7 +3368,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderInfo(::core::mem::transmute_copy(&pguidinstanceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproviderinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproviderinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3379,7 +3379,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderFromInstanceId(::core::mem::transmute_copy(&pguidinstanceid), ::core::mem::transmute_copy(&dwclscontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3390,7 +3390,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderConfigUIInfo(::core::mem::transmute_copy(&pguidinstanceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconfiguiinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconfiguiinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3401,7 +3401,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderConfigUIFromInstanceId(::core::mem::transmute_copy(&pguidinstanceid), ::core::mem::transmute_copy(&dwclscontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconfigui = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconfigui, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3412,7 +3412,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderState(::core::mem::transmute_copy(&pguidinstanceid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstateflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstateflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3438,7 +3438,7 @@ impl ISyncProviderRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.GetChange(::core::mem::transmute_copy(&hevent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3480,7 +3480,7 @@ impl ISyncRegistrationChange_Vtbl {
             let this = (*this).get_impl();
             match this.GetEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psreevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psreevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3491,7 +3491,7 @@ impl ISyncRegistrationChange_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidinstanceid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidinstanceid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3518,7 +3518,7 @@ impl ISyncSessionExtendedErrorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncProviderWithError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproviderwitherror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproviderwitherror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3645,7 +3645,7 @@ impl ISynchronousDataRetriever_Vtbl {
             let this = (*this).get_impl();
             match this.LoadChangeData(::core::mem::transmute(&ploadchangecontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
@@ -28,7 +28,7 @@ impl IEnumWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -139,7 +139,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -155,7 +155,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Year() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iyear = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iyear, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -171,7 +171,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.YearSpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *byearspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(byearspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -187,7 +187,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Month() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imonth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imonth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -203,7 +203,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.MonthSpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bmonthspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bmonthspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -219,7 +219,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Day() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iday = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iday, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -235,7 +235,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.DaySpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bdayspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bdayspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -251,7 +251,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Hours() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ihours = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ihours, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -267,7 +267,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.HoursSpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bhoursspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bhoursspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -283,7 +283,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Minutes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iminutes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iminutes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -299,7 +299,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.MinutesSpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bminutesspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bminutesspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -315,7 +315,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Seconds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -331,7 +331,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.SecondsSpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bsecondsspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bsecondsspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -347,7 +347,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.Microseconds() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imicroseconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imicroseconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -363,7 +363,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.MicrosecondsSpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bmicrosecondsspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bmicrosecondsspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -379,7 +379,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.UTC() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iutc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iutc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -395,7 +395,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.UTCSpecified() {
                 ::core::result::Result::Ok(ok__) => {
-                    *butcspecified = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(butcspecified, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -411,7 +411,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.IsInterval() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bisinterval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bisinterval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -427,7 +427,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.GetVarDate(::core::mem::transmute_copy(&bislocal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dvardate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dvardate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -443,7 +443,7 @@ impl ISWbemDateTime_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileTime(::core::mem::transmute_copy(&bislocal)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strfiletime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strfiletime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -517,7 +517,7 @@ impl ISWbemEventSource_Vtbl {
             let this = (*this).get_impl();
             match this.NextEvent(::core::mem::transmute_copy(&itimeoutms)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -528,7 +528,7 @@ impl ISWbemEventSource_Vtbl {
             let this = (*this).get_impl();
             match this.Security_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -572,7 +572,7 @@ impl ISWbemLocator_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectServer(::core::mem::transmute(&strserver), ::core::mem::transmute(&strnamespace), ::core::mem::transmute(&struser), ::core::mem::transmute(&strpassword), ::core::mem::transmute(&strlocale), ::core::mem::transmute(&strauthority), ::core::mem::transmute_copy(&isecurityflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemservices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemservices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -583,7 +583,7 @@ impl ISWbemLocator_Vtbl {
             let this = (*this).get_impl();
             match this.Security_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -617,7 +617,7 @@ impl ISWbemMethod_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -628,7 +628,7 @@ impl ISWbemMethod_Vtbl {
             let this = (*this).get_impl();
             match this.Origin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strorigin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strorigin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -639,7 +639,7 @@ impl ISWbemMethod_Vtbl {
             let this = (*this).get_impl();
             match this.InParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbeminparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbeminparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -650,7 +650,7 @@ impl ISWbemMethod_Vtbl {
             let this = (*this).get_impl();
             match this.OutParameters() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemoutparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemoutparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -661,7 +661,7 @@ impl ISWbemMethod_Vtbl {
             let this = (*this).get_impl();
             match this.Qualifiers_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemqualifierset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemqualifierset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -696,7 +696,7 @@ impl ISWbemMethodSet_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -707,7 +707,7 @@ impl ISWbemMethodSet_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&strname), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemmethod = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemmethod, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -718,7 +718,7 @@ impl ISWbemMethodSet_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -751,7 +751,7 @@ impl ISWbemNamedValue_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -767,7 +767,7 @@ impl ISWbemNamedValue_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -804,7 +804,7 @@ impl ISWbemNamedValueSet_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -815,7 +815,7 @@ impl ISWbemNamedValueSet_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&strname), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemnamedvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemnamedvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -826,7 +826,7 @@ impl ISWbemNamedValueSet_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -837,7 +837,7 @@ impl ISWbemNamedValueSet_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&strname), ::core::mem::transmute_copy(&varvalue), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemnamedvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemnamedvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -853,7 +853,7 @@ impl ISWbemNamedValueSet_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemnamedvalueset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemnamedvalueset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -917,7 +917,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Put_(::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -943,7 +943,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Instances_(::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -959,7 +959,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Subclasses_(::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -988,7 +988,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Associators_(::core::mem::transmute(&strassocclass), ::core::mem::transmute(&strresultclass), ::core::mem::transmute(&strresultrole), ::core::mem::transmute(&strrole), ::core::mem::transmute_copy(&bclassesonly), ::core::mem::transmute_copy(&bschemaonly), ::core::mem::transmute(&strrequiredassocqualifier), ::core::mem::transmute(&strrequiredqualifier), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1032,7 +1032,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.References_(::core::mem::transmute(&strresultclass), ::core::mem::transmute(&strrole), ::core::mem::transmute_copy(&bclassesonly), ::core::mem::transmute_copy(&bschemaonly), ::core::mem::transmute(&strrequiredqualifier), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1048,7 +1048,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.ExecMethod_(::core::mem::transmute(&strmethodname), ::core::mem::transmute(&objwbeminparameters), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemoutparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemoutparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1064,7 +1064,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Clone_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1075,7 +1075,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectText_(::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strobjecttext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strobjecttext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1086,7 +1086,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.SpawnDerivedClass_(::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1097,7 +1097,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.SpawnInstance_(::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1108,7 +1108,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.CompareTo_(::core::mem::transmute(&objwbemobject), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1119,7 +1119,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Qualifiers_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemqualifierset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemqualifierset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1130,7 +1130,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Properties_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbempropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbempropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1141,7 +1141,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Methods_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemmethodset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemmethodset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1152,7 +1152,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Derivation_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strclassnamearray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strclassnamearray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1163,7 +1163,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Path_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1174,7 +1174,7 @@ impl ISWbemObject_Vtbl {
             let this = (*this).get_impl();
             match this.Security_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1235,7 +1235,7 @@ impl ISWbemObjectEx_Vtbl {
             let this = (*this).get_impl();
             match this.SystemProperties_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbempropertyset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbempropertyset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1246,7 +1246,7 @@ impl ISWbemObjectEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetText_(::core::mem::transmute_copy(&iobjecttextformat), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1305,7 +1305,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1321,7 +1321,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.RelPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strrelpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strrelpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1337,7 +1337,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Server() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strserver = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strserver, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1353,7 +1353,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Namespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1369,7 +1369,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.ParentNamespace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strparentnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strparentnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1380,7 +1380,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1396,7 +1396,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Class() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1412,7 +1412,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.IsClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bisclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bisclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1428,7 +1428,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.IsSingleton() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bissingleton = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bissingleton, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1444,7 +1444,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Keys() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemnamedvalueset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemnamedvalueset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1455,7 +1455,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Security_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1466,7 +1466,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Locale() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strlocale = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strlocale, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1482,7 +1482,7 @@ impl ISWbemObjectPath_Vtbl {
             let this = (*this).get_impl();
             match this.Authority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strauthority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strauthority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1542,7 +1542,7 @@ impl ISWbemObjectSet_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1553,7 +1553,7 @@ impl ISWbemObjectSet_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&strobjectpath), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1564,7 +1564,7 @@ impl ISWbemObjectSet_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1575,7 +1575,7 @@ impl ISWbemObjectSet_Vtbl {
             let this = (*this).get_impl();
             match this.Security_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1586,7 +1586,7 @@ impl ISWbemObjectSet_Vtbl {
             let this = (*this).get_impl();
             match this.ItemIndex(::core::mem::transmute_copy(&lindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1623,7 +1623,7 @@ impl ISWbemPrivilege_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bisenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bisenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1639,7 +1639,7 @@ impl ISWbemPrivilege_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1650,7 +1650,7 @@ impl ISWbemPrivilege_Vtbl {
             let this = (*this).get_impl();
             match this.DisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strdisplayname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strdisplayname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1661,7 +1661,7 @@ impl ISWbemPrivilege_Vtbl {
             let this = (*this).get_impl();
             match this.Identifier() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iprivilege = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iprivilege, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1700,7 +1700,7 @@ impl ISWbemPrivilegeSet_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1711,7 +1711,7 @@ impl ISWbemPrivilegeSet_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&iprivilege)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemprivilege = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemprivilege, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1722,7 +1722,7 @@ impl ISWbemPrivilegeSet_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1733,7 +1733,7 @@ impl ISWbemPrivilegeSet_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute_copy(&iprivilege), ::core::mem::transmute_copy(&bisenabled)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemprivilege = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemprivilege, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1754,7 +1754,7 @@ impl ISWbemPrivilegeSet_Vtbl {
             let this = (*this).get_impl();
             match this.AddAsString(::core::mem::transmute(&strprivilege), ::core::mem::transmute_copy(&bisenabled)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemprivilege = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemprivilege, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1796,7 +1796,7 @@ impl ISWbemProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1812,7 +1812,7 @@ impl ISWbemProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1823,7 +1823,7 @@ impl ISWbemProperty_Vtbl {
             let this = (*this).get_impl();
             match this.IsLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bislocal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bislocal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1834,7 +1834,7 @@ impl ISWbemProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Origin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strorigin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strorigin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1845,7 +1845,7 @@ impl ISWbemProperty_Vtbl {
             let this = (*this).get_impl();
             match this.CIMType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icimtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icimtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1856,7 +1856,7 @@ impl ISWbemProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Qualifiers_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemqualifierset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemqualifierset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1867,7 +1867,7 @@ impl ISWbemProperty_Vtbl {
             let this = (*this).get_impl();
             match this.IsArray() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bisarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bisarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1907,7 +1907,7 @@ impl ISWbemPropertySet_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1918,7 +1918,7 @@ impl ISWbemPropertySet_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&strname), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1929,7 +1929,7 @@ impl ISWbemPropertySet_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1940,7 +1940,7 @@ impl ISWbemPropertySet_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&strname), ::core::mem::transmute_copy(&icimtype), ::core::mem::transmute_copy(&bisarray), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1988,7 +1988,7 @@ impl ISWbemQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *varvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(varvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2004,7 +2004,7 @@ impl ISWbemQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2015,7 +2015,7 @@ impl ISWbemQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.IsLocal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bislocal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bislocal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2026,7 +2026,7 @@ impl ISWbemQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.PropagatesToSubclass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bpropagatestosubclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bpropagatestosubclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2042,7 +2042,7 @@ impl ISWbemQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.PropagatesToInstance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bpropagatestoinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bpropagatestoinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2058,7 +2058,7 @@ impl ISWbemQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.IsOverridable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bisoverridable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bisoverridable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2074,7 +2074,7 @@ impl ISWbemQualifier_Vtbl {
             let this = (*this).get_impl();
             match this.IsAmended() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bisamended = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bisamended, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2117,7 +2117,7 @@ impl ISWbemQualifierSet_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2128,7 +2128,7 @@ impl ISWbemQualifierSet_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&name), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemqualifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemqualifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2139,7 +2139,7 @@ impl ISWbemQualifierSet_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2150,7 +2150,7 @@ impl ISWbemQualifierSet_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&strname), ::core::mem::transmute_copy(&varval), ::core::mem::transmute_copy(&bpropagatestosubclass), ::core::mem::transmute_copy(&bpropagatestoinstance), ::core::mem::transmute_copy(&bisoverridable), ::core::mem::transmute_copy(&iflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemqualifier = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemqualifier, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2193,7 +2193,7 @@ impl ISWbemRefreshableItem_Vtbl {
             let this = (*this).get_impl();
             match this.Index() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2204,7 +2204,7 @@ impl ISWbemRefreshableItem_Vtbl {
             let this = (*this).get_impl();
             match this.Refresher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemrefresher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemrefresher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2215,7 +2215,7 @@ impl ISWbemRefreshableItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bisset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bisset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2226,7 +2226,7 @@ impl ISWbemRefreshableItem_Vtbl {
             let this = (*this).get_impl();
             match this.Object() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2237,7 +2237,7 @@ impl ISWbemRefreshableItem_Vtbl {
             let this = (*this).get_impl();
             match this.ObjectSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2285,7 +2285,7 @@ impl ISWbemRefresher_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *punk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(punk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2296,7 +2296,7 @@ impl ISWbemRefresher_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&iindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemrefreshableitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemrefreshableitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2307,7 +2307,7 @@ impl ISWbemRefresher_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *icount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(icount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2318,7 +2318,7 @@ impl ISWbemRefresher_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&objwbemservices), ::core::mem::transmute(&bsinstancepath), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemrefreshableitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemrefreshableitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2329,7 +2329,7 @@ impl ISWbemRefresher_Vtbl {
             let this = (*this).get_impl();
             match this.AddEnum(::core::mem::transmute(&objwbemservices), ::core::mem::transmute(&bsclassname), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemrefreshableitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemrefreshableitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2350,7 +2350,7 @@ impl ISWbemRefresher_Vtbl {
             let this = (*this).get_impl();
             match this.AutoReconnect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2402,7 +2402,7 @@ impl ISWbemSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.ImpersonationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iimpersonationlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iimpersonationlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2418,7 +2418,7 @@ impl ISWbemSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.AuthenticationLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *iauthenticationlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(iauthenticationlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2434,7 +2434,7 @@ impl ISWbemSecurity_Vtbl {
             let this = (*this).get_impl();
             match this.Privileges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemprivilegeset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemprivilegeset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2485,7 +2485,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.Get(::core::mem::transmute(&strobjectpath), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2511,7 +2511,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.InstancesOf(::core::mem::transmute(&strclass), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2527,7 +2527,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.SubclassesOf(::core::mem::transmute(&strsuperclass), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2543,7 +2543,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.ExecQuery(::core::mem::transmute(&strquery), ::core::mem::transmute(&strquerylanguage), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2573,7 +2573,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.AssociatorsOf(::core::mem::transmute(&strobjectpath), ::core::mem::transmute(&strassocclass), ::core::mem::transmute(&strresultclass), ::core::mem::transmute(&strresultrole), ::core::mem::transmute(&strrole), ::core::mem::transmute_copy(&bclassesonly), ::core::mem::transmute_copy(&bschemaonly), ::core::mem::transmute(&strrequiredassocqualifier), ::core::mem::transmute(&strrequiredqualifier), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2619,7 +2619,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.ReferencesTo(::core::mem::transmute(&strobjectpath), ::core::mem::transmute(&strresultclass), ::core::mem::transmute(&strrole), ::core::mem::transmute_copy(&bclassesonly), ::core::mem::transmute_copy(&bschemaonly), ::core::mem::transmute(&strrequiredqualifier), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2635,7 +2635,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.ExecNotificationQuery(::core::mem::transmute(&strquery), ::core::mem::transmute(&strquerylanguage), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemeventsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemeventsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2651,7 +2651,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.ExecMethod(::core::mem::transmute(&strobjectpath), ::core::mem::transmute(&strmethodname), ::core::mem::transmute(&objwbeminparameters), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemoutparameters = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemoutparameters, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2667,7 +2667,7 @@ impl ISWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.Security_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemsecurity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemsecurity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2715,7 +2715,7 @@ impl ISWbemServicesEx_Vtbl {
             let this = (*this).get_impl();
             match this.Put(::core::mem::transmute(&objwbemobject), ::core::mem::transmute_copy(&iflags), ::core::mem::transmute(&objwbemnamedvalueset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwbemobjectpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwbemobjectpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2776,7 +2776,7 @@ impl IUnsecuredApartment_Vtbl {
             let this = (*this).get_impl();
             match this.CreateObjectStub(::core::mem::transmute(&pobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2804,7 +2804,7 @@ impl IWMIExtension_Vtbl {
             let this = (*this).get_impl();
             match this.WMIObjectPath() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strwmiobjectpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strwmiobjectpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2815,7 +2815,7 @@ impl IWMIExtension_Vtbl {
             let this = (*this).get_impl();
             match this.GetWMIObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwmiobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwmiobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2826,7 +2826,7 @@ impl IWMIExtension_Vtbl {
             let this = (*this).get_impl();
             match this.GetWMIServices() {
                 ::core::result::Result::Ok(ok__) => {
-                    *objwmiservices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(objwmiservices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2931,7 +2931,7 @@ impl IWbemCallResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetResultObject(::core::mem::transmute_copy(&ltimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresultobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresultobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2942,7 +2942,7 @@ impl IWbemCallResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetResultString(::core::mem::transmute_copy(&ltimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrresultstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrresultstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2953,7 +2953,7 @@ impl IWbemCallResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetResultServices(::core::mem::transmute_copy(&ltimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppservices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppservices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2964,7 +2964,7 @@ impl IWbemCallResult_Vtbl {
             let this = (*this).get_impl();
             match this.GetCallStatus(::core::mem::transmute_copy(&ltimeout)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3019,7 +3019,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetQualifierSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqualset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqualset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3045,7 +3045,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetNames(::core::mem::transmute(&wszqualifiername), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&pqualifierval)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3071,7 +3071,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyQualifierSet(::core::mem::transmute(&wszproperty)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqualset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqualset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3082,7 +3082,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcopy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcopy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3093,7 +3093,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectText(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrobjecttext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrobjecttext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3104,7 +3104,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.SpawnDerivedClass(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3115,7 +3115,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.SpawnInstance(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3131,7 +3131,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyOrigin(::core::mem::transmute(&wszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrclassname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrclassname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3177,7 +3177,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetMethodQualifierSet(::core::mem::transmute(&wszmethod)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppqualset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppqualset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3188,7 +3188,7 @@ impl IWbemClassObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetMethodOrigin(::core::mem::transmute(&wszmethodname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstrclassname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstrclassname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3291,7 +3291,7 @@ impl IWbemClientTransport_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectServer(::core::mem::transmute(&straddresstype), ::core::mem::transmute_copy(&dwbinaryaddresslength), ::core::mem::transmute_copy(&abbinaryaddress), ::core::mem::transmute(&strnetworkresource), ::core::mem::transmute(&struser), ::core::mem::transmute(&strpassword), ::core::mem::transmute(&strlocale), ::core::mem::transmute_copy(&lsecurityflags), ::core::mem::transmute(&strauthority), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3431,7 +3431,7 @@ impl IWbemContext_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnewcopy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnewcopy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3442,7 +3442,7 @@ impl IWbemContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetNames(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3473,7 +3473,7 @@ impl IWbemContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute(&wszname), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3518,7 +3518,7 @@ impl IWbemDecoupledBasicEventProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSink(::core::mem::transmute_copy(&a_flags), ::core::mem::transmute(&a_context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *a_sink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(a_sink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3529,7 +3529,7 @@ impl IWbemDecoupledBasicEventProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetService(::core::mem::transmute_copy(&a_flags), ::core::mem::transmute(&a_context)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *a_service = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(a_service, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3583,7 +3583,7 @@ impl IWbemEventConsumerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindConsumer(::core::mem::transmute(&plogicalconsumer)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconsumer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconsumer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3683,7 +3683,7 @@ impl IWbemEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetRestrictedSink(::core::mem::transmute_copy(&lnumqueries), ::core::mem::transmute_copy(&awszqueries), ::core::mem::transmute(&pcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3768,7 +3768,7 @@ impl IWbemHiPerfProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRefresher(::core::mem::transmute(&pnamespace), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprefresher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprefresher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3789,7 +3789,7 @@ impl IWbemHiPerfProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRefreshableEnum(::core::mem::transmute(&pnamespace), ::core::mem::transmute(&wszclass), ::core::mem::transmute(&prefresher), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pcontext), ::core::mem::transmute(&phiperfenum)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3828,7 +3828,7 @@ impl IWbemLevel1Login_Vtbl {
             let this = (*this).get_impl();
             match this.EstablishPosition(::core::mem::transmute(&wszlocalelist), ::core::mem::transmute_copy(&dwnumlocales)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *reserved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(reserved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3839,7 +3839,7 @@ impl IWbemLevel1Login_Vtbl {
             let this = (*this).get_impl();
             match this.RequestChallenge(::core::mem::transmute(&wsznetworkresource), ::core::mem::transmute(&wszuser)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *nonce = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(nonce, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3850,7 +3850,7 @@ impl IWbemLevel1Login_Vtbl {
             let this = (*this).get_impl();
             match this.WBEMLogin(::core::mem::transmute(&wszpreferredlocale), ::core::mem::transmute_copy(&accesstoken), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3861,7 +3861,7 @@ impl IWbemLevel1Login_Vtbl {
             let this = (*this).get_impl();
             match this.NTLMLogin(::core::mem::transmute(&wsznetworkresource), ::core::mem::transmute(&wszpreferredlocale), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3893,7 +3893,7 @@ impl IWbemLocator_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectServer(::core::mem::transmute(&strnetworkresource), ::core::mem::transmute(&struser), ::core::mem::transmute(&strpassword), ::core::mem::transmute(&strlocale), ::core::mem::transmute_copy(&lsecurityflags), ::core::mem::transmute(&strauthority), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppnamespace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppnamespace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3943,7 +3943,7 @@ impl IWbemObjectAccess_Vtbl {
             let this = (*this).get_impl();
             match this.ReadDWORD(::core::mem::transmute_copy(&lhandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3959,7 +3959,7 @@ impl IWbemObjectAccess_Vtbl {
             let this = (*this).get_impl();
             match this.ReadQWORD(::core::mem::transmute_copy(&lhandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pqw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pqw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4056,7 +4056,7 @@ impl IWbemObjectSinkEx_Vtbl {
             let this = (*this).get_impl();
             match this.WriteError(::core::mem::transmute(&pobjerror)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pureturned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pureturned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4067,7 +4067,7 @@ impl IWbemObjectSinkEx_Vtbl {
             let this = (*this).get_impl();
             match this.PromptUser(::core::mem::transmute(&strmessage), ::core::mem::transmute_copy(&uprompttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pureturned = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pureturned, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4111,7 +4111,7 @@ impl IWbemObjectTextSrc_Vtbl {
             let this = (*this).get_impl();
             match this.GetText(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pobj), ::core::mem::transmute_copy(&uobjtextformat), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4122,7 +4122,7 @@ impl IWbemObjectTextSrc_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFromText(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&strtext), ::core::mem::transmute_copy(&uobjtextformat), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnewobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnewobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4187,7 +4187,7 @@ impl IWbemPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo(::core::mem::transmute_copy(&urequestedinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4208,7 +4208,7 @@ impl IWbemPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamespaceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4239,7 +4239,7 @@ impl IWbemPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetScopeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4290,7 +4290,7 @@ impl IWbemPath_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4383,7 +4383,7 @@ impl IWbemPathKeyList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pukeycount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pukeycount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4429,7 +4429,7 @@ impl IWbemPathKeyList_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo(::core::mem::transmute_copy(&urequestedinfo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puresponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puresponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4473,7 +4473,7 @@ impl IWbemPropertyProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&strlocale), ::core::mem::transmute(&strclassmapping), ::core::mem::transmute(&strinstmapping), ::core::mem::transmute(&strpropmapping)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4580,7 +4580,7 @@ impl IWbemQualifierSet_Vtbl {
             let this = (*this).get_impl();
             match this.GetNames(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnames = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnames, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4741,7 +4741,7 @@ impl IWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.QueryObjectSink(::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppresponsehandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppresponsehandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4782,7 +4782,7 @@ impl IWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClassEnum(::core::mem::transmute(&strsuperclass), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4818,7 +4818,7 @@ impl IWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstanceEnum(::core::mem::transmute(&strfilter), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4834,7 +4834,7 @@ impl IWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.ExecQuery(::core::mem::transmute(&strquerylanguage), ::core::mem::transmute(&strquery), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4850,7 +4850,7 @@ impl IWbemServices_Vtbl {
             let this = (*this).get_impl();
             match this.ExecNotificationQuery(::core::mem::transmute(&strquerylanguage), ::core::mem::transmute(&strquery), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4934,7 +4934,7 @@ impl IWbemStatusCodeText_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorCodeText(::core::mem::transmute_copy(&hres), ::core::mem::transmute_copy(&localeid), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *messagetext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(messagetext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4945,7 +4945,7 @@ impl IWbemStatusCodeText_Vtbl {
             let this = (*this).get_impl();
             match this.GetFacilityCodeText(::core::mem::transmute_copy(&hres), ::core::mem::transmute_copy(&localeid), ::core::mem::transmute_copy(&lflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *messagetext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(messagetext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5006,7 +5006,7 @@ impl IWbemUnsecuredApartment_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSinkStub(::core::mem::transmute(&psink), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&wszreserved)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstub = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstub, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
@@ -190,7 +190,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.accParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdispparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdispparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -201,7 +201,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.accChildCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcountchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcountchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -212,7 +212,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accChild(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdispchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdispchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -223,7 +223,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accName(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accValue(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accDescription(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -256,7 +256,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accRole(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -267,7 +267,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accState(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -278,7 +278,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accHelp(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszhelp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszhelp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -294,7 +294,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accKeyboardShortcut(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszkeyboardshortcut = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszkeyboardshortcut, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -305,7 +305,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.accFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.accSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -327,7 +327,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.get_accDefaultAction(::core::mem::transmute(&varchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdefaultaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdefaultaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -348,7 +348,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.accNavigate(::core::mem::transmute_copy(&navdir), ::core::mem::transmute(&varstart)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarendupat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarendupat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -359,7 +359,7 @@ impl IAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.accHitTest(::core::mem::transmute_copy(&xleft), ::core::mem::transmute_copy(&ytop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarchild = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarchild, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -426,7 +426,7 @@ impl IAccessibleEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectForChild(::core::mem::transmute_copy(&idchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -442,7 +442,7 @@ impl IAccessibleEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetRuntimeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -453,7 +453,7 @@ impl IAccessibleEx_Vtbl {
             let this = (*this).get_impl();
             match this.ConvertReturnedElement(::core::mem::transmute(&pin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppretvalout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppretvalout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -485,7 +485,7 @@ impl IAccessibleHandler_Vtbl {
             let this = (*this).get_impl();
             match this.AccessibleObjectFromID(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&lobjectid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piaccessible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piaccessible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -512,7 +512,7 @@ impl IAccessibleHostingElementProviders_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbeddedFragmentRoots() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -523,7 +523,7 @@ impl IAccessibleHostingElementProviders_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectIdForProvider(::core::mem::transmute(&pprovider)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pidobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pidobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IAccessibleWindowlessSite_Vtbl {
             let this = (*this).get_impl();
             match this.AcquireObjectIdRange(::core::mem::transmute_copy(&rangesize), ::core::mem::transmute(&prangeowner)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prangebase = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prangebase, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -572,7 +572,7 @@ impl IAccessibleWindowlessSite_Vtbl {
             let this = (*this).get_impl();
             match this.QueryObjectIdRanges(::core::mem::transmute(&prangesowner)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psaranges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psaranges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -583,7 +583,7 @@ impl IAccessibleWindowlessSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentAccessible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -619,7 +619,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.AnnotationTypeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -630,7 +630,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.AnnotationTypeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -641,7 +641,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Author() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -652,7 +652,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -663,7 +663,7 @@ impl IAnnotationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Target() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -693,7 +693,7 @@ impl ICustomNavigationProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Navigate(::core::mem::transmute_copy(&direction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -722,7 +722,7 @@ impl IDockProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DockPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -755,7 +755,7 @@ impl IDragProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsGrabbed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -766,7 +766,7 @@ impl IDragProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DropEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -777,7 +777,7 @@ impl IDragProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DropEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -788,7 +788,7 @@ impl IDragProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetGrabbedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -821,7 +821,7 @@ impl IDropTargetProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DropTargetEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -832,7 +832,7 @@ impl IDropTargetProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DropTargetEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -871,7 +871,7 @@ impl IExpandCollapseProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ExpandCollapseState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -903,7 +903,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Row() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -914,7 +914,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Column() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -925,7 +925,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RowSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -936,7 +936,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ColumnSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -947,7 +947,7 @@ impl IGridItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ContainingGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -979,7 +979,7 @@ impl IGridProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&row), ::core::mem::transmute_copy(&column)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -990,7 +990,7 @@ impl IGridProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RowCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1001,7 +1001,7 @@ impl IGridProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ColumnCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1049,7 +1049,7 @@ impl IItemContainerProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemByProperty(::core::mem::transmute(&pstartafter), ::core::mem::transmute_copy(&propertyid), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfound = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfound, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1103,7 +1103,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetIAccessible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaccessible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaccessible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1114,7 +1114,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ChildId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1125,7 +1125,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1136,7 +1136,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1147,7 +1147,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1158,7 +1158,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Role() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1169,7 +1169,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1180,7 +1180,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Help() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszhelp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszhelp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1191,7 +1191,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.KeyboardShortcut() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszkeyboardshortcut = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszkeyboardshortcut, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1202,7 +1202,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselectedchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselectedchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1213,7 +1213,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdefaultaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdefaultaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1258,7 +1258,7 @@ impl IMultipleViewProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewName(::core::mem::transmute_copy(&viewid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1274,7 +1274,7 @@ impl IMultipleViewProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1285,7 +1285,7 @@ impl IMultipleViewProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedViews() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1314,7 +1314,7 @@ impl IObjectModelProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnderlyingObjectModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1408,7 +1408,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1419,7 +1419,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1430,7 +1430,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Maximum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1441,7 +1441,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Minimum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1452,7 +1452,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.LargeChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1463,7 +1463,7 @@ impl IRangeValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SmallChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1533,7 +1533,7 @@ impl IRawElementProviderFragment_Vtbl {
             let this = (*this).get_impl();
             match this.Navigate(::core::mem::transmute_copy(&direction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1544,7 +1544,7 @@ impl IRawElementProviderFragment_Vtbl {
             let this = (*this).get_impl();
             match this.GetRuntimeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1555,7 +1555,7 @@ impl IRawElementProviderFragment_Vtbl {
             let this = (*this).get_impl();
             match this.BoundingRectangle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1566,7 +1566,7 @@ impl IRawElementProviderFragment_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbeddedFragmentRoots() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1582,7 +1582,7 @@ impl IRawElementProviderFragment_Vtbl {
             let this = (*this).get_impl();
             match this.FragmentRoot() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1614,7 +1614,7 @@ impl IRawElementProviderFragmentRoot_Vtbl {
             let this = (*this).get_impl();
             match this.ElementProviderFromPoint(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1625,7 +1625,7 @@ impl IRawElementProviderFragmentRoot_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1655,7 +1655,7 @@ impl IRawElementProviderHostingAccessibles_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbeddedAccessibles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1681,7 +1681,7 @@ impl IRawElementProviderHwndOverride_Vtbl {
             let this = (*this).get_impl();
             match this.GetOverrideProviderForHwnd(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1713,7 +1713,7 @@ impl IRawElementProviderSimple_Vtbl {
             let this = (*this).get_impl();
             match this.ProviderOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1724,7 +1724,7 @@ impl IRawElementProviderSimple_Vtbl {
             let this = (*this).get_impl();
             match this.GetPatternProvider(::core::mem::transmute_copy(&patternid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1735,7 +1735,7 @@ impl IRawElementProviderSimple_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyValue(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1746,7 +1746,7 @@ impl IRawElementProviderSimple_Vtbl {
             let this = (*this).get_impl();
             match this.HostRawElementProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1798,7 +1798,7 @@ impl IRawElementProviderSimple3_Vtbl {
             let this = (*this).get_impl();
             match this.GetMetadataValue(::core::mem::transmute_copy(&targetid), ::core::mem::transmute_copy(&metadataid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *returnval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(returnval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1825,7 +1825,7 @@ impl IRawElementProviderWindowlessSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdjacentFragment(::core::mem::transmute_copy(&direction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1836,7 +1836,7 @@ impl IRawElementProviderWindowlessSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetRuntimeIdPrefix() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1890,7 +1890,7 @@ impl IRicheditWindowlessAccessibility_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProvider(::core::mem::transmute(&psite)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprovider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprovider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1950,7 +1950,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1961,7 +1961,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.VerticalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1972,7 +1972,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1983,7 +1983,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.VerticalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1994,7 +1994,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2005,7 +2005,7 @@ impl IScrollProvider_Vtbl {
             let this = (*this).get_impl();
             match this.VerticallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2060,7 +2060,7 @@ impl ISelectionItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsSelected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2071,7 +2071,7 @@ impl ISelectionItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SelectionContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2106,7 +2106,7 @@ impl ISelectionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2117,7 +2117,7 @@ impl ISelectionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanSelectMultiple() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2128,7 +2128,7 @@ impl ISelectionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsSelectionRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2162,7 +2162,7 @@ impl ISelectionProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.FirstSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2173,7 +2173,7 @@ impl ISelectionProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.LastSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2184,7 +2184,7 @@ impl ISelectionProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2195,7 +2195,7 @@ impl ISelectionProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.ItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2229,7 +2229,7 @@ impl ISpreadsheetItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Formula() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2240,7 +2240,7 @@ impl ISpreadsheetItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnnotationObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2251,7 +2251,7 @@ impl ISpreadsheetItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnnotationTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2279,7 +2279,7 @@ impl ISpreadsheetProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2311,7 +2311,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.StyleId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2322,7 +2322,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.StyleName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2333,7 +2333,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FillColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2344,7 +2344,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FillPatternStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2355,7 +2355,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Shape() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2366,7 +2366,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FillPatternColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2377,7 +2377,7 @@ impl IStylesProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2440,7 +2440,7 @@ impl ITableItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetRowHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2451,7 +2451,7 @@ impl ITableItemProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2483,7 +2483,7 @@ impl ITableProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetRowHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2494,7 +2494,7 @@ impl ITableProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2505,7 +2505,7 @@ impl ITableProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RowOrColumnMajor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2534,7 +2534,7 @@ impl ITextChildProvider_Vtbl {
             let this = (*this).get_impl();
             match this.TextContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2545,7 +2545,7 @@ impl ITextChildProvider_Vtbl {
             let this = (*this).get_impl();
             match this.TextRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2576,7 +2576,7 @@ impl ITextEditProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveComposition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2587,7 +2587,7 @@ impl ITextEditProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetConversionTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2622,7 +2622,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2633,7 +2633,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisibleRanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2644,7 +2644,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromChild(::core::mem::transmute(&childelement)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2655,7 +2655,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromPoint(::core::mem::transmute(&point)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2666,7 +2666,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2677,7 +2677,7 @@ impl ITextProvider_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedTextSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2712,7 +2712,7 @@ impl ITextProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromAnnotation(::core::mem::transmute(&annotationelement)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2764,7 +2764,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2775,7 +2775,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute(&range)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2786,7 +2786,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CompareEndpoints(::core::mem::transmute_copy(&endpoint), ::core::mem::transmute(&targetrange), ::core::mem::transmute_copy(&targetendpoint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2802,7 +2802,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindAttribute(::core::mem::transmute_copy(&attributeid), ::core::mem::transmute(&val), ::core::mem::transmute_copy(&backward)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2813,7 +2813,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.FindText(::core::mem::transmute(&text), ::core::mem::transmute_copy(&backward), ::core::mem::transmute_copy(&ignorecase)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2824,7 +2824,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeValue(::core::mem::transmute_copy(&attributeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2835,7 +2835,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoundingRectangles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2846,7 +2846,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnclosingElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2857,7 +2857,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetText(::core::mem::transmute_copy(&maxlength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2868,7 +2868,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Move(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2879,7 +2879,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.MoveEndpointByUnit(::core::mem::transmute_copy(&endpoint), ::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2915,7 +2915,7 @@ impl ITextRangeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2984,7 +2984,7 @@ impl IToggleProvider_Vtbl {
             let this = (*this).get_impl();
             match this.ToggleState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3034,7 +3034,7 @@ impl ITransformProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanMove() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3045,7 +3045,7 @@ impl ITransformProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanResize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3056,7 +3056,7 @@ impl ITransformProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanRotate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3100,7 +3100,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.CanZoom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3111,7 +3111,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.ZoomLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3122,7 +3122,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.ZoomMinimum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3133,7 +3133,7 @@ impl ITransformProvider2_Vtbl {
             let this = (*this).get_impl();
             match this.ZoomMaximum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3226,7 +3226,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CompareElements(::core::mem::transmute(&el1), ::core::mem::transmute(&el2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *aresame = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(aresame, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3237,7 +3237,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CompareRuntimeIds(::core::mem::transmute_copy(&runtimeid1), ::core::mem::transmute_copy(&runtimeid2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *aresame = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(aresame, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3248,7 +3248,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *root = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(root, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3259,7 +3259,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ElementFromHandle(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3270,7 +3270,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ElementFromPoint(::core::mem::transmute(&pt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3281,7 +3281,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocusedElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3292,7 +3292,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootElementBuildCache(::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *root = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(root, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3303,7 +3303,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ElementFromHandleBuildCache(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3314,7 +3314,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ElementFromPointBuildCache(::core::mem::transmute(&pt), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3325,7 +3325,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocusedElementBuildCache(::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3336,7 +3336,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTreeWalker(::core::mem::transmute(&pcondition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *walker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(walker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3347,7 +3347,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ControlViewWalker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *walker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(walker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3358,7 +3358,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ContentViewWalker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *walker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(walker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3369,7 +3369,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.RawViewWalker() {
                 ::core::result::Result::Ok(ok__) => {
-                    *walker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(walker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3380,7 +3380,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.RawViewCondition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *condition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(condition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3391,7 +3391,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ControlViewCondition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *condition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(condition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3402,7 +3402,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ContentViewCondition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *condition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(condition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3413,7 +3413,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCacheRequest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cacherequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cacherequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3424,7 +3424,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTrueCondition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3435,7 +3435,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateFalseCondition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3446,7 +3446,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyCondition(::core::mem::transmute_copy(&propertyid), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3457,7 +3457,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyConditionEx(::core::mem::transmute_copy(&propertyid), ::core::mem::transmute(&value), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3468,7 +3468,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAndCondition(::core::mem::transmute(&condition1), ::core::mem::transmute(&condition2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3479,7 +3479,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAndConditionFromArray(::core::mem::transmute_copy(&conditions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3490,7 +3490,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAndConditionFromNativeArray(::core::mem::transmute_copy(&conditions), ::core::mem::transmute_copy(&conditioncount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3501,7 +3501,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateOrCondition(::core::mem::transmute(&condition1), ::core::mem::transmute(&condition2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3512,7 +3512,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateOrConditionFromArray(::core::mem::transmute_copy(&conditions)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3523,7 +3523,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateOrConditionFromNativeArray(::core::mem::transmute_copy(&conditions), ::core::mem::transmute_copy(&conditioncount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3534,7 +3534,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateNotCondition(::core::mem::transmute(&condition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newcondition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newcondition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3595,7 +3595,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.IntNativeArrayToSafeArray(::core::mem::transmute_copy(&array), ::core::mem::transmute_copy(&arraycount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *safearray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(safearray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3611,7 +3611,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.RectToVariant(::core::mem::transmute(&rc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *var = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(var, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3622,7 +3622,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.VariantToRect(::core::mem::transmute(&var)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3638,7 +3638,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProxyFactoryEntry(::core::mem::transmute(&factory)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *factoryentry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(factoryentry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3649,7 +3649,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyFactoryMapping() {
                 ::core::result::Result::Ok(ok__) => {
-                    *factorymapping = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(factorymapping, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3660,7 +3660,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyProgrammaticName(::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3671,7 +3671,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.GetPatternProgrammaticName(::core::mem::transmute_copy(&pattern)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3692,7 +3692,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.CheckNotSupported(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *isnotsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(isnotsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3703,7 +3703,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ReservedNotSupportedValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *notsupportedvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(notsupportedvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3714,7 +3714,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ReservedMixedAttributeValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mixedattributevalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mixedattributevalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3725,7 +3725,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ElementFromIAccessible(::core::mem::transmute(&accessible), ::core::mem::transmute_copy(&childid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3736,7 +3736,7 @@ impl IUIAutomation_Vtbl {
             let this = (*this).get_impl();
             match this.ElementFromIAccessibleBuildCache(::core::mem::transmute(&accessible), ::core::mem::transmute_copy(&childid), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3824,7 +3824,7 @@ impl IUIAutomation2_Vtbl {
             let this = (*this).get_impl();
             match this.AutoSetFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *autosetfocus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(autosetfocus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3840,7 +3840,7 @@ impl IUIAutomation2_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3856,7 +3856,7 @@ impl IUIAutomation2_Vtbl {
             let this = (*this).get_impl();
             match this.TransactionTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timeout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timeout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3993,7 +3993,7 @@ impl IUIAutomation6_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEventHandlerGroup() {
                 ::core::result::Result::Ok(ok__) => {
-                    *handlergroup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(handlergroup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4014,7 +4014,7 @@ impl IUIAutomation6_Vtbl {
             let this = (*this).get_impl();
             match this.ConnectionRecoveryBehavior() {
                 ::core::result::Result::Ok(ok__) => {
-                    *connectionrecoverybehavioroptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(connectionrecoverybehavioroptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4030,7 +4030,7 @@ impl IUIAutomation6_Vtbl {
             let this = (*this).get_impl();
             match this.CoalesceEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *coalesceeventsoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(coalesceeventsoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4104,7 +4104,7 @@ impl IUIAutomationAndCondition_Vtbl {
             let this = (*this).get_impl();
             match this.ChildCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *childcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(childcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4120,7 +4120,7 @@ impl IUIAutomationAndCondition_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *childarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(childarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4160,7 +4160,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAnnotationTypeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4171,7 +4171,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAnnotationTypeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4182,7 +4182,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAuthor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4193,7 +4193,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4204,7 +4204,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4215,7 +4215,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAnnotationTypeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4226,7 +4226,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAnnotationTypeName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4237,7 +4237,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAuthor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4248,7 +4248,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDateTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4259,7 +4259,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4297,7 +4297,7 @@ impl IUIAutomationBoolCondition_Vtbl {
             let this = (*this).get_impl();
             match this.BooleanValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *boolval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(boolval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4338,7 +4338,7 @@ impl IUIAutomationCacheRequest_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clonedrequest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clonedrequest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4349,7 +4349,7 @@ impl IUIAutomationCacheRequest_Vtbl {
             let this = (*this).get_impl();
             match this.TreeScope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *scope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(scope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4365,7 +4365,7 @@ impl IUIAutomationCacheRequest_Vtbl {
             let this = (*this).get_impl();
             match this.TreeFilter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *filter = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(filter, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4381,7 +4381,7 @@ impl IUIAutomationCacheRequest_Vtbl {
             let this = (*this).get_impl();
             match this.AutomationElementMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4450,7 +4450,7 @@ impl IUIAutomationCustomNavigationPattern_Vtbl {
             let this = (*this).get_impl();
             match this.Navigate(::core::mem::transmute_copy(&direction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4480,7 +4480,7 @@ impl IUIAutomationDockPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDockPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4491,7 +4491,7 @@ impl IUIAutomationDockPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDockPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4529,7 +4529,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsGrabbed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4540,7 +4540,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsGrabbed() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4551,7 +4551,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDropEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4562,7 +4562,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDropEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4573,7 +4573,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDropEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4584,7 +4584,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDropEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4595,7 +4595,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentGrabbedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4606,7 +4606,7 @@ impl IUIAutomationDragPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedGrabbedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4645,7 +4645,7 @@ impl IUIAutomationDropTargetPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDropTargetEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4656,7 +4656,7 @@ impl IUIAutomationDropTargetPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDropTargetEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4667,7 +4667,7 @@ impl IUIAutomationDropTargetPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDropTargetEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4678,7 +4678,7 @@ impl IUIAutomationDropTargetPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDropTargetEffects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4796,7 +4796,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetRuntimeId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *runtimeid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(runtimeid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4807,7 +4807,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirst(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4818,7 +4818,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.FindAll(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4829,7 +4829,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstBuildCache(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4840,7 +4840,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.FindAllBuildCache(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4851,7 +4851,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.BuildUpdatedCache(::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *updatedelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(updatedelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4862,7 +4862,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPropertyValue(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4873,7 +4873,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPropertyValueEx(::core::mem::transmute_copy(&propertyid), ::core::mem::transmute_copy(&ignoredefaultvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4884,7 +4884,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedPropertyValue(::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4895,7 +4895,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedPropertyValueEx(::core::mem::transmute_copy(&propertyid), ::core::mem::transmute_copy(&ignoredefaultvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4916,7 +4916,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPattern(::core::mem::transmute_copy(&patternid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *patternobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patternobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4927,7 +4927,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedPattern(::core::mem::transmute_copy(&patternid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *patternobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(patternobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4938,7 +4938,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *parent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4949,7 +4949,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *children = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(children, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4960,7 +4960,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4971,7 +4971,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentControlType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4982,7 +4982,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLocalizedControlType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4993,7 +4993,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5004,7 +5004,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAcceleratorKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5015,7 +5015,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAccessKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5026,7 +5026,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentHasKeyboardFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5037,7 +5037,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsKeyboardFocusable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5048,7 +5048,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5059,7 +5059,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAutomationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5070,7 +5070,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentClassName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5081,7 +5081,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentHelpText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5092,7 +5092,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCulture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5103,7 +5103,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsControlElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5114,7 +5114,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsContentElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5125,7 +5125,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsPassword() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5136,7 +5136,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentNativeWindowHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5147,7 +5147,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentItemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5158,7 +5158,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsOffscreen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5169,7 +5169,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentOrientation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5180,7 +5180,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFrameworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5191,7 +5191,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsRequiredForForm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5202,7 +5202,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentItemStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5213,7 +5213,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentBoundingRectangle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5224,7 +5224,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLabeledBy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5235,7 +5235,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAriaRole() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5246,7 +5246,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAriaProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5257,7 +5257,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsDataValidForForm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5268,7 +5268,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentControllerFor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5279,7 +5279,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDescribedBy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5290,7 +5290,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFlowsTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5301,7 +5301,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentProviderDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5312,7 +5312,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedProcessId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5323,7 +5323,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedControlType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5334,7 +5334,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLocalizedControlType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5345,7 +5345,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5356,7 +5356,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAcceleratorKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5367,7 +5367,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAccessKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5378,7 +5378,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedHasKeyboardFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5389,7 +5389,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsKeyboardFocusable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5400,7 +5400,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5411,7 +5411,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAutomationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5422,7 +5422,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedClassName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5433,7 +5433,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedHelpText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5444,7 +5444,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCulture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5455,7 +5455,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsControlElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5466,7 +5466,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsContentElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5477,7 +5477,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsPassword() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5488,7 +5488,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedNativeWindowHandle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5499,7 +5499,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedItemType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5510,7 +5510,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsOffscreen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5521,7 +5521,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedOrientation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5532,7 +5532,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFrameworkId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5543,7 +5543,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsRequiredForForm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5554,7 +5554,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedItemStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5565,7 +5565,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedBoundingRectangle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5576,7 +5576,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLabeledBy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5587,7 +5587,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAriaRole() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5598,7 +5598,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAriaProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5609,7 +5609,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsDataValidForForm() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5620,7 +5620,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedControllerFor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5631,7 +5631,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDescribedBy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5642,7 +5642,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFlowsTo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5653,7 +5653,7 @@ impl IUIAutomationElement_Vtbl {
             let this = (*this).get_impl();
             match this.CachedProviderDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5773,7 +5773,7 @@ impl IUIAutomationElement2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentOptimizeForVisualContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5784,7 +5784,7 @@ impl IUIAutomationElement2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedOptimizeForVisualContent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5795,7 +5795,7 @@ impl IUIAutomationElement2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLiveSetting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5806,7 +5806,7 @@ impl IUIAutomationElement2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLiveSetting() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5817,7 +5817,7 @@ impl IUIAutomationElement2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFlowsFrom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5828,7 +5828,7 @@ impl IUIAutomationElement2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFlowsFrom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5869,7 +5869,7 @@ impl IUIAutomationElement3_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsPeripheral() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5880,7 +5880,7 @@ impl IUIAutomationElement3_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsPeripheral() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5920,7 +5920,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPositionInSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5931,7 +5931,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentSizeOfSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5942,7 +5942,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5953,7 +5953,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAnnotationTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5964,7 +5964,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentAnnotationObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5975,7 +5975,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CachedPositionInSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5986,7 +5986,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CachedSizeOfSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5997,7 +5997,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6008,7 +6008,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAnnotationTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6019,7 +6019,7 @@ impl IUIAutomationElement4_Vtbl {
             let this = (*this).get_impl();
             match this.CachedAnnotationObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6060,7 +6060,7 @@ impl IUIAutomationElement5_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLandmarkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6071,7 +6071,7 @@ impl IUIAutomationElement5_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLocalizedLandmarkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6082,7 +6082,7 @@ impl IUIAutomationElement5_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLandmarkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6093,7 +6093,7 @@ impl IUIAutomationElement5_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLocalizedLandmarkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6126,7 +6126,7 @@ impl IUIAutomationElement6_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFullDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6137,7 +6137,7 @@ impl IUIAutomationElement6_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFullDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6171,7 +6171,7 @@ impl IUIAutomationElement7_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstWithOptions(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition), ::core::mem::transmute_copy(&traversaloptions), ::core::mem::transmute(&root)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6182,7 +6182,7 @@ impl IUIAutomationElement7_Vtbl {
             let this = (*this).get_impl();
             match this.FindAllWithOptions(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition), ::core::mem::transmute_copy(&traversaloptions), ::core::mem::transmute(&root)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6193,7 +6193,7 @@ impl IUIAutomationElement7_Vtbl {
             let this = (*this).get_impl();
             match this.FindFirstWithOptionsBuildCache(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition), ::core::mem::transmute(&cacherequest), ::core::mem::transmute_copy(&traversaloptions), ::core::mem::transmute(&root)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6204,7 +6204,7 @@ impl IUIAutomationElement7_Vtbl {
             let this = (*this).get_impl();
             match this.FindAllWithOptionsBuildCache(::core::mem::transmute_copy(&scope), ::core::mem::transmute(&condition), ::core::mem::transmute(&cacherequest), ::core::mem::transmute_copy(&traversaloptions), ::core::mem::transmute(&root)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6215,7 +6215,7 @@ impl IUIAutomationElement7_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentMetadataValue(::core::mem::transmute_copy(&targetid), ::core::mem::transmute_copy(&metadataid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *returnval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(returnval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6249,7 +6249,7 @@ impl IUIAutomationElement8_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentHeadingLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6260,7 +6260,7 @@ impl IUIAutomationElement8_Vtbl {
             let this = (*this).get_impl();
             match this.CachedHeadingLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6291,7 +6291,7 @@ impl IUIAutomationElement9_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsDialog() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6302,7 +6302,7 @@ impl IUIAutomationElement9_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsDialog() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6330,7 +6330,7 @@ impl IUIAutomationElementArray_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6341,7 +6341,7 @@ impl IUIAutomationElementArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetElement(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6460,7 +6460,7 @@ impl IUIAutomationExpandCollapsePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentExpandCollapseState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6471,7 +6471,7 @@ impl IUIAutomationExpandCollapsePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedExpandCollapseState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6526,7 +6526,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentContainingGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6537,7 +6537,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6548,7 +6548,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentColumn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6559,7 +6559,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRowSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6570,7 +6570,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentColumnSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6581,7 +6581,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedContainingGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6592,7 +6592,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedRow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6603,7 +6603,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedColumn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6614,7 +6614,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedRowSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6625,7 +6625,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedColumnSpan() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6664,7 +6664,7 @@ impl IUIAutomationGridPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&row), ::core::mem::transmute_copy(&column)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6675,7 +6675,7 @@ impl IUIAutomationGridPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRowCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6686,7 +6686,7 @@ impl IUIAutomationGridPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentColumnCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6697,7 +6697,7 @@ impl IUIAutomationGridPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedRowCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6708,7 +6708,7 @@ impl IUIAutomationGridPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedColumnCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6758,7 +6758,7 @@ impl IUIAutomationItemContainerPattern_Vtbl {
             let this = (*this).get_impl();
             match this.FindItemByProperty(::core::mem::transmute(&pstartafter), ::core::mem::transmute_copy(&propertyid), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfound = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfound, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6822,7 +6822,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentChildId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6833,7 +6833,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6844,7 +6844,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6855,7 +6855,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6866,7 +6866,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRole() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6877,7 +6877,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6888,7 +6888,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentHelp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszhelp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszhelp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6899,7 +6899,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentKeyboardShortcut() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszkeyboardshortcut = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszkeyboardshortcut, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6910,7 +6910,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselectedchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselectedchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6921,7 +6921,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentDefaultAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdefaultaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdefaultaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6932,7 +6932,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedChildId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6943,7 +6943,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6954,7 +6954,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6965,7 +6965,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6976,7 +6976,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedRole() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6987,7 +6987,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6998,7 +6998,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedHelp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszhelp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszhelp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7009,7 +7009,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedKeyboardShortcut() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszkeyboardshortcut = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszkeyboardshortcut, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7020,7 +7020,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselectedchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselectedchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7031,7 +7031,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedDefaultAction() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszdefaultaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszdefaultaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7042,7 +7042,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetIAccessible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaccessible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaccessible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7099,7 +7099,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewName(::core::mem::transmute_copy(&view)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7115,7 +7115,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCurrentView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7126,7 +7126,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSupportedViews() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7137,7 +7137,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCurrentView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7148,7 +7148,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedSupportedViews() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7179,7 +7179,7 @@ impl IUIAutomationNotCondition_Vtbl {
             let this = (*this).get_impl();
             match this.GetChild() {
                 ::core::result::Result::Ok(ok__) => {
-                    *condition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(condition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7222,7 +7222,7 @@ impl IUIAutomationObjectModelPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnderlyingObjectModel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7250,7 +7250,7 @@ impl IUIAutomationOrCondition_Vtbl {
             let this = (*this).get_impl();
             match this.ChildCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *childcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(childcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7266,7 +7266,7 @@ impl IUIAutomationOrCondition_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *childarray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(childarray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7295,7 +7295,7 @@ impl IUIAutomationPatternHandler_Vtbl {
             let this = (*this).get_impl();
             match this.CreateClientWrapper(::core::mem::transmute(&ppatterninstance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclientwrapper = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclientwrapper, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7385,7 +7385,7 @@ impl IUIAutomationPropertyCondition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7396,7 +7396,7 @@ impl IUIAutomationPropertyCondition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7407,7 +7407,7 @@ impl IUIAutomationPropertyCondition_Vtbl {
             let this = (*this).get_impl();
             match this.PropertyConditionFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7439,7 +7439,7 @@ impl IUIAutomationProxyFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateProvider(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&idobject), ::core::mem::transmute_copy(&idchild)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *provider = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(provider, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7450,7 +7450,7 @@ impl IUIAutomationProxyFactory_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyFactoryId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *factoryid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(factoryid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7492,7 +7492,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ProxyFactory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *factory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(factory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7503,7 +7503,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ClassName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *classname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(classname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7514,7 +7514,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.ImageName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *imagename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(imagename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7525,7 +7525,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.AllowSubstringMatch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *allowsubstringmatch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(allowsubstringmatch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7536,7 +7536,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.CanCheckBaseClass() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cancheckbaseclass = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cancheckbaseclass, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7547,7 +7547,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.NeedsAdviseEvents() {
                 ::core::result::Result::Ok(ok__) => {
-                    *adviseevents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(adviseevents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7588,7 +7588,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetWinEventsForAutomationEvent(::core::mem::transmute_copy(&eventid), ::core::mem::transmute_copy(&propertyid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *winevents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(winevents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7637,7 +7637,7 @@ impl IUIAutomationProxyFactoryMapping_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7648,7 +7648,7 @@ impl IUIAutomationProxyFactoryMapping_Vtbl {
             let this = (*this).get_impl();
             match this.GetTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *table = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(table, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7659,7 +7659,7 @@ impl IUIAutomationProxyFactoryMapping_Vtbl {
             let this = (*this).get_impl();
             match this.GetEntry(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *entry = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(entry, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7743,7 +7743,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7754,7 +7754,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7765,7 +7765,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentMaximum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7776,7 +7776,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentMinimum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7787,7 +7787,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLargeChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7798,7 +7798,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentSmallChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7809,7 +7809,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7820,7 +7820,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7831,7 +7831,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedMaximum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7842,7 +7842,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedMinimum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7853,7 +7853,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLargeChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7864,7 +7864,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedSmallChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7907,7 +7907,7 @@ impl IUIAutomationRegistrar_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterProperty(::core::mem::transmute_copy(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7918,7 +7918,7 @@ impl IUIAutomationRegistrar_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterEvent(::core::mem::transmute_copy(&event)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *eventid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eventid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7994,7 +7994,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentHorizontalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8005,7 +8005,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentVerticalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8016,7 +8016,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentHorizontalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8027,7 +8027,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentVerticalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8038,7 +8038,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentHorizontallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8049,7 +8049,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentVerticallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8060,7 +8060,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedHorizontalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8071,7 +8071,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedVerticalScrollPercent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8082,7 +8082,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedHorizontalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8093,7 +8093,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedVerticalViewSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8104,7 +8104,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedHorizontallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8115,7 +8115,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedVerticallyScrollable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8178,7 +8178,7 @@ impl IUIAutomationSelectionItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsSelected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8189,7 +8189,7 @@ impl IUIAutomationSelectionItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentSelectionContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8200,7 +8200,7 @@ impl IUIAutomationSelectionItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsSelected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8211,7 +8211,7 @@ impl IUIAutomationSelectionItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedSelectionContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8251,7 +8251,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8262,7 +8262,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCanSelectMultiple() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8273,7 +8273,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsSelectionRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8284,7 +8284,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8295,7 +8295,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCanSelectMultiple() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8306,7 +8306,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsSelectionRequired() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8347,7 +8347,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFirstSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8358,7 +8358,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentLastSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8369,7 +8369,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCurrentSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8380,7 +8380,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8391,7 +8391,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFirstSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8402,7 +8402,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedLastSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8413,7 +8413,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCurrentSelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8424,7 +8424,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8465,7 +8465,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFormula() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8476,7 +8476,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentAnnotationObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8487,7 +8487,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentAnnotationTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8498,7 +8498,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFormula() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8509,7 +8509,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedAnnotationObjects() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8520,7 +8520,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedAnnotationTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8554,7 +8554,7 @@ impl IUIAutomationSpreadsheetPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8618,7 +8618,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentStyleId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8629,7 +8629,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentStyleName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8640,7 +8640,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFillColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8651,7 +8651,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFillPatternStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8662,7 +8662,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentShape() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8673,7 +8673,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentFillPatternColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8684,7 +8684,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8700,7 +8700,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedStyleId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8711,7 +8711,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedStyleName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8722,7 +8722,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFillColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8733,7 +8733,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFillPatternStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8744,7 +8744,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedShape() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8755,7 +8755,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedFillPatternColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8766,7 +8766,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8842,7 +8842,7 @@ impl IUIAutomationTableItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentRowHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8853,7 +8853,7 @@ impl IUIAutomationTableItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentColumnHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8864,7 +8864,7 @@ impl IUIAutomationTableItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedRowHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8875,7 +8875,7 @@ impl IUIAutomationTableItemPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedColumnHeaderItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8909,7 +8909,7 @@ impl IUIAutomationTablePattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentRowHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8920,7 +8920,7 @@ impl IUIAutomationTablePattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentColumnHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8931,7 +8931,7 @@ impl IUIAutomationTablePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentRowOrColumnMajor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8942,7 +8942,7 @@ impl IUIAutomationTablePattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedRowHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8953,7 +8953,7 @@ impl IUIAutomationTablePattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedColumnHeaders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8964,7 +8964,7 @@ impl IUIAutomationTablePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedRowOrColumnMajor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8996,7 +8996,7 @@ impl IUIAutomationTextChildPattern_Vtbl {
             let this = (*this).get_impl();
             match this.TextContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *container = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(container, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9007,7 +9007,7 @@ impl IUIAutomationTextChildPattern_Vtbl {
             let this = (*this).get_impl();
             match this.TextRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *range = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9038,7 +9038,7 @@ impl IUIAutomationTextEditPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveComposition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *range = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9049,7 +9049,7 @@ impl IUIAutomationTextEditPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetConversionTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *range = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9107,7 +9107,7 @@ impl IUIAutomationTextPattern_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromPoint(::core::mem::transmute(&pt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *range = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9118,7 +9118,7 @@ impl IUIAutomationTextPattern_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromChild(::core::mem::transmute(&child)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *range = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9129,7 +9129,7 @@ impl IUIAutomationTextPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ranges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ranges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9140,7 +9140,7 @@ impl IUIAutomationTextPattern_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisibleRanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ranges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ranges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9151,7 +9151,7 @@ impl IUIAutomationTextPattern_Vtbl {
             let this = (*this).get_impl();
             match this.DocumentRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *range = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9162,7 +9162,7 @@ impl IUIAutomationTextPattern_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedTextSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedtextselection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedtextselection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9197,7 +9197,7 @@ impl IUIAutomationTextPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromAnnotation(::core::mem::transmute(&annotation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *range = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9249,7 +9249,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *clonedrange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(clonedrange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9260,7 +9260,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute(&range)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *aresame = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(aresame, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9271,7 +9271,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.CompareEndpoints(::core::mem::transmute_copy(&srcendpoint), ::core::mem::transmute(&range), ::core::mem::transmute_copy(&targetendpoint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *compvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(compvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9287,7 +9287,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.FindAttribute(::core::mem::transmute_copy(&attr), ::core::mem::transmute(&val), ::core::mem::transmute_copy(&backward)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9298,7 +9298,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.FindText(::core::mem::transmute(&text), ::core::mem::transmute_copy(&backward), ::core::mem::transmute_copy(&ignorecase)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *found = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(found, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9309,7 +9309,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeValue(::core::mem::transmute_copy(&attr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9320,7 +9320,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoundingRectangles() {
                 ::core::result::Result::Ok(ok__) => {
-                    *boundingrects = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(boundingrects, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9331,7 +9331,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnclosingElement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enclosingelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enclosingelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9342,7 +9342,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetText(::core::mem::transmute_copy(&maxlength)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *text = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(text, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9353,7 +9353,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Move(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *moved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9364,7 +9364,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveEndpointByUnit(::core::mem::transmute_copy(&endpoint), ::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *moved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(moved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9400,7 +9400,7 @@ impl IUIAutomationTextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *children = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(children, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9468,7 +9468,7 @@ impl IUIAutomationTextRange3_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnclosingElementBuildCache(::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *enclosingelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enclosingelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9479,7 +9479,7 @@ impl IUIAutomationTextRange3_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildrenBuildCache(::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *children = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(children, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9490,7 +9490,7 @@ impl IUIAutomationTextRange3_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeValues(::core::mem::transmute_copy(&attributeids), ::core::mem::transmute_copy(&attributeidcount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributevalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributevalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9519,7 +9519,7 @@ impl IUIAutomationTextRangeArray_Vtbl {
             let this = (*this).get_impl();
             match this.Length() {
                 ::core::result::Result::Ok(ok__) => {
-                    *length = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(length, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9530,7 +9530,7 @@ impl IUIAutomationTextRangeArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetElement(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *element = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(element, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9564,7 +9564,7 @@ impl IUIAutomationTogglePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentToggleState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9575,7 +9575,7 @@ impl IUIAutomationTogglePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedToggleState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9629,7 +9629,7 @@ impl IUIAutomationTransformPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCanMove() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9640,7 +9640,7 @@ impl IUIAutomationTransformPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCanResize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9651,7 +9651,7 @@ impl IUIAutomationTransformPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCanRotate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9662,7 +9662,7 @@ impl IUIAutomationTransformPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCanMove() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9673,7 +9673,7 @@ impl IUIAutomationTransformPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCanResize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9684,7 +9684,7 @@ impl IUIAutomationTransformPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCanRotate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9740,7 +9740,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCanZoom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9751,7 +9751,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCanZoom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9762,7 +9762,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentZoomLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9773,7 +9773,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedZoomLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9784,7 +9784,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentZoomMinimum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9795,7 +9795,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedZoomMinimum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9806,7 +9806,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentZoomMaximum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9817,7 +9817,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
             let this = (*this).get_impl();
             match this.CachedZoomMaximum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9864,7 +9864,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentElement(::core::mem::transmute(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *parent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9875,7 +9875,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstChildElement(::core::mem::transmute(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *first = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(first, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9886,7 +9886,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastChildElement(::core::mem::transmute(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *last = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(last, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9897,7 +9897,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextSiblingElement(::core::mem::transmute(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *next = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(next, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9908,7 +9908,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousSiblingElement(::core::mem::transmute(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *previous = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previous, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9919,7 +9919,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.NormalizeElement(::core::mem::transmute(&element)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *normalized = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(normalized, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9930,7 +9930,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentElementBuildCache(::core::mem::transmute(&element), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *parent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(parent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9941,7 +9941,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstChildElementBuildCache(::core::mem::transmute(&element), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *first = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(first, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9952,7 +9952,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastChildElementBuildCache(::core::mem::transmute(&element), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *last = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(last, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9963,7 +9963,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextSiblingElementBuildCache(::core::mem::transmute(&element), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *next = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(next, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9974,7 +9974,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousSiblingElementBuildCache(::core::mem::transmute(&element), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *previous = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previous, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9985,7 +9985,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.NormalizeElementBuildCache(::core::mem::transmute(&element), ::core::mem::transmute(&cacherequest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *normalized = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(normalized, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9996,7 +9996,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             let this = (*this).get_impl();
             match this.Condition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *condition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(condition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10046,7 +10046,7 @@ impl IUIAutomationValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10057,7 +10057,7 @@ impl IUIAutomationValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10068,7 +10068,7 @@ impl IUIAutomationValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10079,7 +10079,7 @@ impl IUIAutomationValuePattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10148,7 +10148,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForInputIdle(::core::mem::transmute_copy(&milliseconds)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *success = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(success, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10164,7 +10164,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCanMaximize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10175,7 +10175,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCanMinimize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10186,7 +10186,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsModal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10197,7 +10197,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentIsTopmost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10208,7 +10208,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentWindowVisualState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10219,7 +10219,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentWindowInteractionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10230,7 +10230,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCanMaximize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10241,7 +10241,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedCanMinimize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10252,7 +10252,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsModal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10263,7 +10263,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedIsTopmost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10274,7 +10274,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedWindowVisualState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10285,7 +10285,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             let this = (*this).get_impl();
             match this.CachedWindowInteractionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *retval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10335,7 +10335,7 @@ impl IValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10346,7 +10346,7 @@ impl IValueProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsReadOnly() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10412,7 +10412,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.WaitForInputIdle(::core::mem::transmute_copy(&milliseconds)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10423,7 +10423,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanMaximize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10434,7 +10434,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.CanMinimize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10445,7 +10445,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsModal() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10456,7 +10456,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.WindowVisualState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10467,7 +10467,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.WindowInteractionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10478,7 +10478,7 @@ impl IWindowProvider_Vtbl {
             let this = (*this).get_impl();
             match this.IsTopmost() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pretval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
@@ -25,7 +25,7 @@ impl IUIAnimationInterpolator_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *duration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(duration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -36,7 +36,7 @@ impl IUIAnimationInterpolator_Vtbl {
             let this = (*this).get_impl();
             match this.GetFinalValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -47,7 +47,7 @@ impl IUIAnimationInterpolator_Vtbl {
             let this = (*this).get_impl();
             match this.InterpolateValue(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -58,7 +58,7 @@ impl IUIAnimationInterpolator_Vtbl {
             let this = (*this).get_impl();
             match this.InterpolateVelocity(::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *velocity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(velocity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -103,7 +103,7 @@ impl IUIAnimationInterpolator2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDimension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IUIAnimationInterpolator2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *duration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(duration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -218,7 +218,7 @@ impl IUIAnimationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAnimationVariable(::core::mem::transmute_copy(&initialvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *variable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -234,7 +234,7 @@ impl IUIAnimationManager_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStoryboard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyboard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyboard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -255,7 +255,7 @@ impl IUIAnimationManager_Vtbl {
             let this = (*this).get_impl();
             match this.Update(::core::mem::transmute_copy(&timenow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *updateresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(updateresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -266,7 +266,7 @@ impl IUIAnimationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetVariableFromTag(::core::mem::transmute(&object), ::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *variable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -277,7 +277,7 @@ impl IUIAnimationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryboardFromTag(::core::mem::transmute(&object), ::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyboard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyboard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -288,7 +288,7 @@ impl IUIAnimationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -405,7 +405,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAnimationVectorVariable(::core::mem::transmute_copy(&initialvalue), ::core::mem::transmute_copy(&cdimension)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *variable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -416,7 +416,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAnimationVariable(::core::mem::transmute_copy(&initialvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *variable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -432,7 +432,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStoryboard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyboard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyboard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -453,7 +453,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.Update(::core::mem::transmute_copy(&timenow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *updateresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(updateresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -464,7 +464,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.GetVariableFromTag(::core::mem::transmute(&object), ::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *variable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(variable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -475,7 +475,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryboardFromTag(::core::mem::transmute(&object), ::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyboard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyboard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -486,7 +486,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.EstimateNextEventTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -497,7 +497,7 @@ impl IUIAnimationManager2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -709,7 +709,7 @@ impl IUIAnimationStoryboard_Vtbl {
             let this = (*this).get_impl();
             match this.AddKeyframeAtOffset(::core::mem::transmute_copy(&existingkeyframe), ::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *keyframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keyframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -720,7 +720,7 @@ impl IUIAnimationStoryboard_Vtbl {
             let this = (*this).get_impl();
             match this.AddKeyframeAfterTransition(::core::mem::transmute(&transition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *keyframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keyframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -756,7 +756,7 @@ impl IUIAnimationStoryboard_Vtbl {
             let this = (*this).get_impl();
             match this.Schedule(::core::mem::transmute_copy(&timenow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *schedulingresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(schedulingresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -792,7 +792,7 @@ impl IUIAnimationStoryboard_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -803,7 +803,7 @@ impl IUIAnimationStoryboard_Vtbl {
             let this = (*this).get_impl();
             match this.GetElapsedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *elapsedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(elapsedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -875,7 +875,7 @@ impl IUIAnimationStoryboard2_Vtbl {
             let this = (*this).get_impl();
             match this.AddKeyframeAtOffset(::core::mem::transmute_copy(&existingkeyframe), ::core::mem::transmute_copy(&offset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *keyframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keyframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -886,7 +886,7 @@ impl IUIAnimationStoryboard2_Vtbl {
             let this = (*this).get_impl();
             match this.AddKeyframeAfterTransition(::core::mem::transmute(&transition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *keyframe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keyframe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -927,7 +927,7 @@ impl IUIAnimationStoryboard2_Vtbl {
             let this = (*this).get_impl();
             match this.Schedule(::core::mem::transmute_copy(&timenow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *schedulingresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(schedulingresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -963,7 +963,7 @@ impl IUIAnimationStoryboard2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -974,7 +974,7 @@ impl IUIAnimationStoryboard2_Vtbl {
             let this = (*this).get_impl();
             match this.GetElapsedTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *elapsedtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(elapsedtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1107,7 +1107,7 @@ impl IUIAnimationTimer_Vtbl {
             let this = (*this).get_impl();
             match this.GetTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *seconds = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(seconds, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1200,7 +1200,7 @@ impl IUIAnimationTimerUpdateHandler_Vtbl {
             let this = (*this).get_impl();
             match this.OnUpdate(::core::mem::transmute_copy(&timenow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1256,7 +1256,7 @@ impl IUIAnimationTransition_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *duration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(duration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1291,7 +1291,7 @@ impl IUIAnimationTransition2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDimension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1327,7 +1327,7 @@ impl IUIAnimationTransition2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *duration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(duration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1359,7 +1359,7 @@ impl IUIAnimationTransitionFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransition(::core::mem::transmute(&interpolator)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1382,7 +1382,7 @@ impl IUIAnimationTransitionFactory2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateTransition(::core::mem::transmute(&interpolator)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1416,7 +1416,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstantaneousTransition(::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1427,7 +1427,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateConstantTransition(::core::mem::transmute_copy(&duration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1438,7 +1438,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDiscreteTransition(::core::mem::transmute_copy(&delay), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&hold)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1449,7 +1449,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1460,7 +1460,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearTransitionFromSpeed(::core::mem::transmute_copy(&speed), ::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1471,7 +1471,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSinusoidalTransitionFromVelocity(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&period)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1482,7 +1482,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSinusoidalTransitionFromRange(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&minimumvalue), ::core::mem::transmute_copy(&maximumvalue), ::core::mem::transmute_copy(&period), ::core::mem::transmute_copy(&slope)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1493,7 +1493,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAccelerateDecelerateTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&accelerationratio), ::core::mem::transmute_copy(&decelerationratio)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1504,7 +1504,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateReversalTransition(::core::mem::transmute_copy(&duration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1515,7 +1515,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCubicTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&finalvelocity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1526,7 +1526,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSmoothStopTransition(::core::mem::transmute_copy(&maximumduration), ::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1537,7 +1537,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.CreateParabolicTransitionFromAcceleration(::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&finalvelocity), ::core::mem::transmute_copy(&acceleration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1592,7 +1592,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstantaneousTransition(::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1603,7 +1603,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstantaneousVectorTransition(::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&cdimension)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1614,7 +1614,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateConstantTransition(::core::mem::transmute_copy(&duration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1625,7 +1625,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDiscreteTransition(::core::mem::transmute_copy(&delay), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&hold)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1636,7 +1636,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDiscreteVectorTransition(::core::mem::transmute_copy(&delay), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&cdimension), ::core::mem::transmute_copy(&hold)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1647,7 +1647,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1658,7 +1658,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearVectorTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&cdimension)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1669,7 +1669,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearTransitionFromSpeed(::core::mem::transmute_copy(&speed), ::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1680,7 +1680,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateLinearVectorTransitionFromSpeed(::core::mem::transmute_copy(&speed), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&cdimension)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1691,7 +1691,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSinusoidalTransitionFromVelocity(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&period)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1702,7 +1702,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSinusoidalTransitionFromRange(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&minimumvalue), ::core::mem::transmute_copy(&maximumvalue), ::core::mem::transmute_copy(&period), ::core::mem::transmute_copy(&slope)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1713,7 +1713,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateAccelerateDecelerateTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&accelerationratio), ::core::mem::transmute_copy(&decelerationratio)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1724,7 +1724,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateReversalTransition(::core::mem::transmute_copy(&duration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1735,7 +1735,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCubicTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&finalvelocity)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1746,7 +1746,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCubicVectorTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&finalvelocity), ::core::mem::transmute_copy(&cdimension)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1757,7 +1757,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSmoothStopTransition(::core::mem::transmute_copy(&maximumduration), ::core::mem::transmute_copy(&finalvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1768,7 +1768,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateParabolicTransitionFromAcceleration(::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&finalvelocity), ::core::mem::transmute_copy(&acceleration)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *transition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(transition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1779,7 +1779,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCubicBezierLinearTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&x1), ::core::mem::transmute_copy(&y1), ::core::mem::transmute_copy(&x2), ::core::mem::transmute_copy(&y2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1790,7 +1790,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateCubicBezierLinearVectorTransition(::core::mem::transmute_copy(&duration), ::core::mem::transmute_copy(&finalvalue), ::core::mem::transmute_copy(&cdimension), ::core::mem::transmute_copy(&x1), ::core::mem::transmute_copy(&y1), ::core::mem::transmute_copy(&x2), ::core::mem::transmute_copy(&y2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptransition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptransition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1847,7 +1847,7 @@ impl IUIAnimationVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1858,7 +1858,7 @@ impl IUIAnimationVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetFinalValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *finalvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(finalvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1869,7 +1869,7 @@ impl IUIAnimationVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *previousvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previousvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1880,7 +1880,7 @@ impl IUIAnimationVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntegerValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1891,7 +1891,7 @@ impl IUIAnimationVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetFinalIntegerValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *finalvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(finalvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1902,7 +1902,7 @@ impl IUIAnimationVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousIntegerValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *previousvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previousvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1913,7 +1913,7 @@ impl IUIAnimationVariable_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentStoryboard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyboard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyboard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2015,7 +2015,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDimension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dimension = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dimension, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2026,7 +2026,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2052,7 +2052,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFinalValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *finalvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(finalvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2068,7 +2068,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *previousvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previousvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2084,7 +2084,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetIntegerValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2100,7 +2100,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFinalIntegerValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *finalvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(finalvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2116,7 +2116,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousIntegerValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *previousvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(previousvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2132,7 +2132,7 @@ impl IUIAnimationVariable2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentStoryboard() {
                 ::core::result::Result::Ok(ok__) => {
-                    *storyboard = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(storyboard, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
@@ -27,7 +27,7 @@ impl IDeviceModelPlugIn_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumChannels() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnumchannels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnumchannels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -43,7 +43,7 @@ impl IDeviceModelPlugIn_Vtbl {
             let this = (*this).get_impl();
             match this.ColorimetricToDeviceColors(::core::mem::transmute_copy(&ccolors), ::core::mem::transmute_copy(&cchannels), ::core::mem::transmute_copy(&pxyzcolors)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevicevalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevicevalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -54,7 +54,7 @@ impl IDeviceModelPlugIn_Vtbl {
             let this = (*this).get_impl();
             match this.ColorimetricToDeviceColorsWithBlack(::core::mem::transmute_copy(&ccolors), ::core::mem::transmute_copy(&cchannels), ::core::mem::transmute_copy(&pxyzcolors), ::core::mem::transmute_copy(&pblackinformation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdevicevalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdevicevalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -70,7 +70,7 @@ impl IDeviceModelPlugIn_Vtbl {
             let this = (*this).get_impl();
             match this.GetPrimarySamples() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprimarycolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprimarycolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -91,7 +91,7 @@ impl IDeviceModelPlugIn_Vtbl {
             let this = (*this).get_impl();
             match this.GetNeutralAxisSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccolors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccolors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
@@ -27,7 +27,7 @@ impl IRichEditOle_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientSite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpolesite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpolesite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -155,7 +155,7 @@ impl IRichEditOleCallback_Vtbl {
             let this = (*this).get_impl();
             match this.GetNewStorage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lplpstg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lplpstg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -289,7 +289,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -300,7 +300,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -311,7 +311,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -322,7 +322,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryRanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstories = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstories, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -333,7 +333,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetSaved() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -349,7 +349,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultTabStop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -380,7 +380,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Freeze() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -391,7 +391,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Unfreeze() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -412,7 +412,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Undo(::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -423,7 +423,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Redo(::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -434,7 +434,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.Range(::core::mem::transmute_copy(&cpactive), ::core::mem::transmute_copy(&cpanchor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -445,7 +445,7 @@ impl ITextDocument_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromPoint(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -535,7 +535,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaretType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -551,7 +551,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplays() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisplays = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisplays, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -562,7 +562,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentFont() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -578,7 +578,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentPara() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppara = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppara, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -594,7 +594,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEastAsianFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -605,7 +605,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGenerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -621,7 +621,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotificationMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -637,7 +637,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -648,7 +648,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryRanges2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstories = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstories, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -659,7 +659,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypographyOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -670,7 +670,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetVersion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -681,7 +681,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -702,7 +702,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCallManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvoid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvoid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -718,7 +718,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectColor(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -729,7 +729,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetImmContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -745,7 +745,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -756,7 +756,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrings() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -772,7 +772,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.Range2(::core::mem::transmute_copy(&cpactive), ::core::mem::transmute_copy(&cpanchor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -783,7 +783,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.RangeFromPoint2(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -834,7 +834,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMathProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -850,7 +850,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveStory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -866,7 +866,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMainStory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -877,7 +877,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetNewStory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -888,7 +888,7 @@ impl ITextDocument2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStory(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -993,7 +993,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetEffectColor(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1004,7 +1004,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetCaretType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcarettype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcarettype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1020,7 +1020,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetImmContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1041,7 +1041,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetNotificationMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1062,7 +1062,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1073,7 +1073,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1084,7 +1084,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetFEFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1125,7 +1125,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentFont() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitextfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitextfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1136,7 +1136,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentPara() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitextpara = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitextpara, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1147,7 +1147,7 @@ impl ITextDocument2Old_Vtbl {
             let this = (*this).get_impl();
             match this.GetCallManager() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppvoid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppvoid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1258,7 +1258,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuplicate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1274,7 +1274,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.CanChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1285,7 +1285,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&pfont)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1301,7 +1301,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1317,7 +1317,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetAllCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1333,7 +1333,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnimation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1349,7 +1349,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1365,7 +1365,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetBold() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1381,7 +1381,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmboss() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1397,7 +1397,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetForeColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1413,7 +1413,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetHidden() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1429,7 +1429,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetEngrave() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1445,7 +1445,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetItalic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1461,7 +1461,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetKerning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1477,7 +1477,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguageID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1493,7 +1493,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1509,7 +1509,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1525,7 +1525,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1541,7 +1541,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetProtected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1557,7 +1557,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetShadow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1573,7 +1573,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1589,7 +1589,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetSmallCaps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1605,7 +1605,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1621,7 +1621,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrikeThrough() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1637,7 +1637,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubscript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1653,7 +1653,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetSuperscript() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1669,7 +1669,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnderline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1685,7 +1685,7 @@ impl ITextFont_Vtbl {
             let this = (*this).get_impl();
             match this.GetWeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1818,7 +1818,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1829,7 +1829,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutoLigatures() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1845,7 +1845,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutospaceAlpha() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1861,7 +1861,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutospaceNumeric() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1877,7 +1877,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetAutospaceParens() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1893,7 +1893,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCharRep() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1909,7 +1909,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompressionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1925,7 +1925,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCookie() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1941,7 +1941,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDoubleStrike() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1957,7 +1957,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuplicate2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1973,7 +1973,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1984,7 +1984,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMathZone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2000,7 +2000,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetModWidthPairs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2016,7 +2016,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetModWidthSpace() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2032,7 +2032,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOldNumbers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2048,7 +2048,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOverlapping() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2064,7 +2064,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPositionSubSuper() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2080,7 +2080,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetScaling() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2096,7 +2096,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpaceExtension() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2112,7 +2112,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetUnderlinePositionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2138,7 +2138,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2154,7 +2154,7 @@ impl ITextFont2_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual2(::core::mem::transmute(&pfont)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2426,7 +2426,7 @@ impl ITextHost_Vtbl {
             let this = (*this).get_impl();
             match this.TxGetPasswordChar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2685,7 +2685,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuplicate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppara = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppara, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2701,7 +2701,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.CanChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2712,7 +2712,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&ppara)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2728,7 +2728,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2744,7 +2744,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2760,7 +2760,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetHyphenation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2776,7 +2776,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstLineIndent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2787,7 +2787,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeepTogether() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2803,7 +2803,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeepWithNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2819,7 +2819,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetLeftIndent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2830,7 +2830,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetLineSpacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2841,7 +2841,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetLineSpacingRule() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2852,7 +2852,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetListAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2868,7 +2868,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetListLevelIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2884,7 +2884,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetListStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2900,7 +2900,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetListTab() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2916,7 +2916,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetListType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2932,7 +2932,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetNoLineNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2948,7 +2948,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetPageBreakBefore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2964,7 +2964,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetRightIndent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2990,7 +2990,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpaceAfter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3006,7 +3006,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetSpaceBefore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3022,7 +3022,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetWidowControl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3038,7 +3038,7 @@ impl ITextPara_Vtbl {
             let this = (*this).get_impl();
             match this.GetTabCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3149,7 +3149,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBorders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppborders = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppborders, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3160,7 +3160,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuplicate2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppara = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppara, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3176,7 +3176,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFontAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3192,7 +3192,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.GetHangingPunctuation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3208,7 +3208,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSnapToGrid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3224,7 +3224,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTrimPunctuationAtStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3245,7 +3245,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3256,7 +3256,7 @@ impl ITextPara2_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual2(::core::mem::transmute(&ppara)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3360,7 +3360,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3376,7 +3376,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetChar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3392,7 +3392,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuplicate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3403,7 +3403,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormattedText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3419,7 +3419,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcpfirst = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcpfirst, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3435,7 +3435,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcplim = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcplim, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3451,7 +3451,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetFont() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3467,7 +3467,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetPara() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppara = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppara, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3483,7 +3483,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3494,7 +3494,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetStoryType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3510,7 +3510,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Expand(::core::mem::transmute_copy(&unit)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3521,7 +3521,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndex(::core::mem::transmute_copy(&unit)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3542,7 +3542,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.InRange(::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3553,7 +3553,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.InStory(::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3564,7 +3564,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3580,7 +3580,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.StartOf(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3591,7 +3591,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.EndOf(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3602,7 +3602,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Move(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3613,7 +3613,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveStart(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3624,7 +3624,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveEnd(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3635,7 +3635,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveWhile(::core::mem::transmute_copy(&cset), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3646,7 +3646,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveStartWhile(::core::mem::transmute_copy(&cset), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3657,7 +3657,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveEndWhile(::core::mem::transmute_copy(&cset), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3668,7 +3668,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveUntil(::core::mem::transmute_copy(&cset), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3679,7 +3679,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveStartUntil(::core::mem::transmute_copy(&cset), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3690,7 +3690,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.MoveEndUntil(::core::mem::transmute_copy(&cset), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3701,7 +3701,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.FindText(::core::mem::transmute(&bstr), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3712,7 +3712,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.FindTextStart(::core::mem::transmute(&bstr), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3723,7 +3723,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.FindTextEnd(::core::mem::transmute(&bstr), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3734,7 +3734,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Delete(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3745,7 +3745,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Cut() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3756,7 +3756,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.Copy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3772,7 +3772,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.CanPaste(::core::mem::transmute_copy(&pvar), ::core::mem::transmute_copy(&format)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3783,7 +3783,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.CanEdit() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3814,7 +3814,7 @@ impl ITextRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbeddedObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3932,7 +3932,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3943,7 +3943,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCells() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcells = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcells, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3954,7 +3954,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumn() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcolumn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcolumn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3965,7 +3965,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3976,7 +3976,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDuplicate2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3987,7 +3987,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFont2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4003,7 +4003,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormattedText2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4019,7 +4019,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGravity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4035,7 +4035,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPara2() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppara = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppara, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4051,7 +4051,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetRow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4062,7 +4062,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStartPara() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4073,7 +4073,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetTable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4084,7 +4084,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4115,7 +4115,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.Find(::core::mem::transmute(&prange), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4141,7 +4141,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4162,7 +4162,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetText2(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4218,7 +4218,7 @@ impl ITextRange2_Vtbl {
             let this = (*this).get_impl();
             match this.GetMathFunctionType(::core::mem::transmute(&bstr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4336,7 +4336,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4352,7 +4352,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4368,7 +4368,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellCountCache() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4384,7 +4384,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4400,7 +4400,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellMargin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4416,7 +4416,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4432,7 +4432,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4448,7 +4448,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeepTogether() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4464,7 +4464,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeepWithNext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4480,7 +4480,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetNestLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4491,7 +4491,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetRTL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4507,7 +4507,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4523,7 +4523,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellColorBack() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4539,7 +4539,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellColorFore() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4555,7 +4555,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellMergeFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4571,7 +4571,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellShading() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4587,7 +4587,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellVerticalText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4603,7 +4603,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetCellWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4644,7 +4644,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.CanChange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4655,7 +4655,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4671,7 +4671,7 @@ impl ITextRow_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&prow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4764,7 +4764,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4780,7 +4780,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4791,7 +4791,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveLeft(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4802,7 +4802,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveRight(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4813,7 +4813,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveUp(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4824,7 +4824,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.MoveDown(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4835,7 +4835,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.HomeKey(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4846,7 +4846,7 @@ impl ITextSelection_Vtbl {
             let this = (*this).get_impl();
             match this.EndKey(::core::mem::transmute_copy(&unit), ::core::mem::transmute_copy(&extend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdelta = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdelta, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5008,7 +5008,7 @@ impl ITextServices_Vtbl {
             let this = (*this).get_impl();
             match this.TxGetDropTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdroptarget = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdroptarget, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5105,7 +5105,7 @@ impl ITextStory_Vtbl {
             let this = (*this).get_impl();
             match this.GetActive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5121,7 +5121,7 @@ impl ITextStory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisplay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisplay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5132,7 +5132,7 @@ impl ITextStory_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5143,7 +5143,7 @@ impl ITextStory_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5159,7 +5159,7 @@ impl ITextStory_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&r#type)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5170,7 +5170,7 @@ impl ITextStory_Vtbl {
             let this = (*this).get_impl();
             match this.GetRange(::core::mem::transmute_copy(&cpactive), ::core::mem::transmute_copy(&cpanchor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5181,7 +5181,7 @@ impl ITextStory_Vtbl {
             let this = (*this).get_impl();
             match this.GetText(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5238,7 +5238,7 @@ impl ITextStoryRanges_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5249,7 +5249,7 @@ impl ITextStoryRanges_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5260,7 +5260,7 @@ impl ITextStoryRanges_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5291,7 +5291,7 @@ impl ITextStoryRanges2_Vtbl {
             let this = (*this).get_impl();
             match this.Item2(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5333,7 +5333,7 @@ impl ITextStrings_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5344,7 +5344,7 @@ impl ITextStrings_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5385,7 +5385,7 @@ impl ITextStrings_Vtbl {
             let this = (*this).get_impl();
             match this.GetCch(::core::mem::transmute_copy(&istring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
@@ -40,7 +40,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute_copy(&hbmimage), ::core::mem::transmute_copy(&hbmmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -51,7 +51,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.ReplaceIcon(::core::mem::transmute_copy(&i), ::core::mem::transmute_copy(&hicon)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -72,7 +72,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.AddMasked(::core::mem::transmute_copy(&hbmimage), ::core::mem::transmute_copy(&crmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -93,7 +93,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetIcon(::core::mem::transmute_copy(&i), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *picon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(picon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -104,7 +104,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageInfo(::core::mem::transmute_copy(&i)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pimageinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pimageinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -130,7 +130,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageRect(::core::mem::transmute_copy(&i)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -151,7 +151,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -167,7 +167,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.SetBkColor(::core::mem::transmute_copy(&clrbk)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -178,7 +178,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetBkColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -229,7 +229,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemFlags(::core::mem::transmute_copy(&i)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -240,7 +240,7 @@ impl IImageList_Vtbl {
             let this = (*this).get_impl();
             match this.GetOverlayImage(::core::mem::transmute_copy(&ioverlay)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
@@ -98,7 +98,7 @@ impl IActiveIME_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRegisterWord(::core::mem::transmute(&szreading), ::core::mem::transmute_copy(&dwstyle), ::core::mem::transmute(&szregister), ::core::mem::transmute_copy(&pdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -109,7 +109,7 @@ impl IActiveIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodePageA() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ucodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ucodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -120,7 +120,7 @@ impl IActiveIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetLangId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -258,7 +258,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.AssociateContext(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&hime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phprev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phprev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -279,7 +279,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phimc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phimc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -295,7 +295,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRegisterWordA(::core::mem::transmute_copy(&hkl), ::core::mem::transmute(&szreading), ::core::mem::transmute_copy(&dwstyle), ::core::mem::transmute(&szregister), ::core::mem::transmute_copy(&pdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -306,7 +306,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRegisterWordW(::core::mem::transmute_copy(&hkl), ::core::mem::transmute(&szreading), ::core::mem::transmute_copy(&dwstyle), ::core::mem::transmute(&szregister), ::core::mem::transmute_copy(&pdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -347,7 +347,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetCandidateWindow(::core::mem::transmute_copy(&himc), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcandidate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcandidate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -358,7 +358,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompositionFontA(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -369,7 +369,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompositionFontW(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -390,7 +390,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompositionWindow(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcompform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcompform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -401,7 +401,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phimc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phimc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -427,7 +427,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultIMEWnd(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdefwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdefwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -473,7 +473,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&hkl), ::core::mem::transmute_copy(&fdwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -494,7 +494,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatusWindowPos(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptpos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptpos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -505,7 +505,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetVirtualKey(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puvirtualkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puvirtualkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -516,7 +516,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.InstallIMEA(::core::mem::transmute(&szimefilename), ::core::mem::transmute(&szlayouttext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -527,7 +527,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.InstallIMEW(::core::mem::transmute(&szimefilename), ::core::mem::transmute(&szlayouttext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -643,7 +643,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.OnDefWindowProc(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&msg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -659,7 +659,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodePageA(::core::mem::transmute_copy(&hkl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ucodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ucodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -670,7 +670,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetLangId(::core::mem::transmute_copy(&hkl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -701,7 +701,7 @@ impl IActiveIMMApp_Vtbl {
             let this = (*this).get_impl();
             match this.EnumInputContext(::core::mem::transmute_copy(&idthread)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -884,7 +884,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.AssociateContext(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&hime)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phprev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phprev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -905,7 +905,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phimc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phimc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -921,7 +921,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRegisterWordA(::core::mem::transmute_copy(&hkl), ::core::mem::transmute(&szreading), ::core::mem::transmute_copy(&dwstyle), ::core::mem::transmute(&szregister), ::core::mem::transmute_copy(&pdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -932,7 +932,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.EnumRegisterWordW(::core::mem::transmute_copy(&hkl), ::core::mem::transmute(&szreading), ::core::mem::transmute_copy(&dwstyle), ::core::mem::transmute(&szregister), ::core::mem::transmute_copy(&pdata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *penum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -973,7 +973,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetCandidateWindow(::core::mem::transmute_copy(&himc), ::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcandidate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcandidate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -984,7 +984,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompositionFontA(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -995,7 +995,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompositionFontW(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1016,7 +1016,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompositionWindow(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcompform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcompform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1027,7 +1027,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phimc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phimc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1053,7 +1053,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultIMEWnd(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phdefwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phdefwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1099,7 +1099,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&hkl), ::core::mem::transmute_copy(&fdwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1120,7 +1120,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatusWindowPos(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptpos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptpos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1131,7 +1131,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetVirtualKey(::core::mem::transmute_copy(&hwnd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puvirtualkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puvirtualkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1142,7 +1142,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.InstallIMEA(::core::mem::transmute(&szimefilename), ::core::mem::transmute(&szlayouttext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1153,7 +1153,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.InstallIMEW(::core::mem::transmute(&szimefilename), ::core::mem::transmute(&szlayouttext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1264,7 +1264,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.LockIMC(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1280,7 +1280,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetIMCLockCount(::core::mem::transmute_copy(&himc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlockcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlockcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1291,7 +1291,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.CreateIMCC(::core::mem::transmute_copy(&dwsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phimcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phimcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1317,7 +1317,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.ReSizeIMCC(::core::mem::transmute_copy(&himcc), ::core::mem::transmute_copy(&dwsize)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phimcc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phimcc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1328,7 +1328,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetIMCCSize(::core::mem::transmute_copy(&himcc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1339,7 +1339,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetIMCCLockCount(::core::mem::transmute_copy(&himcc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwlockcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwlockcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1360,7 +1360,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSoftKeyboard(::core::mem::transmute_copy(&utype), ::core::mem::transmute_copy(&howner), ::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phsoftkbdwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phsoftkbdwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1381,7 +1381,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodePageA(::core::mem::transmute_copy(&hkl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ucodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ucodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1392,7 +1392,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.GetLangId(::core::mem::transmute_copy(&hkl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1438,7 +1438,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.EnumInputContext(::core::mem::transmute_copy(&idthread)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1449,7 +1449,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.RequestMessageA(::core::mem::transmute_copy(&himc), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1460,7 +1460,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.RequestMessageW(::core::mem::transmute_copy(&himc), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1471,7 +1471,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.SendIMCA(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1482,7 +1482,7 @@ impl IActiveIMMIME_Vtbl {
             let this = (*this).get_impl();
             match this.SendIMCW(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1622,7 +1622,7 @@ impl IActiveIMMMessagePumpOwner_Vtbl {
             let this = (*this).get_impl();
             match this.Pause() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1690,7 +1690,7 @@ impl IEnumInputContext_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1737,7 +1737,7 @@ impl IEnumRegisterWordA_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1784,7 +1784,7 @@ impl IEnumRegisterWordW_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
@@ -60,7 +60,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialOriginX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *x = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(x, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -76,7 +76,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialOriginY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *y = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(y, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -92,7 +92,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialVelocityX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *x = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(x, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -108,7 +108,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialVelocityY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *y = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(y, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -124,7 +124,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialAngularVelocity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *velocity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(velocity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -140,7 +140,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialExpansionVelocity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *velocity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(velocity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -156,7 +156,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialRadius() {
                 ::core::result::Result::Ok(ok__) => {
-                    *radius = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(radius, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -172,7 +172,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.BoundaryLeft() {
                 ::core::result::Result::Ok(ok__) => {
-                    *left = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(left, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -188,7 +188,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.BoundaryTop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *top = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(top, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.BoundaryRight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *right = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(right, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -220,7 +220,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.BoundaryBottom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bottom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bottom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -236,7 +236,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.ElasticMarginLeft() {
                 ::core::result::Result::Ok(ok__) => {
-                    *left = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(left, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -252,7 +252,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.ElasticMarginTop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *top = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(top, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -268,7 +268,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.ElasticMarginRight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *right = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(right, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -284,7 +284,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.ElasticMarginBottom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bottom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bottom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -300,7 +300,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredDisplacement() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displacement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displacement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -316,7 +316,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredRotation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rotation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rotation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -332,7 +332,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredExpansion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *expansion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expansion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -348,7 +348,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredDeceleration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deceleration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deceleration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -364,7 +364,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredAngularDeceleration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deceleration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deceleration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -380,7 +380,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredExpansionDeceleration() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deceleration = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deceleration, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -396,7 +396,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.InitialTimestamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *timestamp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(timestamp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -417,7 +417,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.Process() {
                 ::core::result::Result::Ok(ok__) => {
-                    *completed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(completed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -428,7 +428,7 @@ impl IInertiaProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.ProcessTime(::core::mem::transmute_copy(&timestamp)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *completed = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(completed, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -532,7 +532,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedManipulations() {
                 ::core::result::Result::Ok(ok__) => {
-                    *manipulations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(manipulations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -548,7 +548,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.PivotPointX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivotpointx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivotpointx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -564,7 +564,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.PivotPointY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivotpointy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivotpointy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -580,7 +580,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.PivotRadius() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pivotradius = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pivotradius, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -631,7 +631,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetVelocityX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *velocityx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(velocityx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -642,7 +642,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetVelocityY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *velocityy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(velocityy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -653,7 +653,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetExpansionVelocity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *expansionvelocity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expansionvelocity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -664,7 +664,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetAngularVelocity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *angularvelocity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(angularvelocity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -675,7 +675,7 @@ impl IManipulationProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.MinimumScaleRotateRadius() {
                 ::core::result::Result::Ok(ok__) => {
-                    *minradius = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(minradius, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
@@ -141,7 +141,7 @@ impl IEmptyVolumeCache_Vtbl {
             let this = (*this).get_impl();
             match this.Deactivate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -227,7 +227,7 @@ impl IReconcilableObject_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgressFeedbackMaxEstimate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulprogressmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulprogressmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
@@ -16,7 +16,7 @@ impl IUIApplication_Vtbl {
             let this = (*this).get_impl();
             match this.OnCreateUICommand(::core::mem::transmute_copy(&commandid), ::core::mem::transmute_copy(&typeid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *commandhandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(commandhandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -55,7 +55,7 @@ impl IUICollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -66,7 +66,7 @@ impl IUICollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -149,7 +149,7 @@ impl IUICommandHandler_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateProperty(::core::mem::transmute_copy(&commandid), ::core::mem::transmute_copy(&key), ::core::mem::transmute_copy(&currentvalue)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -258,7 +258,7 @@ impl IUIFramework_Vtbl {
             let this = (*this).get_impl();
             match this.GetUICommandProperty(::core::mem::transmute_copy(&commandid), ::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -315,7 +315,7 @@ impl IUIImage_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitmap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -341,7 +341,7 @@ impl IUIImageFromBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImage(::core::mem::transmute_copy(&bitmap), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *image = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(image, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -369,7 +369,7 @@ impl IUIRibbon_Vtbl {
             let this = (*this).get_impl();
             match this.GetHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -410,7 +410,7 @@ impl IUISimplePropertySet_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
@@ -10,7 +10,7 @@ impl IObjectArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcobjects = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcobjects, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
@@ -86,7 +86,7 @@ impl INamedPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetNamedValue(::core::mem::transmute(&pszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -102,7 +102,7 @@ impl INamedPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -113,7 +113,7 @@ impl INamedPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetNameAt(::core::mem::transmute_copy(&iprop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -148,7 +148,7 @@ impl IObjectWithPropertyKey_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -210,7 +210,7 @@ impl IPersistSerializedPropStorage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyStorageSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -245,7 +245,7 @@ impl IPropertyChange_Vtbl {
             let this = (*this).get_impl();
             match this.ApplyToPropVariant(::core::mem::transmute_copy(&propvarin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvarout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvarout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -274,7 +274,7 @@ impl IPropertyChangeArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcoperations = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcoperations, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -359,7 +359,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyKey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -370,7 +370,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetCanonicalName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -381,7 +381,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvartype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvartype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -392,7 +392,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -403,7 +403,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetEditInvitation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszinvite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszinvite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -414,7 +414,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeFlags(::core::mem::transmute_copy(&mask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdtflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdtflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -425,7 +425,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdvflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdvflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -436,7 +436,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultColumnWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcxchars = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcxchars, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -447,7 +447,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdisplaytype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdisplaytype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -458,7 +458,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcsflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcsflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -469,7 +469,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroupingRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -480,7 +480,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelativeDescriptionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -496,7 +496,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetSortDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -507,7 +507,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetSortDescriptionLabel(::core::mem::transmute_copy(&fdescending)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -518,7 +518,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.GetAggregationType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *paggtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paggtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -544,7 +544,7 @@ impl IPropertyDescription_Vtbl {
             let this = (*this).get_impl();
             match this.FormatForDisplay(::core::mem::transmute_copy(&propvar), ::core::mem::transmute_copy(&pdfflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdisplay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdisplay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -598,7 +598,7 @@ impl IPropertyDescription2_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageReferenceForValue(::core::mem::transmute_copy(&propvar)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszimageres = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszimageres, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -655,7 +655,7 @@ impl IPropertyDescriptionList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcelem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcelem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -713,7 +713,7 @@ impl IPropertyDescriptionSearchInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSearchInfoFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdsiflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdsiflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -724,7 +724,7 @@ impl IPropertyDescriptionSearchInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnIndexType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdcitype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdcitype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -735,7 +735,7 @@ impl IPropertyDescriptionSearchInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetProjectionString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszprojection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszprojection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -746,7 +746,7 @@ impl IPropertyDescriptionSearchInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbmaxsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbmaxsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -782,7 +782,7 @@ impl IPropertyEnumType_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penumtype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penumtype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -793,7 +793,7 @@ impl IPropertyEnumType_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -804,7 +804,7 @@ impl IPropertyEnumType_Vtbl {
             let this = (*this).get_impl();
             match this.GetRangeMinValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvarmin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvarmin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -815,7 +815,7 @@ impl IPropertyEnumType_Vtbl {
             let this = (*this).get_impl();
             match this.GetRangeSetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvarset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvarset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -826,7 +826,7 @@ impl IPropertyEnumType_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdisplay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdisplay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -859,7 +859,7 @@ impl IPropertyEnumType2_Vtbl {
             let this = (*this).get_impl();
             match this.GetImageReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszimageres = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszimageres, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -888,7 +888,7 @@ impl IPropertyEnumTypeList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pctypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pctypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -909,7 +909,7 @@ impl IPropertyEnumTypeList_Vtbl {
             let this = (*this).get_impl();
             match this.FindMatchingIndex(::core::mem::transmute_copy(&propvarcmp)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -945,7 +945,7 @@ impl IPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cprops = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cprops, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -956,7 +956,7 @@ impl IPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&iprop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -967,7 +967,7 @@ impl IPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1013,7 +1013,7 @@ impl IPropertyStoreCache_Vtbl {
             let this = (*this).get_impl();
             match this.GetState(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1137,7 +1137,7 @@ impl IPropertySystem_Vtbl {
             let this = (*this).get_impl();
             match this.FormatForDisplayAlloc(::core::mem::transmute_copy(&key), ::core::mem::transmute_copy(&propvar), ::core::mem::transmute_copy(&pdff)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdisplay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdisplay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1233,7 +1233,7 @@ impl IPropertyUI_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultWidth(::core::mem::transmute_copy(&fmtid), ::core::mem::transmute_copy(&pid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcxchars = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcxchars, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1244,7 +1244,7 @@ impl IPropertyUI_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags(::core::mem::transmute_copy(&fmtid), ::core::mem::transmute_copy(&pid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
@@ -43,7 +43,7 @@ impl DFConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -54,7 +54,7 @@ impl DFConstraint_Vtbl {
             let this = (*this).get_impl();
             match this.Value() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -158,7 +158,7 @@ impl Folder_Vtbl {
             let this = (*this).get_impl();
             match this.Title() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -169,7 +169,7 @@ impl Folder_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -180,7 +180,7 @@ impl Folder_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -191,7 +191,7 @@ impl Folder_Vtbl {
             let this = (*this).get_impl();
             match this.ParentFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -202,7 +202,7 @@ impl Folder_Vtbl {
             let this = (*this).get_impl();
             match this.Items() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -213,7 +213,7 @@ impl Folder_Vtbl {
             let this = (*this).get_impl();
             match this.ParseName(::core::mem::transmute(&bname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -239,7 +239,7 @@ impl Folder_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsOf(::core::mem::transmute(&vitem), ::core::mem::transmute_copy(&icolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -281,7 +281,7 @@ impl Folder2_Vtbl {
             let this = (*this).get_impl();
             match this.Self_() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -292,7 +292,7 @@ impl Folder2_Vtbl {
             let this = (*this).get_impl();
             match this.OfflineStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pul = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pul, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -308,7 +308,7 @@ impl Folder2_Vtbl {
             let this = (*this).get_impl();
             match this.HaveToShowWebViewBarricade() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbhavetoshowwebviewbarricade = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbhavetoshowwebviewbarricade, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -347,7 +347,7 @@ impl Folder3_Vtbl {
             let this = (*this).get_impl();
             match this.ShowWebViewBarricade() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbshowwebviewbarricade = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbshowwebviewbarricade, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -398,7 +398,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -409,7 +409,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -420,7 +420,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -436,7 +436,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -447,7 +447,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -458,7 +458,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -469,7 +469,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsLink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -480,7 +480,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -491,7 +491,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsFileSystem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -502,7 +502,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.IsBrowsable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -513,7 +513,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.ModifyDate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -529,7 +529,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.Size() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pul = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pul, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -551,7 +551,7 @@ impl FolderItem_Vtbl {
             let this = (*this).get_impl();
             match this.Verbs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -607,7 +607,7 @@ impl FolderItem2_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedProperty(::core::mem::transmute(&bstrpropname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvret = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvret, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -640,7 +640,7 @@ impl FolderItemVerb_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -651,7 +651,7 @@ impl FolderItemVerb_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -662,7 +662,7 @@ impl FolderItemVerb_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -703,7 +703,7 @@ impl FolderItemVerbs_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -714,7 +714,7 @@ impl FolderItemVerbs_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -725,7 +725,7 @@ impl FolderItemVerbs_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -736,7 +736,7 @@ impl FolderItemVerbs_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -747,7 +747,7 @@ impl FolderItemVerbs_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -784,7 +784,7 @@ impl FolderItems_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -795,7 +795,7 @@ impl FolderItems_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -806,7 +806,7 @@ impl FolderItems_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -817,7 +817,7 @@ impl FolderItems_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -828,7 +828,7 @@ impl FolderItems_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -887,7 +887,7 @@ impl FolderItems3_Vtbl {
             let this = (*this).get_impl();
             match this.Verbs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -933,7 +933,7 @@ impl IACList2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1054,7 +1054,7 @@ impl IActionProgress_Vtbl {
             let this = (*this).get_impl();
             match this.QueryCancel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcancelled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcancelled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1129,7 +1129,7 @@ impl IAppActivationUIInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetMonitor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1140,7 +1140,7 @@ impl IAppActivationUIInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetInvokePoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1151,7 +1151,7 @@ impl IAppActivationUIInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetShowCommand() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1162,7 +1162,7 @@ impl IAppActivationUIInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetShowUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1173,7 +1173,7 @@ impl IAppActivationUIInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1206,7 +1206,7 @@ impl IAppPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1217,7 +1217,7 @@ impl IAppPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pappcategorylist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pappcategorylist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1228,7 +1228,7 @@ impl IAppPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOfApps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwapps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwapps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1239,7 +1239,7 @@ impl IAppPublisher_Vtbl {
             let this = (*this).get_impl();
             match this.EnumApps(::core::mem::transmute_copy(&pappcategoryid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppepa = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppepa, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1274,7 +1274,7 @@ impl IAppVisibility_Vtbl {
             let this = (*this).get_impl();
             match this.GetAppVisibilityOnMonitor(::core::mem::transmute_copy(&hmonitor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1285,7 +1285,7 @@ impl IAppVisibility_Vtbl {
             let this = (*this).get_impl();
             match this.IsLauncherVisible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvisible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvisible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1296,7 +1296,7 @@ impl IAppVisibility_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&pcallback)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1362,7 +1362,7 @@ impl IApplicationActivationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateApplication(::core::mem::transmute(&appusermodelid), ::core::mem::transmute(&arguments), ::core::mem::transmute_copy(&options)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *processid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(processid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1373,7 +1373,7 @@ impl IApplicationActivationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateForFile(::core::mem::transmute(&appusermodelid), ::core::mem::transmute(&itemarray), ::core::mem::transmute(&verb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *processid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(processid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1384,7 +1384,7 @@ impl IApplicationActivationManager_Vtbl {
             let this = (*this).get_impl();
             match this.ActivateForProtocol(::core::mem::transmute(&appusermodelid), ::core::mem::transmute(&itemarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *processid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(processid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1420,7 +1420,7 @@ impl IApplicationAssociationRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.QueryCurrentDefault(::core::mem::transmute(&pszquery), ::core::mem::transmute_copy(&atquerytype), ::core::mem::transmute_copy(&alquerylevel)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszassociation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszassociation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1431,7 +1431,7 @@ impl IApplicationAssociationRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAppIsDefault(::core::mem::transmute(&pszquery), ::core::mem::transmute_copy(&atquerytype), ::core::mem::transmute_copy(&alquerylevel), ::core::mem::transmute(&pszappregistryname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdefault = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdefault, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1442,7 +1442,7 @@ impl IApplicationAssociationRegistration_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAppIsDefaultAll(::core::mem::transmute_copy(&alquerylevel), ::core::mem::transmute(&pszappregistryname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdefault = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdefault, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1531,7 +1531,7 @@ impl IApplicationDesignModeSettings_Vtbl {
             let this = (*this).get_impl();
             match this.ComputeApplicationSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *applicationsizepixels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(applicationsizepixels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1542,7 +1542,7 @@ impl IApplicationDesignModeSettings_Vtbl {
             let this = (*this).get_impl();
             match this.IsApplicationViewStateSupported(::core::mem::transmute_copy(&viewstate), ::core::mem::transmute(&nativedisplaysizepixels), ::core::mem::transmute_copy(&scalefactor)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1617,7 +1617,7 @@ impl IApplicationDesignModeSettings2_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationViewOrientation(::core::mem::transmute(&applicationsizepixels)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *vieworientation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(vieworientation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1719,7 +1719,7 @@ impl IAssocHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1730,7 +1730,7 @@ impl IAssocHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetUIName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1761,7 +1761,7 @@ impl IAssocHandler_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInvoker(::core::mem::transmute(&pdo)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinvoker = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinvoker, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1869,7 +1869,7 @@ impl IAttachmentExecute_Vtbl {
             let this = (*this).get_impl();
             match this.Prompt(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&prompt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *paction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(paction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1885,7 +1885,7 @@ impl IAttachmentExecute_Vtbl {
             let this = (*this).get_impl();
             match this.Execute(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&pszverb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phprocess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phprocess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1967,7 +1967,7 @@ impl IAutoComplete2_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2073,7 +2073,7 @@ impl IBandSite_Vtbl {
             let this = (*this).get_impl();
             match this.EnumBands(::core::mem::transmute_copy(&uband)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwbandid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwbandid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2164,7 +2164,7 @@ impl IBanneredBar_Vtbl {
             let this = (*this).get_impl();
             match this.GetIconSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2180,7 +2180,7 @@ impl IBanneredBar_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitmap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbitmap = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbitmap, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2209,7 +2209,7 @@ impl IBrowserFrameOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetFrameOptions(::core::mem::transmute_copy(&dwmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2264,7 +2264,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentSite() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppipsite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppipsite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2285,7 +2285,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetOleObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppobjv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppobjv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2296,7 +2296,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetTravelLog() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2312,7 +2312,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.IsControlWindowShown(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfshown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfshown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2328,7 +2328,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.IEParseDisplayName(::core::mem::transmute_copy(&uicp), ::core::mem::transmute(&pwszpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidlout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidlout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2354,7 +2354,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetNavigateState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbnstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbnstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2365,7 +2365,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.NotifyRedirect(::core::mem::transmute(&psv), ::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdidbrowse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdidbrowse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2391,7 +2391,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2407,7 +2407,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetPidl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2428,7 +2428,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetBrowserByIndex(::core::mem::transmute_copy(&dwid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2454,7 +2454,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetSetCodePage(::core::mem::transmute_copy(&pvarin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2465,7 +2465,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.OnHttpEquiv(::core::mem::transmute(&psv), ::core::mem::transmute_copy(&fdone), ::core::mem::transmute_copy(&pvarargin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarargout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarargout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2476,7 +2476,7 @@ impl IBrowserService_Vtbl {
             let this = (*this).get_impl();
             match this.GetPalette() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hpal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hpal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2610,7 +2610,7 @@ impl IBrowserService2_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewRect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2666,7 +2666,7 @@ impl IBrowserService2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateViewWindow(::core::mem::transmute(&psvnew), ::core::mem::transmute(&psvold), ::core::mem::transmute_copy(&prcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2682,7 +2682,7 @@ impl IBrowserService2_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2693,7 +2693,7 @@ impl IBrowserService2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBaseBrowserData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbbd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbbd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3019,7 +3019,7 @@ impl IBrowserService3_Vtbl {
             let this = (*this).get_impl();
             match this.IEParseDisplayNameEx(::core::mem::transmute_copy(&uicp), ::core::mem::transmute(&pwszpath), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidlout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidlout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3098,7 +3098,7 @@ impl ICDBurn_Vtbl {
             let this = (*this).get_impl();
             match this.HasRecordableDrive() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfhasrecorder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfhasrecorder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3126,7 +3126,7 @@ impl ICDBurnExt_Vtbl {
             let this = (*this).get_impl();
             match this.GetSupportedActionTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwactions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwactions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3165,7 +3165,7 @@ impl ICategorizer_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategoryInfo(::core::mem::transmute_copy(&dwcategoryid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pci = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pci, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3217,7 +3217,7 @@ impl ICategoryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategoryForSCID(::core::mem::transmute_copy(&pscid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3228,7 +3228,7 @@ impl ICategoryProvider_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCategories() {
                 ::core::result::Result::Ok(ok__) => {
-                    *penum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(penum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3286,7 +3286,7 @@ impl IColumnManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnCount(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3336,7 +3336,7 @@ impl IColumnProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetColumnInfo(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psci = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psci, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3347,7 +3347,7 @@ impl IColumnProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemData(::core::mem::transmute_copy(&pscid), ::core::mem::transmute_copy(&pscd)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvardata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvardata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3427,7 +3427,7 @@ impl ICommDlgBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3619,7 +3619,7 @@ impl IContextMenu3_Vtbl {
             let this = (*this).get_impl();
             match this.HandleMenuMsg2(::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3728,7 +3728,7 @@ impl ICreateProcessInputs_Vtbl {
             let this = (*this).get_impl();
             match this.GetCreateFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcreationflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcreationflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3837,7 +3837,7 @@ impl ICredentialProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldDescriptorCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3848,7 +3848,7 @@ impl ICredentialProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldDescriptorAt(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcpfd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcpfd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3864,7 +3864,7 @@ impl ICredentialProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetCredentialAt(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcpc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcpc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3926,7 +3926,7 @@ impl ICredentialProviderCredential_Vtbl {
             let this = (*this).get_impl();
             match this.SetSelected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbautologon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbautologon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3947,7 +3947,7 @@ impl ICredentialProviderCredential_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute_copy(&dwfieldid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3958,7 +3958,7 @@ impl ICredentialProviderCredential_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitmapValue(::core::mem::transmute_copy(&dwfieldid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbmp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbmp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3974,7 +3974,7 @@ impl ICredentialProviderCredential_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubmitButtonValue(::core::mem::transmute_copy(&dwfieldid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwadjacentto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwadjacentto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3990,7 +3990,7 @@ impl ICredentialProviderCredential_Vtbl {
             let this = (*this).get_impl();
             match this.GetComboBoxValueAt(::core::mem::transmute_copy(&dwfieldid), ::core::mem::transmute_copy(&dwitem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4065,7 +4065,7 @@ impl ICredentialProviderCredential2_Vtbl {
             let this = (*this).get_impl();
             match this.GetUserSid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4145,7 +4145,7 @@ impl ICredentialProviderCredentialEvents_Vtbl {
             let this = (*this).get_impl();
             match this.OnCreatingWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndowner = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndowner, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4217,7 +4217,7 @@ impl ICredentialProviderCredentialWithFieldOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetFieldOptions(::core::mem::transmute_copy(&fieldid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *options = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(options, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4266,7 +4266,7 @@ impl ICredentialProviderFilter_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateRemoteCredential(::core::mem::transmute_copy(&pcpcsin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcpcsout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcpcsout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4316,7 +4316,7 @@ impl ICredentialProviderUser_Vtbl {
             let this = (*this).get_impl();
             match this.GetSid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4327,7 +4327,7 @@ impl ICredentialProviderUser_Vtbl {
             let this = (*this).get_impl();
             match this.GetProviderID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *providerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(providerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4338,7 +4338,7 @@ impl ICredentialProviderUser_Vtbl {
             let this = (*this).get_impl();
             match this.GetStringValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stringvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stringvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4349,7 +4349,7 @@ impl ICredentialProviderUser_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4386,7 +4386,7 @@ impl ICredentialProviderUserArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetAccountOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *credentialprovideraccountoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(credentialprovideraccountoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4397,7 +4397,7 @@ impl ICredentialProviderUserArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *usercount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(usercount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4408,7 +4408,7 @@ impl ICredentialProviderUserArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&userindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *user = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(user, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4568,7 +4568,7 @@ impl IDataObjectAsyncCapability_Vtbl {
             let this = (*this).get_impl();
             match this.GetAsyncMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfisopasync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfisopasync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4584,7 +4584,7 @@ impl IDataObjectAsyncCapability_Vtbl {
             let this = (*this).get_impl();
             match this.InOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinasyncop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinasyncop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4623,7 +4623,7 @@ impl IDataObjectProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataObject() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4759,7 +4759,7 @@ impl IDefaultFolderMenuInitialize_Vtbl {
             let this = (*this).get_impl();
             match this.GetMenuRestrictions(::core::mem::transmute_copy(&dfmrmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdfmrvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdfmrvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4851,7 +4851,7 @@ impl IDeskBand2_Vtbl {
             let this = (*this).get_impl();
             match this.CanRenderComposited() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcanrendercomposited = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcanrendercomposited, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4867,7 +4867,7 @@ impl IDeskBand2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompositionState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcompositionenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcompositionenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4895,7 +4895,7 @@ impl IDeskBandInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultBandWidth(::core::mem::transmute_copy(&dwbandid), ::core::mem::transmute_copy(&dwviewmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4928,7 +4928,7 @@ impl IDeskBar_Vtbl {
             let this = (*this).get_impl();
             match this.GetClient() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkclient = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkclient, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4982,7 +4982,7 @@ impl IDeskBarClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize(::core::mem::transmute_copy(&dwwhich)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5051,7 +5051,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetWallpaper(::core::mem::transmute(&monitorid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *wallpaper = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wallpaper, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5062,7 +5062,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetMonitorDevicePathAt(::core::mem::transmute_copy(&monitorindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *monitorid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(monitorid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5073,7 +5073,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetMonitorDevicePathCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5084,7 +5084,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetMonitorRECT(::core::mem::transmute(&monitorid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *displayrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displayrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5100,7 +5100,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetBackgroundColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *color = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(color, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5116,7 +5116,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *position = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(position, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5132,7 +5132,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetSlideshow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *items = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(items, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5158,7 +5158,7 @@ impl IDesktopWallpaper_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5207,7 +5207,7 @@ impl IDestinationStreamFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDestinationStream() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5342,7 +5342,7 @@ impl IDockingWindowSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetBorderDW(::core::mem::transmute(&punkobj)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prcborder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prcborder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5481,7 +5481,7 @@ impl IDynamicHWHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetDynamicInfo(::core::mem::transmute(&pszdeviceid), ::core::mem::transmute_copy(&dwcontenttype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5519,7 +5519,7 @@ impl IEnumACString_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5582,7 +5582,7 @@ impl IEnumExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5629,7 +5629,7 @@ impl IEnumExtraSearch_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5679,7 +5679,7 @@ impl IEnumFullIDList_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5726,7 +5726,7 @@ impl IEnumHLITEM_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumhlitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumhlitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5776,7 +5776,7 @@ impl IEnumIDList_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5823,7 +5823,7 @@ impl IEnumObjects_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5853,7 +5853,7 @@ impl IEnumPublishedApps_Vtbl {
             let this = (*this).get_impl();
             match this.Next() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pia = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pia, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5916,7 +5916,7 @@ impl IEnumResources_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5963,7 +5963,7 @@ impl IEnumShellItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6010,7 +6010,7 @@ impl IEnumSyncMgrConflict_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6057,7 +6057,7 @@ impl IEnumSyncMgrEvents_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6104,7 +6104,7 @@ impl IEnumSyncMgrSyncItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6151,7 +6151,7 @@ impl IEnumTravelLogEntry_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6189,7 +6189,7 @@ impl IEnumerableView_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEnumIDListFromContents(::core::mem::transmute_copy(&pidlfolder), ::core::mem::transmute_copy(&dwenumflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumidlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumidlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6281,7 +6281,7 @@ impl IExecuteCommandApplicationHostEnvironment_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pahe = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pahe, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6304,7 +6304,7 @@ impl IExecuteCommandHost_Vtbl {
             let this = (*this).get_impl();
             match this.GetUIMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puimode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puimode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6332,7 +6332,7 @@ impl IExpDispSupport_Vtbl {
             let this = (*this).get_impl();
             match this.FindConnectionPoint(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppccp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppccp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6375,7 +6375,7 @@ impl IExpDispSupportXP_Vtbl {
             let this = (*this).get_impl();
             match this.FindCIE4ConnectionPoint(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppccp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppccp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6460,7 +6460,7 @@ impl IExplorerBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&psbe)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6481,7 +6481,7 @@ impl IExplorerBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6600,7 +6600,7 @@ impl IExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitle(::core::mem::transmute(&psiitemarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6611,7 +6611,7 @@ impl IExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetIcon(::core::mem::transmute(&psiitemarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6622,7 +6622,7 @@ impl IExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetToolTip(::core::mem::transmute(&psiitemarray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszinfotip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszinfotip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6633,7 +6633,7 @@ impl IExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetCanonicalName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidcommandname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidcommandname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6644,7 +6644,7 @@ impl IExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetState(::core::mem::transmute(&psiitemarray), ::core::mem::transmute_copy(&foktobeslow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmdstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmdstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6660,7 +6660,7 @@ impl IExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6671,7 +6671,7 @@ impl IExplorerCommand_Vtbl {
             let this = (*this).get_impl();
             match this.EnumSubCommands() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6734,7 +6734,7 @@ impl IExplorerCommandState_Vtbl {
             let this = (*this).get_impl();
             match this.GetState(::core::mem::transmute(&psiitemarray), ::core::mem::transmute_copy(&foktobeslow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmdstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmdstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6757,7 +6757,7 @@ impl IExplorerPaneVisibility_Vtbl {
             let this = (*this).get_impl();
             match this.GetPaneState(::core::mem::transmute_copy(&ep)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *peps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(peps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6879,7 +6879,7 @@ impl IExtractImage_Vtbl {
             let this = (*this).get_impl();
             match this.Extract() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbmpthumbnail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbmpthumbnail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6909,7 +6909,7 @@ impl IExtractImage2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDateStamp() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatestamp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatestamp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6967,7 +6967,7 @@ impl IFileDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileTypeIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pifiletype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pifiletype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6978,7 +6978,7 @@ impl IFileDialog_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&pfde)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6999,7 +6999,7 @@ impl IFileDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfos = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfos, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7020,7 +7020,7 @@ impl IFileDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7031,7 +7031,7 @@ impl IFileDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7047,7 +7047,7 @@ impl IFileDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7073,7 +7073,7 @@ impl IFileDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7304,7 +7304,7 @@ impl IFileDialogCustomize_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlState(::core::mem::transmute_copy(&dwidctl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7320,7 +7320,7 @@ impl IFileDialogCustomize_Vtbl {
             let this = (*this).get_impl();
             match this.GetEditBoxText(::core::mem::transmute_copy(&dwidctl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7336,7 +7336,7 @@ impl IFileDialogCustomize_Vtbl {
             let this = (*this).get_impl();
             match this.GetCheckButtonState(::core::mem::transmute_copy(&dwidctl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbchecked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbchecked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7367,7 +7367,7 @@ impl IFileDialogCustomize_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlItemState(::core::mem::transmute_copy(&dwidctl), ::core::mem::transmute_copy(&dwiditem)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7383,7 +7383,7 @@ impl IFileDialogCustomize_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedControlItem(::core::mem::transmute_copy(&dwidctl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwiditem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwiditem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7486,7 +7486,7 @@ impl IFileDialogEvents_Vtbl {
             let this = (*this).get_impl();
             match this.OnShareViolation(::core::mem::transmute(&pfd), ::core::mem::transmute(&psi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7502,7 +7502,7 @@ impl IFileDialogEvents_Vtbl {
             let this = (*this).get_impl();
             match this.OnOverwrite(::core::mem::transmute(&pfd), ::core::mem::transmute(&psi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presponse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presponse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7541,7 +7541,7 @@ impl IFileIsInUse_Vtbl {
             let this = (*this).get_impl();
             match this.GetAppName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7552,7 +7552,7 @@ impl IFileIsInUse_Vtbl {
             let this = (*this).get_impl();
             match this.GetUsage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfut = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfut, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7563,7 +7563,7 @@ impl IFileIsInUse_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcapflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcapflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7574,7 +7574,7 @@ impl IFileIsInUse_Vtbl {
             let this = (*this).get_impl();
             match this.GetSwitchToHWND() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7613,7 +7613,7 @@ impl IFileOpenDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetResults() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7624,7 +7624,7 @@ impl IFileOpenDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsai = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsai, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7673,7 +7673,7 @@ impl IFileOperation_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&pfops)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7774,7 +7774,7 @@ impl IFileOperation_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnyOperationsAborted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfanyoperationsaborted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfanyoperationsaborted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7986,7 +7986,7 @@ impl IFileSaveDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8038,7 +8038,7 @@ impl IFileSearchBand_Vtbl {
             let this = (*this).get_impl();
             match this.SearchID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsearchid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsearchid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8049,7 +8049,7 @@ impl IFileSearchBand_Vtbl {
             let this = (*this).get_impl();
             match this.Scope() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarscope = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarscope, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8060,7 +8060,7 @@ impl IFileSearchBand_Vtbl {
             let this = (*this).get_impl();
             match this.QueryFile() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarfile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarfile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8094,7 +8094,7 @@ impl IFileSyncMergeHandler_Vtbl {
             let this = (*this).get_impl();
             match this.Merge(::core::mem::transmute(&localfilepath), ::core::mem::transmute(&serverfilepath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *updatestatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(updatestatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8135,7 +8135,7 @@ impl IFileSystemBindData_Vtbl {
             let this = (*this).get_impl();
             match this.GetFindData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8173,7 +8173,7 @@ impl IFileSystemBindData2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plifileid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plifileid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8189,7 +8189,7 @@ impl IFileSystemBindData2_Vtbl {
             let this = (*this).get_impl();
             match this.GetJunctionCLSID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8325,7 +8325,7 @@ impl IFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentViewMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pviewmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pviewmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8346,7 +8346,7 @@ impl IFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&iitemindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8357,7 +8357,7 @@ impl IFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.ItemCount(::core::mem::transmute_copy(&uflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8373,7 +8373,7 @@ impl IFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectionMarkedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8384,7 +8384,7 @@ impl IFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocusedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8395,7 +8395,7 @@ impl IFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemPosition(::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8411,7 +8411,7 @@ impl IFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultSpacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8507,7 +8507,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewProperty(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&propkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8538,7 +8538,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentFolderFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8549,7 +8549,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSortColumnCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pccolumns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pccolumns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8575,7 +8575,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetVisibleItem(::core::mem::transmute_copy(&istart), ::core::mem::transmute_copy(&fprevious)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8586,7 +8586,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedItem(::core::mem::transmute_copy(&istart)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8597,7 +8597,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection(::core::mem::transmute_copy(&fnoneimpliesfolder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsia = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsia, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8608,7 +8608,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectionState(::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8639,7 +8639,7 @@ impl IFolderView2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroupSubsetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcvisiblerows = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcvisiblerows, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8750,7 +8750,7 @@ impl IFolderViewOptions_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderViewOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvoflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvoflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8796,7 +8796,7 @@ impl IFolderViewSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plvm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plvm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8807,7 +8807,7 @@ impl IFolderViewSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetIconSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiconsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiconsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8828,7 +8828,7 @@ impl IFolderViewSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetGroupSubsetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcvisiblerows = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcvisiblerows, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8866,7 +8866,7 @@ impl IFrameworkInputPane_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&pwindow), ::core::mem::transmute(&phandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8877,7 +8877,7 @@ impl IFrameworkInputPane_Vtbl {
             let this = (*this).get_impl();
             match this.AdviseWithHWND(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&phandler)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8893,7 +8893,7 @@ impl IFrameworkInputPane_Vtbl {
             let this = (*this).get_impl();
             match this.Location() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prcinputpanescreenlocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prcinputpanescreenlocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9055,7 +9055,7 @@ impl IHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9066,7 +9066,7 @@ impl IHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationPublisher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9077,7 +9077,7 @@ impl IHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationIconReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9105,7 +9105,7 @@ impl IHandlerInfo2_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplicationId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9179,7 +9179,7 @@ impl IHlink_Vtbl {
             let this = (*this).get_impl();
             match this.GetFriendlyName(::core::mem::transmute_copy(&grfhlfnamef)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwzfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwzfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9195,7 +9195,7 @@ impl IHlink_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetFrameName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwztargetframename = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwztargetframename, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9206,7 +9206,7 @@ impl IHlink_Vtbl {
             let this = (*this).get_impl();
             match this.GetMiscStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9227,7 +9227,7 @@ impl IHlink_Vtbl {
             let this = (*this).get_impl();
             match this.GetAdditionalParams() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwzadditionalparams = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwzadditionalparams, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9282,7 +9282,7 @@ impl IHlinkBrowseContext_Vtbl {
             let this = (*this).get_impl();
             match this.Register(::core::mem::transmute_copy(&reserved), ::core::mem::transmute(&piunk), ::core::mem::transmute(&pimk)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwregister = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwregister, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9293,7 +9293,7 @@ impl IHlinkBrowseContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetObject(::core::mem::transmute(&pimk), ::core::mem::transmute_copy(&fbindifrootregistered)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9314,7 +9314,7 @@ impl IHlinkBrowseContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetBrowseWindowInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phlbwi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phlbwi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9330,7 +9330,7 @@ impl IHlinkBrowseContext_Vtbl {
             let this = (*this).get_impl();
             match this.OnNavigateHlink(::core::mem::transmute_copy(&grfhlnf), ::core::mem::transmute(&pimktarget), ::core::mem::transmute(&pwzlocation), ::core::mem::transmute(&pwzfriendlyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puhlid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puhlid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9346,7 +9346,7 @@ impl IHlinkBrowseContext_Vtbl {
             let this = (*this).get_impl();
             match this.EnumNavigationStack(::core::mem::transmute_copy(&dwreserved), ::core::mem::transmute_copy(&grfhlfnamef)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppienumhlitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppienumhlitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9362,7 +9362,7 @@ impl IHlinkBrowseContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetHlink(::core::mem::transmute_copy(&uhlid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppihl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppihl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9378,7 +9378,7 @@ impl IHlinkBrowseContext_Vtbl {
             let this = (*this).get_impl();
             match this.Clone(::core::mem::transmute(&piunkouter), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunkobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunkobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9434,7 +9434,7 @@ impl IHlinkFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetBrowseContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppihlbc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppihlbc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9485,7 +9485,7 @@ impl IHlinkSite_Vtbl {
             let this = (*this).get_impl();
             match this.QueryService(::core::mem::transmute_copy(&dwsitedata), ::core::mem::transmute_copy(&guidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9496,7 +9496,7 @@ impl IHlinkSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetMoniker(::core::mem::transmute_copy(&dwsitedata), ::core::mem::transmute_copy(&dwassign), ::core::mem::transmute_copy(&dwwhich)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9547,7 +9547,7 @@ impl IHlinkTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetBrowseContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppihlbc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppihlbc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9563,7 +9563,7 @@ impl IHlinkTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetMoniker(::core::mem::transmute(&pwzlocation), ::core::mem::transmute_copy(&dwassign)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppimklocation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppimklocation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9574,7 +9574,7 @@ impl IHlinkTarget_Vtbl {
             let this = (*this).get_impl();
             match this.GetFriendlyName(::core::mem::transmute(&pwzlocation)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwzfriendlyname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwzfriendlyname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9608,7 +9608,7 @@ impl IHomeGroup_Vtbl {
             let this = (*this).get_impl();
             match this.IsMember() {
                 ::core::result::Result::Ok(ok__) => {
-                    *member = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(member, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9619,7 +9619,7 @@ impl IHomeGroup_Vtbl {
             let this = (*this).get_impl();
             match this.ShowSharingWizard(::core::mem::transmute_copy(&owner)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sharingchoices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sharingchoices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -9689,7 +9689,7 @@ impl IImageRecompress_Vtbl {
             let this = (*this).get_impl();
             match this.RecompressImage(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&cx), ::core::mem::transmute_copy(&cy), ::core::mem::transmute_copy(&iquality), ::core::mem::transmute(&pstg)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstrmout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstrmout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10003,7 +10003,7 @@ impl IItemNameLimits_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxLength(::core::mem::transmute(&pszname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pimaxnamelen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pimaxnamelen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10041,7 +10041,7 @@ impl IKnownFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkfid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkfid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10052,7 +10052,7 @@ impl IKnownFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetCategory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcategory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcategory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10068,7 +10068,7 @@ impl IKnownFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetPath(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszpath = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszpath, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10084,7 +10084,7 @@ impl IKnownFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetIDList(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10095,7 +10095,7 @@ impl IKnownFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10106,7 +10106,7 @@ impl IKnownFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetRedirectionCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10117,7 +10117,7 @@ impl IKnownFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderDefinition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkfd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkfd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10163,7 +10163,7 @@ impl IKnownFolderManager_Vtbl {
             let this = (*this).get_impl();
             match this.FolderIdFromCsidl(::core::mem::transmute_copy(&ncsidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10174,7 +10174,7 @@ impl IKnownFolderManager_Vtbl {
             let this = (*this).get_impl();
             match this.FolderIdToCsidl(::core::mem::transmute_copy(&rfid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pncsidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pncsidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10190,7 +10190,7 @@ impl IKnownFolderManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolder(::core::mem::transmute_copy(&rfid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10201,7 +10201,7 @@ impl IKnownFolderManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderByName(::core::mem::transmute(&pszcanonicalname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10222,7 +10222,7 @@ impl IKnownFolderManager_Vtbl {
             let this = (*this).get_impl();
             match this.FindFolderFromPath(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&mode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10233,7 +10233,7 @@ impl IKnownFolderManager_Vtbl {
             let this = (*this).get_impl();
             match this.FindFolderFromIDList(::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppkf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppkf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10244,7 +10244,7 @@ impl IKnownFolderManager_Vtbl {
             let this = (*this).get_impl();
             match this.Redirect(::core::mem::transmute_copy(&rfid), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&psztargetpath), ::core::mem::transmute_copy(&cfolders), ::core::mem::transmute_copy(&pexclusion)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszerror = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszerror, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10279,7 +10279,7 @@ impl ILaunchSourceAppUserModelId_Vtbl {
             let this = (*this).get_impl();
             match this.GetAppUserModelId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *launchingapp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(launchingapp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10306,7 +10306,7 @@ impl ILaunchSourceViewSizePreference_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceViewToPosition() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10317,7 +10317,7 @@ impl ILaunchSourceViewSizePreference_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceViewSizePreference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *sourcesizeafterlaunch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sourcesizeafterlaunch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10347,7 +10347,7 @@ impl ILaunchTargetMonitor_Vtbl {
             let this = (*this).get_impl();
             match this.GetMonitor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *monitor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(monitor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10370,7 +10370,7 @@ impl ILaunchTargetViewSizePreference_Vtbl {
             let this = (*this).get_impl();
             match this.GetTargetViewSizePreference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *targetsizeonlaunch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(targetsizeonlaunch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10535,7 +10535,7 @@ impl INameSpaceTreeAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.OnGetDefaultAccessibilityAction(::core::mem::transmute(&psi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdefaultaction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdefaultaction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10551,7 +10551,7 @@ impl INameSpaceTreeAccessible_Vtbl {
             let this = (*this).get_impl();
             match this.OnGetAccessibilityRole(::core::mem::transmute(&psi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarrole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarrole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10605,7 +10605,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.TreeAdvise(::core::mem::transmute(&punk)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10641,7 +10641,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetRootItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsiarootitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsiarootitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10657,7 +10657,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemState(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&nstcismask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnstcisflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnstcisflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10668,7 +10668,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psiaitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psiaitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10679,7 +10679,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemCustomState(::core::mem::transmute(&psi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pistatenumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pistatenumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10705,7 +10705,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextItem(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&nstcgi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsinext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsinext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10716,7 +10716,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.HitTest(::core::mem::transmute_copy(&ppt)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsiout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsiout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10727,7 +10727,7 @@ impl INameSpaceTreeControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemRect(::core::mem::transmute(&psi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10787,7 +10787,7 @@ impl INameSpaceTreeControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlStyle(::core::mem::transmute_copy(&nstcsmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnstcsstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnstcsstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10803,7 +10803,7 @@ impl INameSpaceTreeControl2_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlStyle2(::core::mem::transmute_copy(&nstcsmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnstcsstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnstcsstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -10838,7 +10838,7 @@ impl INameSpaceTreeControlCustomDraw_Vtbl {
             let this = (*this).get_impl();
             match this.PrePaint(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&prc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plres = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plres, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11082,7 +11082,7 @@ impl INameSpaceTreeControlFolderCapabilities_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderCapabilities(::core::mem::transmute_copy(&nfcmask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnfcvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnfcvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11241,7 +11241,7 @@ impl INetworkFolderInternal_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceDisplayType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *displaytype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(displaytype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11252,7 +11252,7 @@ impl INetworkFolderInternal_Vtbl {
             let this = (*this).get_impl();
             match this.GetIDList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *idlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(idlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11289,7 +11289,7 @@ impl INewMenuClient_Vtbl {
             let this = (*this).get_impl();
             match this.IncludeItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11440,7 +11440,7 @@ impl INewWDEvents_Vtbl {
             let this = (*this).get_impl();
             match this.PassportAuthenticate(::core::mem::transmute(&bstrsigninurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvfauthenitcated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvfauthenitcated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11553,7 +11553,7 @@ impl IObjectWithAppUserModelID_Vtbl {
             let this = (*this).get_impl();
             match this.GetAppID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszappid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszappid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11600,7 +11600,7 @@ impl IObjectWithCancelEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetCancelEvent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11629,7 +11629,7 @@ impl IObjectWithFolderEnumMode_Vtbl {
             let this = (*this).get_impl();
             match this.GetMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11662,7 +11662,7 @@ impl IObjectWithProgID_Vtbl {
             let this = (*this).get_impl();
             match this.GetProgID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszprogid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszprogid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11728,7 +11728,7 @@ impl IOpenControlPanel_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11839,7 +11839,7 @@ impl IOperationsProgressDialog_Vtbl {
             let this = (*this).get_impl();
             match this.GetOperationStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *popstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(popstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11949,7 +11949,7 @@ impl IPackageDebugSettings_Vtbl {
             let this = (*this).get_impl();
             match this.GetPackageExecutionState(::core::mem::transmute(&packagefullname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packageexecutionstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packageexecutionstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -11960,7 +11960,7 @@ impl IPackageDebugSettings_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterForPackageStateChanges(::core::mem::transmute(&packagefullname), ::core::mem::transmute(&ppackageexecutionstatechangenotification)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12119,7 +12119,7 @@ impl IPersistFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurFolder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12151,7 +12151,7 @@ impl IPersistFolder3_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderTargetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfti = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfti, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12187,7 +12187,7 @@ impl IPersistIDList_Vtbl {
             let this = (*this).get_impl();
             match this.GetIDList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12248,7 +12248,7 @@ impl IPreviewHandler_Vtbl {
             let this = (*this).get_impl();
             match this.QueryFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12289,7 +12289,7 @@ impl IPreviewHandlerFrame_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindowContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12374,7 +12374,7 @@ impl IPreviousVersionsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.AreSnapshotsAvailable(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&foktobeslow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfavailable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfavailable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12401,7 +12401,7 @@ impl IProfferService_Vtbl {
             let this = (*this).get_impl();
             match this.ProfferService(::core::mem::transmute_copy(&serviceid), ::core::mem::transmute(&serviceprovider)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12527,7 +12527,7 @@ impl IPropertyKeyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *keycount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(keycount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12538,7 +12538,7 @@ impl IPropertyKeyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetKeyAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12693,7 +12693,7 @@ impl IQueryAssociations_Vtbl {
             let this = (*this).get_impl();
             match this.GetKey(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&key), ::core::mem::transmute(&pszextra)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkeyout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkeyout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12751,7 +12751,7 @@ impl IQueryCodePage_Vtbl {
             let this = (*this).get_impl();
             match this.GetCodePage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puicodepage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puicodepage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12818,7 +12818,7 @@ impl IQueryInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfoTip(::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppwsztip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppwsztip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12829,7 +12829,7 @@ impl IQueryInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfoFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12860,7 +12860,7 @@ impl IRegTreeItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetCheckState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbcheck = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbcheck, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12896,7 +12896,7 @@ impl IRelatedItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemIDList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12907,7 +12907,7 @@ impl IRelatedItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -12986,7 +12986,7 @@ impl IResultsFolder_Vtbl {
             let this = (*this).get_impl();
             match this.AddIDList(::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidladded = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidladded, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13108,7 +13108,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.canAdvanceError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcanadvance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcanadvance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13119,7 +13119,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.canRetreatError() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcanretreat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcanretreat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13130,7 +13130,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getErrorLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13141,7 +13141,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getErrorChar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plchar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plchar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13152,7 +13152,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getErrorCode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13163,7 +13163,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getErrorMsg() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13174,7 +13174,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getErrorUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13185,7 +13185,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getAlwaysShowLockState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfalwaysshowlocked = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfalwaysshowlocked, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13196,7 +13196,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getDetailsPaneOpen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdetailspaneopen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdetailspaneopen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13212,7 +13212,7 @@ impl IScriptErrorList_Vtbl {
             let this = (*this).get_impl();
             match this.getPerErrorDisplay() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfpererrordisplay = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfpererrordisplay, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13262,7 +13262,7 @@ impl ISearchBoxInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13294,7 +13294,7 @@ impl ISearchContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetSearchUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsearchurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsearchurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13305,7 +13305,7 @@ impl ISearchContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetSearchText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsearchtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsearchtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13316,7 +13316,7 @@ impl ISearchContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetSearchStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwsearchstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwsearchstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13413,7 +13413,7 @@ impl ISearchFolderItemFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetIDList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13457,7 +13457,7 @@ impl ISharedBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetSharedBitmap() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13468,7 +13468,7 @@ impl ISharedBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13479,7 +13479,7 @@ impl ISharedBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13495,7 +13495,7 @@ impl ISharedBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.Detach() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13546,7 +13546,7 @@ impl ISharingConfigurationManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetSharePermissions(::core::mem::transmute_copy(&dsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prole = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prole, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13605,7 +13605,7 @@ impl IShellApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetPossibleActions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwactions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwactions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13616,7 +13616,7 @@ impl IShellApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetSlowAppInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psaid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psaid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13627,7 +13627,7 @@ impl IShellApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetCachedSlowAppInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psaid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psaid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13712,7 +13712,7 @@ impl IShellBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.GetViewStateStream(::core::mem::transmute_copy(&grfmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstrm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstrm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13723,7 +13723,7 @@ impl IShellBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.GetControlWindow(::core::mem::transmute_copy(&id)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13734,7 +13734,7 @@ impl IShellBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.SendControlMsg(::core::mem::transmute_copy(&id), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pret = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pret, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13745,7 +13745,7 @@ impl IShellBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.QueryActiveShellView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13817,7 +13817,7 @@ impl IShellDetails_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsOf(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&icolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdetails = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdetails, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13874,7 +13874,7 @@ impl IShellDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13885,7 +13885,7 @@ impl IShellDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13896,7 +13896,7 @@ impl IShellDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.NameSpace(::core::mem::transmute(&vdir)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13907,7 +13907,7 @@ impl IShellDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.BrowseForFolder(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&title), ::core::mem::transmute_copy(&options), ::core::mem::transmute(&rootfolder)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsdf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsdf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -13918,7 +13918,7 @@ impl IShellDispatch_Vtbl {
             let this = (*this).get_impl();
             match this.Windows() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14067,7 +14067,7 @@ impl IShellDispatch2_Vtbl {
             let this = (*this).get_impl();
             match this.IsRestricted(::core::mem::transmute(&group), ::core::mem::transmute(&restriction)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plrestrictvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plrestrictvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14088,7 +14088,7 @@ impl IShellDispatch2_Vtbl {
             let this = (*this).get_impl();
             match this.GetSystemInformation(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14099,7 +14099,7 @@ impl IShellDispatch2_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceStart(::core::mem::transmute(&servicename), ::core::mem::transmute(&persistent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psuccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psuccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14110,7 +14110,7 @@ impl IShellDispatch2_Vtbl {
             let this = (*this).get_impl();
             match this.ServiceStop(::core::mem::transmute(&servicename), ::core::mem::transmute(&persistent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psuccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psuccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14121,7 +14121,7 @@ impl IShellDispatch2_Vtbl {
             let this = (*this).get_impl();
             match this.IsServiceRunning(::core::mem::transmute(&servicename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prunning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prunning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14132,7 +14132,7 @@ impl IShellDispatch2_Vtbl {
             let this = (*this).get_impl();
             match this.CanStartStopService(::core::mem::transmute(&servicename)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcanstartstop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcanstartstop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14143,7 +14143,7 @@ impl IShellDispatch2_Vtbl {
             let this = (*this).get_impl();
             match this.ShowBrowserBar(::core::mem::transmute(&bstrclsid), ::core::mem::transmute(&bshow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psuccess = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psuccess, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14213,7 +14213,7 @@ impl IShellDispatch4_Vtbl {
             let this = (*this).get_impl();
             match this.ExplorerPolicy(::core::mem::transmute(&bstrpolicyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14224,7 +14224,7 @@ impl IShellDispatch4_Vtbl {
             let this = (*this).get_impl();
             match this.GetSetting(::core::mem::transmute_copy(&lsetting)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14373,7 +14373,7 @@ impl IShellFavoritesNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.SubscriptionsEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14384,7 +14384,7 @@ impl IShellFavoritesNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSubscriptionForSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14395,7 +14395,7 @@ impl IShellFavoritesNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.DeleteSubscriptionForSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14490,7 +14490,7 @@ impl IShellFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayNameOf(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&uflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14501,7 +14501,7 @@ impl IShellFolder_Vtbl {
             let this = (*this).get_impl();
             match this.SetNameOf(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&pidl), ::core::mem::transmute(&pszname), ::core::mem::transmute_copy(&uflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidlout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidlout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14545,7 +14545,7 @@ impl IShellFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultSearchGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14556,7 +14556,7 @@ impl IShellFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumSearches() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14572,7 +14572,7 @@ impl IShellFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultColumnState(::core::mem::transmute_copy(&icolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcsflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcsflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14583,7 +14583,7 @@ impl IShellFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsEx(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&pscid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pv = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pv, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14594,7 +14594,7 @@ impl IShellFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.GetDetailsOf(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&icolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14605,7 +14605,7 @@ impl IShellFolder2_Vtbl {
             let this = (*this).get_impl();
             match this.MapColumnToSCID(::core::mem::transmute_copy(&icolumn)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pscid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pscid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14709,7 +14709,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetArrangeParam() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plparamsort = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plparamsort, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14735,7 +14735,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.AddObject(::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14751,7 +14751,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.RemoveObject(::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14762,7 +14762,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetObjectCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14778,7 +14778,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.UpdateObject(::core::mem::transmute_copy(&pidlold), ::core::mem::transmute_copy(&pidlnew)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14789,7 +14789,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.RefreshObject(::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14805,7 +14805,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectedCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puselected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puselected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14826,7 +14826,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetDragPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14837,7 +14837,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetDropPoint() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14873,7 +14873,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemSpacing() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pspacing = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pspacing, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14884,7 +14884,7 @@ impl IShellFolderView_Vtbl {
             let this = (*this).get_impl();
             match this.SetCallback(::core::mem::transmute(&pnewcb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppoldcb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppoldcb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14983,7 +14983,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -14994,7 +14994,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15005,7 +15005,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.Folder() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15016,7 +15016,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15027,7 +15027,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.FocusedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15043,7 +15043,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.PopupItemMenu(::core::mem::transmute(&pfi), ::core::mem::transmute(&vx), ::core::mem::transmute(&vy)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15054,7 +15054,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.Script() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15065,7 +15065,7 @@ impl IShellFolderViewDual_Vtbl {
             let this = (*this).get_impl();
             match this.ViewOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plviewoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plviewoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15104,7 +15104,7 @@ impl IShellFolderViewDual2_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentViewMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pviewmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pviewmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15153,7 +15153,7 @@ impl IShellFolderViewDual3_Vtbl {
             let this = (*this).get_impl();
             match this.GroupBy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrgroupby = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrgroupby, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15169,7 +15169,7 @@ impl IShellFolderViewDual3_Vtbl {
             let this = (*this).get_impl();
             match this.FolderFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15185,7 +15185,7 @@ impl IShellFolderViewDual3_Vtbl {
             let this = (*this).get_impl();
             match this.SortColumns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsortcolumns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsortcolumns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15206,7 +15206,7 @@ impl IShellFolderViewDual3_Vtbl {
             let this = (*this).get_impl();
             match this.IconSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *piiconsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piiconsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15248,7 +15248,7 @@ impl IShellIcon_Vtbl {
             let this = (*this).get_impl();
             match this.GetIconOf(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piconindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piconindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15313,7 +15313,7 @@ impl IShellIconOverlayIdentifier_Vtbl {
             let this = (*this).get_impl();
             match this.GetPriority() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppriority = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppriority, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15519,7 +15519,7 @@ impl IShellImageData_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperties(::core::mem::transmute_copy(&dwmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15565,7 +15565,7 @@ impl IShellImageData_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterAbort(::core::mem::transmute(&pabort)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppabortprev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppabortprev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15653,7 +15653,7 @@ impl IShellImageDataFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateIShellImageData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshimg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshimg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15664,7 +15664,7 @@ impl IShellImageDataFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageFromFile(::core::mem::transmute(&pszpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshimg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshimg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15675,7 +15675,7 @@ impl IShellImageDataFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateImageFromStream(::core::mem::transmute(&pstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppshimg = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppshimg, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15686,7 +15686,7 @@ impl IShellImageDataFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataFormatFromPath(::core::mem::transmute(&pszpath)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdataformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdataformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15727,7 +15727,7 @@ impl IShellItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetParent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15738,7 +15738,7 @@ impl IShellItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName(::core::mem::transmute_copy(&sigdnname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15749,7 +15749,7 @@ impl IShellItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributes(::core::mem::transmute_copy(&sfgaomask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psfgaoattribs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psfgaoattribs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15760,7 +15760,7 @@ impl IShellItem_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&hint)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piorder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piorder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15830,7 +15830,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15841,7 +15841,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetCLSID(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15852,7 +15852,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFileTime(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pft = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pft, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15863,7 +15863,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetInt32(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15874,7 +15874,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetString(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15885,7 +15885,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetUInt32(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pui = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pui, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15896,7 +15896,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetUInt64(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pull = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pull, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15907,7 +15907,7 @@ impl IShellItem2_Vtbl {
             let this = (*this).get_impl();
             match this.GetBool(::core::mem::transmute_copy(&key)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15969,7 +15969,7 @@ impl IShellItemArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributes(::core::mem::transmute_copy(&attribflags), ::core::mem::transmute_copy(&sfgaomask)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psfgaoattribs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psfgaoattribs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15980,7 +15980,7 @@ impl IShellItemArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwnumitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwnumitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -15991,7 +15991,7 @@ impl IShellItemArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemAt(::core::mem::transmute_copy(&dwindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16002,7 +16002,7 @@ impl IShellItemArray_Vtbl {
             let this = (*this).get_impl();
             match this.EnumItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumshellitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumshellitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16040,7 +16040,7 @@ impl IShellItemFilter_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnumFlagsForItem(::core::mem::transmute(&psi)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgrfflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgrfflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16070,7 +16070,7 @@ impl IShellItemImageFactory_Vtbl {
             let this = (*this).get_impl();
             match this.GetImage(::core::mem::transmute(&size), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16105,7 +16105,7 @@ impl IShellItemResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16116,7 +16116,7 @@ impl IShellItemResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pullsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pullsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16137,7 +16137,7 @@ impl IShellItemResources_Vtbl {
             let this = (*this).get_impl();
             match this.GetResourceDescription(::core::mem::transmute_copy(&pcsir)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16148,7 +16148,7 @@ impl IShellItemResources_Vtbl {
             let this = (*this).get_impl();
             match this.EnumResources() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16259,7 +16259,7 @@ impl IShellLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plofoptions = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plofoptions, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16275,7 +16275,7 @@ impl IShellLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.GetFolderType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16291,7 +16291,7 @@ impl IShellLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.GetIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16312,7 +16312,7 @@ impl IShellLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.Save(::core::mem::transmute(&psifoldertosavein), ::core::mem::transmute(&pszlibraryname), ::core::mem::transmute_copy(&lsf)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsisavedto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsisavedto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16323,7 +16323,7 @@ impl IShellLibrary_Vtbl {
             let this = (*this).get_impl();
             match this.SaveInKnownFolder(::core::mem::transmute_copy(&kfidtosavein), ::core::mem::transmute(&pszlibraryname), ::core::mem::transmute_copy(&lsf)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsisavedto = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsisavedto, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16390,7 +16390,7 @@ impl IShellLinkA_Vtbl {
             let this = (*this).get_impl();
             match this.GetIDList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16436,7 +16436,7 @@ impl IShellLinkA_Vtbl {
             let this = (*this).get_impl();
             match this.GetHotkey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwhotkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwhotkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16452,7 +16452,7 @@ impl IShellLinkA_Vtbl {
             let this = (*this).get_impl();
             match this.GetShowCmd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pishowcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pishowcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16544,7 +16544,7 @@ impl IShellLinkDataList_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16597,7 +16597,7 @@ impl IShellLinkDual_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16613,7 +16613,7 @@ impl IShellLinkDual_Vtbl {
             let this = (*this).get_impl();
             match this.Description() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16629,7 +16629,7 @@ impl IShellLinkDual_Vtbl {
             let this = (*this).get_impl();
             match this.WorkingDirectory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16645,7 +16645,7 @@ impl IShellLinkDual_Vtbl {
             let this = (*this).get_impl();
             match this.Arguments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16661,7 +16661,7 @@ impl IShellLinkDual_Vtbl {
             let this = (*this).get_impl();
             match this.Hotkey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pihk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pihk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16677,7 +16677,7 @@ impl IShellLinkDual_Vtbl {
             let this = (*this).get_impl();
             match this.ShowCommand() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pishowcommand = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pishowcommand, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16746,7 +16746,7 @@ impl IShellLinkDual2_Vtbl {
             let this = (*this).get_impl();
             match this.Target() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfi = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfi, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16794,7 +16794,7 @@ impl IShellLinkW_Vtbl {
             let this = (*this).get_impl();
             match this.GetIDList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16840,7 +16840,7 @@ impl IShellLinkW_Vtbl {
             let this = (*this).get_impl();
             match this.GetHotkey() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwhotkey = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwhotkey, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16856,7 +16856,7 @@ impl IShellLinkW_Vtbl {
             let this = (*this).get_impl();
             match this.GetShowCmd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pishowcmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pishowcmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -16975,7 +16975,7 @@ impl IShellMenu_Vtbl {
             let this = (*this).get_impl();
             match this.GetState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *psmd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psmd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17057,7 +17057,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.EnumOptions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgrfenumflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgrfenumflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17073,7 +17073,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedItem() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17089,7 +17089,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.Root() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17105,7 +17105,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.Depth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pidepth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pidepth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17121,7 +17121,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.Mode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pumode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pumode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17137,7 +17137,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.Flags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17158,7 +17158,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.TVFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17169,7 +17169,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.Columns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *bstrcolumns = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(bstrcolumns, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17185,7 +17185,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.CountViewTypes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pitypes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pitypes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17201,7 +17201,7 @@ impl IShellNameSpace_Vtbl {
             let this = (*this).get_impl();
             match this.SelectedItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17410,7 +17410,7 @@ impl IShellUIHelper_Vtbl {
             let this = (*this).get_impl();
             match this.IsSubscribed(::core::mem::transmute(&url)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17446,7 +17446,7 @@ impl IShellUIHelper_Vtbl {
             let this = (*this).get_impl();
             match this.ShowBrowserUI(::core::mem::transmute(&bstrname), ::core::mem::transmute_copy(&pvarin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17522,7 +17522,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.SqmEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17533,7 +17533,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.PhishingEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17544,7 +17544,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.BrandImageUri() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstruri = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstruri, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17570,7 +17570,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.IsSearchProviderInstalled(::core::mem::transmute(&url)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17581,7 +17581,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.IsSearchMigrated() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmigrated = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmigrated, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17592,7 +17592,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultSearchProvider() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17608,7 +17608,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.RunOnceHasShown() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfshown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfshown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17619,7 +17619,7 @@ impl IShellUIHelper2_Vtbl {
             let this = (*this).get_impl();
             match this.SearchGuideUrl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17680,7 +17680,7 @@ impl IShellUIHelper3_Vtbl {
             let this = (*this).get_impl();
             match this.IsServiceInstalled(::core::mem::transmute(&url), ::core::mem::transmute(&verb)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17691,7 +17691,7 @@ impl IShellUIHelper3_Vtbl {
             let this = (*this).get_impl();
             match this.InPrivateFilteringEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17727,7 +17727,7 @@ impl IShellUIHelper3_Vtbl {
             let this = (*this).get_impl();
             match this.IsSuggestedSitesEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17805,7 +17805,7 @@ impl IShellUIHelper4_Vtbl {
             let this = (*this).get_impl();
             match this.msIsSiteMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsitemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsitemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17821,7 +17821,7 @@ impl IShellUIHelper4_Vtbl {
             let this = (*this).get_impl();
             match this.msSiteModeAddThumbBarButton(::core::mem::transmute(&bstriconurl), ::core::mem::transmute(&bstrtooltip)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarbuttonid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarbuttonid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17872,7 +17872,7 @@ impl IShellUIHelper4_Vtbl {
             let this = (*this).get_impl();
             match this.msSiteModeAddButtonStyle(::core::mem::transmute(&uibuttonid), ::core::mem::transmute(&bstriconurl), ::core::mem::transmute(&bstrtooltip)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarstyleid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarstyleid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17893,7 +17893,7 @@ impl IShellUIHelper4_Vtbl {
             let this = (*this).get_impl();
             match this.msIsSiteModeFirstRun(::core::mem::transmute_copy(&fpreservestate)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puifirstrun = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puifirstrun, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17909,7 +17909,7 @@ impl IShellUIHelper4_Vtbl {
             let this = (*this).get_impl();
             match this.msTrackingProtectionEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17920,7 +17920,7 @@ impl IShellUIHelper4_Vtbl {
             let this = (*this).get_impl();
             match this.msActiveXFilteringEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -17972,7 +17972,7 @@ impl IShellUIHelper5_Vtbl {
             let this = (*this).get_impl();
             match this.msProvisionNetworks(::core::mem::transmute(&bstrprovisioningxml)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18075,7 +18075,7 @@ impl IShellUIHelper6_Vtbl {
             let this = (*this).get_impl();
             match this.msPinnedSiteState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarsitestate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarsitestate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18170,7 +18170,7 @@ impl IShellUIHelper7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExperimentalFlag(::core::mem::transmute(&bstrflagstring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *vfflag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(vfflag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18186,7 +18186,7 @@ impl IShellUIHelper7_Vtbl {
             let this = (*this).get_impl();
             match this.GetExperimentalValue(::core::mem::transmute(&bstrvaluestring)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18202,7 +18202,7 @@ impl IShellUIHelper7_Vtbl {
             let this = (*this).get_impl();
             match this.GetNeedIEAutoLaunchFlag(::core::mem::transmute(&bstrurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *flag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18218,7 +18218,7 @@ impl IShellUIHelper7_Vtbl {
             let this = (*this).get_impl();
             match this.HasNeedIEAutoLaunchFlag(::core::mem::transmute(&bstrurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *exists = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(exists, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18266,7 +18266,7 @@ impl IShellUIHelper8_Vtbl {
             let this = (*this).get_impl();
             match this.GetCVListData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18277,7 +18277,7 @@ impl IShellUIHelper8_Vtbl {
             let this = (*this).get_impl();
             match this.GetCVListLocalData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18288,7 +18288,7 @@ impl IShellUIHelper8_Vtbl {
             let this = (*this).get_impl();
             match this.GetEMIEListData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18299,7 +18299,7 @@ impl IShellUIHelper8_Vtbl {
             let this = (*this).get_impl();
             match this.GetEMIEListLocalData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18349,7 +18349,7 @@ impl IShellUIHelper9_Vtbl {
             let this = (*this).get_impl();
             match this.GetOSSku() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18405,7 +18405,7 @@ impl IShellView_Vtbl {
             let this = (*this).get_impl();
             match this.CreateViewWindow(::core::mem::transmute(&psvprevious), ::core::mem::transmute_copy(&pfs), ::core::mem::transmute(&psb), ::core::mem::transmute_copy(&prcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18421,7 +18421,7 @@ impl IShellView_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18524,7 +18524,7 @@ impl IShellView3_Vtbl {
             let this = (*this).get_impl();
             match this.CreateViewWindow3(::core::mem::transmute(&psbowner), ::core::mem::transmute(&psvprev), ::core::mem::transmute_copy(&dwviewflags), ::core::mem::transmute_copy(&dwmask), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&fvmode), ::core::mem::transmute_copy(&pvid), ::core::mem::transmute_copy(&prcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwndview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwndview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18560,7 +18560,7 @@ impl IShellWindows_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18571,7 +18571,7 @@ impl IShellWindows_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *folder = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(folder, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18582,7 +18582,7 @@ impl IShellWindows_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18593,7 +18593,7 @@ impl IShellWindows_Vtbl {
             let this = (*this).get_impl();
             match this.Register(::core::mem::transmute(&pid), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&swclass)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18604,7 +18604,7 @@ impl IShellWindows_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterPending(::core::mem::transmute_copy(&lthreadid), ::core::mem::transmute_copy(&pvarloc), ::core::mem::transmute_copy(&pvarlocroot), ::core::mem::transmute_copy(&swclass)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18675,7 +18675,7 @@ impl ISortColumnArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *columncount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(columncount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18686,7 +18686,7 @@ impl ISortColumnArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetAt(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *sortcolumn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(sortcolumn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18697,7 +18697,7 @@ impl ISortColumnArray_Vtbl {
             let this = (*this).get_impl();
             match this.GetSortType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18760,7 +18760,7 @@ impl IStorageProviderBanners_Vtbl {
             let this = (*this).get_impl();
             match this.GetBanner(::core::mem::transmute(&provideridentity), ::core::mem::transmute(&subscriptionid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *contentid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(contentid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18792,7 +18792,7 @@ impl IStorageProviderCopyHook_Vtbl {
             let this = (*this).get_impl();
             match this.CopyCallback(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&operation), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&srcfile), ::core::mem::transmute_copy(&srcattribs), ::core::mem::transmute(&destfile), ::core::mem::transmute_copy(&destattribs)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *result = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(result, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18817,7 +18817,7 @@ impl IStorageProviderHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyHandlerFromPath(::core::mem::transmute(&path)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyhandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyhandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18828,7 +18828,7 @@ impl IStorageProviderHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyHandlerFromUri(::core::mem::transmute(&uri)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyhandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyhandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18839,7 +18839,7 @@ impl IStorageProviderHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyHandlerFromFileId(::core::mem::transmute(&fileid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyhandler = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyhandler, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18871,7 +18871,7 @@ impl IStorageProviderPropertyHandler_Vtbl {
             let this = (*this).get_impl();
             match this.RetrieveProperties(::core::mem::transmute_copy(&propertiestoretrieve), ::core::mem::transmute_copy(&propertiestoretrievecount)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *retrievedproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(retrievedproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -18947,7 +18947,7 @@ impl IStreamUnbufferedInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSectorSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcbsectorsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcbsectorsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19014,7 +19014,7 @@ impl ISyncMgrConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&propkey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropvar = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropvar, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19025,7 +19025,7 @@ impl ISyncMgrConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetConflictIdInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pconflictidinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pconflictidinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19036,7 +19036,7 @@ impl ISyncMgrConflict_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemsArray() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparray = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparray, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19079,7 +19079,7 @@ impl ISyncMgrConflictFolder_Vtbl {
             let this = (*this).get_impl();
             match this.GetConflictIDList(::core::mem::transmute(&pconflict)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidlconflict = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidlconflict, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19103,7 +19103,7 @@ impl ISyncMgrConflictItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19114,7 +19114,7 @@ impl ISyncMgrConflictItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&iindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piteminfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piteminfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19159,7 +19159,7 @@ impl ISyncMgrConflictResolutionItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19170,7 +19170,7 @@ impl ISyncMgrConflictResolutionItems_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&iindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *piteminfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(piteminfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19212,7 +19212,7 @@ impl ISyncMgrConflictResolveInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetPresenterNextStep() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnpresenternextstep = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnpresenternextstep, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19228,7 +19228,7 @@ impl ISyncMgrConflictResolveInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemChoiceCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchoices = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchoices, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19239,7 +19239,7 @@ impl ISyncMgrConflictResolveInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemChoice(::core::mem::transmute_copy(&ichoice)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pichoiceindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pichoiceindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19293,7 +19293,7 @@ impl ISyncMgrConflictStore_Vtbl {
             let this = (*this).get_impl();
             match this.EnumConflicts(::core::mem::transmute(&pszhandlerid), ::core::mem::transmute(&pszitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19314,7 +19314,7 @@ impl ISyncMgrConflictStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount(::core::mem::transmute(&pszhandlerid), ::core::mem::transmute(&pszitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnconflicts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnconflicts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19485,7 +19485,7 @@ impl ISyncMgrEnumItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19527,7 +19527,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguideventid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguideventid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19538,7 +19538,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandlerID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszhandlerid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszhandlerid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19549,7 +19549,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszitemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszitemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19560,7 +19560,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetLevel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnlevel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnlevel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19571,7 +19571,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19582,7 +19582,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcreationtime = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcreationtime, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19593,7 +19593,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19604,7 +19604,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19615,7 +19615,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszlinktext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszlinktext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19626,7 +19626,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetLinkReference() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszlinkreference = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszlinkreference, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19637,7 +19637,7 @@ impl ISyncMgrEvent_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19696,7 +19696,7 @@ impl ISyncMgrEventStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19707,7 +19707,7 @@ impl ISyncMgrEventStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcevents = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcevents, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19718,7 +19718,7 @@ impl ISyncMgrEventStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetEvent(::core::mem::transmute_copy(&rguideventid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppevent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppevent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19762,7 +19762,7 @@ impl ISyncMgrHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19773,7 +19773,7 @@ impl ISyncMgrHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandlerInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pphandlerinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pphandlerinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19789,7 +19789,7 @@ impl ISyncMgrHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19800,7 +19800,7 @@ impl ISyncMgrHandler_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmpolicies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmpolicies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19852,7 +19852,7 @@ impl ISyncMgrHandlerCollection_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandlerEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19893,7 +19893,7 @@ impl ISyncMgrHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pntype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pntype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19904,7 +19904,7 @@ impl ISyncMgrHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeLabel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztypelabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztypelabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19915,7 +19915,7 @@ impl ISyncMgrHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetComment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -19926,7 +19926,7 @@ impl ISyncMgrHandlerInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastSyncTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftlastsync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftlastsync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20011,7 +20011,7 @@ impl ISyncMgrResolutionHandler_Vtbl {
             let this = (*this).get_impl();
             match this.QueryAbilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20022,7 +20022,7 @@ impl ISyncMgrResolutionHandler_Vtbl {
             let this = (*this).get_impl();
             match this.KeepOther(::core::mem::transmute(&psiother)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeedback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeedback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20033,7 +20033,7 @@ impl ISyncMgrResolutionHandler_Vtbl {
             let this = (*this).get_impl();
             match this.KeepRecent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeedback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeedback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20044,7 +20044,7 @@ impl ISyncMgrResolutionHandler_Vtbl {
             let this = (*this).get_impl();
             match this.RemoveFromSyncSet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeedback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeedback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20055,7 +20055,7 @@ impl ISyncMgrResolutionHandler_Vtbl {
             let this = (*this).get_impl();
             match this.KeepItems(::core::mem::transmute(&parray)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeedback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeedback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20105,7 +20105,7 @@ impl ISyncMgrSessionCreator_Vtbl {
             let this = (*this).get_impl();
             match this.CreateSession(::core::mem::transmute(&pszhandlerid), ::core::mem::transmute_copy(&ppszitemids), ::core::mem::transmute_copy(&citems)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcallback = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcallback, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20150,7 +20150,7 @@ impl ISyncMgrSyncCallback_Vtbl {
             let this = (*this).get_impl();
             match this.ReportEvent(::core::mem::transmute(&pszitemid), ::core::mem::transmute_copy(&nlevel), ::core::mem::transmute_copy(&nflags), ::core::mem::transmute(&pszname), ::core::mem::transmute(&pszdescription), ::core::mem::transmute(&pszlinktext), ::core::mem::transmute(&pszlinkreference), ::core::mem::transmute(&pszcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguideventid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguideventid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20230,7 +20230,7 @@ impl ISyncMgrSyncItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszitemid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszitemid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20241,7 +20241,7 @@ impl ISyncMgrSyncItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20252,7 +20252,7 @@ impl ISyncMgrSyncItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiteminfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiteminfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20268,7 +20268,7 @@ impl ISyncMgrSyncItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmcapabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmcapabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20279,7 +20279,7 @@ impl ISyncMgrSyncItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetPolicies() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmpolicies = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmpolicies, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20324,7 +20324,7 @@ impl ISyncMgrSyncItemContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncItem(::core::mem::transmute(&pszitemid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20335,7 +20335,7 @@ impl ISyncMgrSyncItemContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncItemEnumerator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20346,7 +20346,7 @@ impl ISyncMgrSyncItemContainer_Vtbl {
             let this = (*this).get_impl();
             match this.GetSyncItemCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20381,7 +20381,7 @@ impl ISyncMgrSyncItemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetTypeLabel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztypelabel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztypelabel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20392,7 +20392,7 @@ impl ISyncMgrSyncItemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetComment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszcomment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszcomment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20403,7 +20403,7 @@ impl ISyncMgrSyncItemInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastSyncTime() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pftlastsync = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pftlastsync, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20477,7 +20477,7 @@ impl ISyncMgrSynchronize_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandlerInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncmgrhandlerinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncmgrhandlerinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20488,7 +20488,7 @@ impl ISyncMgrSynchronize_Vtbl {
             let this = (*this).get_impl();
             match this.EnumSyncMgrItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsyncmgrenumitems = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsyncmgrenumitems, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -20922,7 +20922,7 @@ impl IThumbnailCapture_Vtbl {
             let this = (*this).get_impl();
             match this.CaptureThumbnail(::core::mem::transmute_copy(&pmaxsize), ::core::mem::transmute(&phtmldoc2)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phbmthumbnail = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phbmthumbnail, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21149,7 +21149,7 @@ impl ITransferDestination_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&psink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21215,7 +21215,7 @@ impl ITransferSource_Vtbl {
             let this = (*this).get_impl();
             match this.Advise(::core::mem::transmute(&psink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21241,7 +21241,7 @@ impl ITransferSource_Vtbl {
             let this = (*this).get_impl();
             match this.MoveItem(::core::mem::transmute(&psi), ::core::mem::transmute(&psiparentdst), ::core::mem::transmute(&psznamedst), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsinew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsinew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21252,7 +21252,7 @@ impl ITransferSource_Vtbl {
             let this = (*this).get_impl();
             match this.RecycleItem(::core::mem::transmute(&psisource), ::core::mem::transmute(&psiparentdest), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsinewdest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsinewdest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21268,7 +21268,7 @@ impl ITransferSource_Vtbl {
             let this = (*this).get_impl();
             match this.RenameItem(::core::mem::transmute(&psisource), ::core::mem::transmute(&psznewname), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsinewdest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsinewdest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21279,7 +21279,7 @@ impl ITransferSource_Vtbl {
             let this = (*this).get_impl();
             match this.LinkItem(::core::mem::transmute(&psisource), ::core::mem::transmute(&psiparentdest), ::core::mem::transmute(&psznewname), ::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsinewdest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsinewdest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21290,7 +21290,7 @@ impl ITransferSource_Vtbl {
             let this = (*this).get_impl();
             match this.ApplyPropertiesToItem(::core::mem::transmute(&psisource)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsinew = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsinew, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21301,7 +21301,7 @@ impl ITransferSource_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultDestinationName(::core::mem::transmute(&psisource), ::core::mem::transmute(&psiparentdest)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszdestinationname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszdestinationname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21364,7 +21364,7 @@ impl ITravelEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetPidl() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21425,7 +21425,7 @@ impl ITravelLog_Vtbl {
             let this = (*this).get_impl();
             match this.GetTravelEntry(::core::mem::transmute(&punk), ::core::mem::transmute_copy(&ioffset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppte = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppte, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21436,7 +21436,7 @@ impl ITravelLog_Vtbl {
             let this = (*this).get_impl();
             match this.FindTravelEntry(::core::mem::transmute(&punk), ::core::mem::transmute_copy(&pidl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppte = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppte, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21457,7 +21457,7 @@ impl ITravelLog_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21508,7 +21508,7 @@ impl ITravelLogClient_Vtbl {
             let this = (*this).get_impl();
             match this.FindWindowByIndex(::core::mem::transmute_copy(&dwid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21519,7 +21519,7 @@ impl ITravelLogClient_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindowData(::core::mem::transmute(&pstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pwindata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pwindata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21553,7 +21553,7 @@ impl ITravelLogEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetTitle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppsztitle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppsztitle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21564,7 +21564,7 @@ impl ITravelLogEntry_Vtbl {
             let this = (*this).get_impl();
             match this.GetURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21600,7 +21600,7 @@ impl ITravelLogStg_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEntry(::core::mem::transmute(&pszurl), ::core::mem::transmute(&psztitle), ::core::mem::transmute(&ptlerelativeto), ::core::mem::transmute_copy(&fprepend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pptle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pptle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21616,7 +21616,7 @@ impl ITravelLogStg_Vtbl {
             let this = (*this).get_impl();
             match this.EnumEntries(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21627,7 +21627,7 @@ impl ITravelLogStg_Vtbl {
             let this = (*this).get_impl();
             match this.FindEntries(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&pszurl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21638,7 +21638,7 @@ impl ITravelLogStg_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount(::core::mem::transmute_copy(&flags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcentries = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcentries, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21654,7 +21654,7 @@ impl ITravelLogStg_Vtbl {
             let this = (*this).get_impl();
             match this.GetRelativeEntry(::core::mem::transmute_copy(&ioffset)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21771,7 +21771,7 @@ impl IUniformResourceLocatorA_Vtbl {
             let this = (*this).get_impl();
             match this.GetURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21814,7 +21814,7 @@ impl IUniformResourceLocatorW_Vtbl {
             let this = (*this).get_impl();
             match this.GetURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppszurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppszurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -21850,7 +21850,7 @@ impl IUpdateIDList_Vtbl {
             let this = (*this).get_impl();
             match this.Update(::core::mem::transmute(&pbc), ::core::mem::transmute_copy(&pidlin)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppidlout = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppidlout, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22060,7 +22060,7 @@ impl IVirtualDesktopManager_Vtbl {
             let this = (*this).get_impl();
             match this.IsWindowOnCurrentVirtualDesktop(::core::mem::transmute_copy(&toplevelwindow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *oncurrentdesktop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(oncurrentdesktop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22071,7 +22071,7 @@ impl IVirtualDesktopManager_Vtbl {
             let this = (*this).get_impl();
             match this.GetWindowDesktopId(::core::mem::transmute_copy(&toplevelwindow)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *desktopid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(desktopid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22124,7 +22124,7 @@ impl IVisualProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetColor(::core::mem::transmute_copy(&vpcf)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22140,7 +22140,7 @@ impl IVisualProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cyiteminpixels = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cyiteminpixels, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22156,7 +22156,7 @@ impl IVisualProperties_Vtbl {
             let this = (*this).get_impl();
             match this.GetFont() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22261,7 +22261,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Application() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22272,7 +22272,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22283,7 +22283,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Container() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22294,7 +22294,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Document() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdisp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdisp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22305,7 +22305,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.TopLevelContainer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22316,7 +22316,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Type() {
                 ::core::result::Result::Ok(ok__) => {
-                    *r#type = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(r#type, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22327,7 +22327,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Left() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22343,7 +22343,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Top() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22359,7 +22359,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22375,7 +22375,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22391,7 +22391,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.LocationName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locationname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locationname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22402,7 +22402,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.LocationURL() {
                 ::core::result::Result::Ok(ok__) => {
-                    *locationurl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(locationurl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22413,7 +22413,7 @@ impl IWebBrowser_Vtbl {
             let this = (*this).get_impl();
             match this.Busy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22489,7 +22489,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryStatusWB(::core::mem::transmute_copy(&cmdid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcmdf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcmdf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22510,7 +22510,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.ReadyState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plreadystate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plreadystate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22521,7 +22521,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.Offline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pboffline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pboffline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22537,7 +22537,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.Silent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbsilent = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbsilent, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22553,7 +22553,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterAsBrowser() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbregister = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbregister, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22569,7 +22569,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterAsDropTarget() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbregister = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbregister, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22585,7 +22585,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.TheaterMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbregister = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbregister, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22601,7 +22601,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.AddressBar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22617,7 +22617,7 @@ impl IWebBrowser2_Vtbl {
             let this = (*this).get_impl();
             match this.Resizable() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22703,7 +22703,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute(&property)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvtvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvtvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22714,7 +22714,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22725,7 +22725,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.HWND() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22736,7 +22736,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.FullName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *fullname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(fullname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22747,7 +22747,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.Path() {
                 ::core::result::Result::Ok(ok__) => {
-                    *path = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(path, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22758,7 +22758,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22774,7 +22774,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.StatusBar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22790,7 +22790,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.StatusText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *statustext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(statustext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22806,7 +22806,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.ToolBar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22822,7 +22822,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.MenuBar() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22838,7 +22838,7 @@ impl IWebBrowserApp_Vtbl {
             let this = (*this).get_impl();
             match this.FullScreen() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbfullscreen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbfullscreen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22949,7 +22949,7 @@ impl IWebWizardHost_Vtbl {
             let this = (*this).get_impl();
             match this.Caption() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrcaption = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrcaption, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -22965,7 +22965,7 @@ impl IWebWizardHost_Vtbl {
             let this = (*this).get_impl();
             match this.get_Property(::core::mem::transmute(&bstrpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23012,7 +23012,7 @@ impl IWebWizardHost2_Vtbl {
             let this = (*this).get_impl();
             match this.SignString(::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *signedvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(signedvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23045,7 +23045,7 @@ impl IWizardExtension_Vtbl {
             let this = (*this).get_impl();
             match this.GetFirstPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23056,7 +23056,7 @@ impl IWizardExtension_Vtbl {
             let this = (*this).get_impl();
             match this.GetLastPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23089,7 +23089,7 @@ impl IWizardSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviousPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23100,7 +23100,7 @@ impl IWizardSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetNextPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -23111,7 +23111,7 @@ impl IWizardSite_Vtbl {
             let this = (*this).get_impl();
             match this.GetCancelledPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phpage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phpage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
@@ -26,7 +26,7 @@ impl IDynamicRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *benabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(benabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IDynamicRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.HWND() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -58,7 +58,7 @@ impl IDynamicRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.ClipRectangle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prccliprect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prccliprect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -74,7 +74,7 @@ impl IDynamicRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.ClipRegion() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phcliprgn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phcliprgn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -90,7 +90,7 @@ impl IDynamicRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.DrawingAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppida = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppida, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -106,7 +106,7 @@ impl IDynamicRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.DataCacheEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfcachedata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfcachedata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -174,7 +174,7 @@ impl IGestureRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -190,7 +190,7 @@ impl IGestureRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.MaxStrokeCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcstrokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcstrokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -321,7 +321,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.hWnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -337,7 +337,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collecting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collecting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -353,7 +353,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultDrawingAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -369,7 +369,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Renderer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentinkrenderer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentinkrenderer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -385,7 +385,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Ink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -401,7 +401,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.AutoRedraw() {
                 ::core::result::Result::Ok(ok__) => {
-                    *autoredraw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(autoredraw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -417,7 +417,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.CollectingInk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collecting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collecting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -428,7 +428,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.CollectionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -444,7 +444,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.DynamicRendering() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -460,7 +460,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredPacketDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packetguids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packetguids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -476,7 +476,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.MouseIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mouseicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mouseicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -497,7 +497,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.MousePointer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mousepointer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mousepointer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -513,7 +513,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Cursors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cursors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cursors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -524,7 +524,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.MarginX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *marginx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(marginx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -540,7 +540,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.MarginY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *marginy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(marginy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.Tablet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *singletablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(singletablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -567,7 +567,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.SupportHighContrastInk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *support = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(support, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -588,7 +588,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.GetGestureStatus(::core::mem::transmute_copy(&gesture)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listening = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listening, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -619,7 +619,7 @@ impl IInkCollector_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventInterest(::core::mem::transmute_copy(&eventid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -698,7 +698,7 @@ impl IInkCursor_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -709,7 +709,7 @@ impl IInkCursor_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -720,7 +720,7 @@ impl IInkCursor_Vtbl {
             let this = (*this).get_impl();
             match this.Inverted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *status = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(status, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -731,7 +731,7 @@ impl IInkCursor_Vtbl {
             let this = (*this).get_impl();
             match this.DrawingAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -747,7 +747,7 @@ impl IInkCursor_Vtbl {
             let this = (*this).get_impl();
             match this.Tablet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -758,7 +758,7 @@ impl IInkCursor_Vtbl {
             let this = (*this).get_impl();
             match this.Buttons() {
                 ::core::result::Result::Ok(ok__) => {
-                    *buttons = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(buttons, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -795,7 +795,7 @@ impl IInkCursorButton_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -806,7 +806,7 @@ impl IInkCursorButton_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -817,7 +817,7 @@ impl IInkCursorButton_Vtbl {
             let this = (*this).get_impl();
             match this.State() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentstate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentstate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -850,7 +850,7 @@ impl IInkCursorButtons_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -861,7 +861,7 @@ impl IInkCursorButtons_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -872,7 +872,7 @@ impl IInkCursorButtons_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&identifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *button = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(button, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -905,7 +905,7 @@ impl IInkCursors_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -916,7 +916,7 @@ impl IInkCursors_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -927,7 +927,7 @@ impl IInkCursors_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *cursor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cursor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -963,7 +963,7 @@ impl IInkCustomStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -974,7 +974,7 @@ impl IInkCustomStrokes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -985,7 +985,7 @@ impl IInkCustomStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&identifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1058,7 +1058,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1069,7 +1069,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *properties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(properties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1080,7 +1080,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.Dirty() {
                 ::core::result::Result::Ok(ok__) => {
-                    *dirty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dirty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1096,7 +1096,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.CustomStrokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunkinkcustomstrokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunkinkcustomstrokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1107,7 +1107,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoundingBox(::core::mem::transmute_copy(&boundingboxmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1128,7 +1128,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ExtractStrokes(::core::mem::transmute(&strokes), ::core::mem::transmute_copy(&extractflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *extractedink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(extractedink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1139,7 +1139,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ExtractWithRectangle(::core::mem::transmute(&rectangle), ::core::mem::transmute_copy(&extractflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *extractedink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(extractedink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1155,7 +1155,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *newink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1166,7 +1166,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.HitTestCircle(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&radius)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1177,7 +1177,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.HitTestWithRectangle(::core::mem::transmute(&selectionrectangle), ::core::mem::transmute_copy(&intersectpercent)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1198,7 +1198,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStrokes(::core::mem::transmute(&strokeids)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1214,7 +1214,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.Save(::core::mem::transmute_copy(&persistenceformat), ::core::mem::transmute_copy(&compressionmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *data = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(data, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1230,7 +1230,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.CreateStroke(::core::mem::transmute(&packetdata), ::core::mem::transmute(&packetdescription)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stroke = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stroke, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1241,7 +1241,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ClipboardCopyWithRectangle(::core::mem::transmute(&rectangle), ::core::mem::transmute_copy(&clipboardformats), ::core::mem::transmute_copy(&clipboardmodes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1252,7 +1252,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ClipboardCopy(::core::mem::transmute(&strokes), ::core::mem::transmute_copy(&clipboardformats), ::core::mem::transmute_copy(&clipboardmodes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *dataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(dataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1263,7 +1263,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.CanPaste(::core::mem::transmute(&dataobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *canpaste = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(canpaste, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1274,7 +1274,7 @@ impl IInkDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ClipboardPaste(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute(&dataobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1333,7 +1333,7 @@ impl IInkDivider_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1349,7 +1349,7 @@ impl IInkDivider_Vtbl {
             let this = (*this).get_impl();
             match this.RecognizerContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recognizercontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recognizercontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1365,7 +1365,7 @@ impl IInkDivider_Vtbl {
             let this = (*this).get_impl();
             match this.LineHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lineheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lineheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1381,7 +1381,7 @@ impl IInkDivider_Vtbl {
             let this = (*this).get_impl();
             match this.Divide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *inkdivisionresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inkdivisionresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1417,7 +1417,7 @@ impl IInkDivisionResult_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1428,7 +1428,7 @@ impl IInkDivisionResult_Vtbl {
             let this = (*this).get_impl();
             match this.ResultByType(::core::mem::transmute_copy(&divisiontype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inkdivisionunits = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inkdivisionunits, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1461,7 +1461,7 @@ impl IInkDivisionUnit_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1472,7 +1472,7 @@ impl IInkDivisionUnit_Vtbl {
             let this = (*this).get_impl();
             match this.DivisionType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *divisiontype = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(divisiontype, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1483,7 +1483,7 @@ impl IInkDivisionUnit_Vtbl {
             let this = (*this).get_impl();
             match this.RecognizedString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recostring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recostring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1494,7 +1494,7 @@ impl IInkDivisionUnit_Vtbl {
             let this = (*this).get_impl();
             match this.RotationTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rotationtransform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rotationtransform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1528,7 +1528,7 @@ impl IInkDivisionUnits_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1539,7 +1539,7 @@ impl IInkDivisionUnits_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1550,7 +1550,7 @@ impl IInkDivisionUnits_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inkdivisionunit = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inkdivisionunit, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1600,7 +1600,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.Color() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1616,7 +1616,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1632,7 +1632,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentheight = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentheight, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1648,7 +1648,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.FitToCurve() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1664,7 +1664,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.IgnorePressure() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1680,7 +1680,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.AntiAliased() {
                 ::core::result::Result::Ok(ok__) => {
-                    *flag = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flag, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1696,7 +1696,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.Transparency() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currenttransparency = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currenttransparency, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1712,7 +1712,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.RasterOperation() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentrasteroperation = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentrasteroperation, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1728,7 +1728,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.PenTip() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentpentip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentpentip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1744,7 +1744,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *properties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(properties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1755,7 +1755,7 @@ impl IInkDrawingAttributes_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *drawingattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(drawingattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1879,7 +1879,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Status() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1890,7 +1890,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.UseMouseForInput() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1906,7 +1906,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.InkMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1922,7 +1922,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.InkInsertMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1938,7 +1938,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.DrawingAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1954,7 +1954,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.RecognitionTimeout() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1970,7 +1970,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Recognizer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1986,7 +1986,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Factoid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2002,7 +2002,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelInks() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pselink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pselink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2018,7 +2018,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelInksDisplayMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinkdisplaymode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinkdisplaymode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2039,7 +2039,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.GetGestureStatus(::core::mem::transmute_copy(&gesture)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plisten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plisten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2060,7 +2060,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.BackColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2071,7 +2071,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Appearance() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pappearance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pappearance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2087,7 +2087,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.BorderStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pborderstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pborderstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2103,7 +2103,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Hwnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pohhwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pohhwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2114,7 +2114,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Font() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfont = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfont, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2130,7 +2130,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Text() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2146,7 +2146,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.MouseIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mouseicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mouseicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2167,7 +2167,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.MousePointer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mousepointer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mousepointer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2183,7 +2183,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Locked() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2199,7 +2199,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2215,7 +2215,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.MaxLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plmaxlength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plmaxlength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2231,7 +2231,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.MultiLine() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2247,7 +2247,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.ScrollBars() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2263,7 +2263,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.DisableNoScroll() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pval = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pval, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2279,7 +2279,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelAlignment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselalignment = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselalignment, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2295,7 +2295,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelBold() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselbold = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselbold, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2311,7 +2311,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelItalic() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselitalic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselitalic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2327,7 +2327,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelUnderline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselunderline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselunderline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2343,7 +2343,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2359,7 +2359,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelFontName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselfontname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselfontname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2375,7 +2375,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelFontSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselfontsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselfontsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2391,7 +2391,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelCharOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarselcharoffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarselcharoffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2407,7 +2407,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.TextRTF() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtextrtf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtextrtf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2423,7 +2423,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plselstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plselstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2439,7 +2439,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsellength = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsellength, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2455,7 +2455,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrseltext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrseltext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2471,7 +2471,7 @@ impl IInkEdit_Vtbl {
             let this = (*this).get_impl();
             match this.SelRTF() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrselrtf = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrselrtf, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2592,7 +2592,7 @@ impl IInkExtendedProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2603,7 +2603,7 @@ impl IInkExtendedProperties_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2614,7 +2614,7 @@ impl IInkExtendedProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute(&identifier)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *item = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(item, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2625,7 +2625,7 @@ impl IInkExtendedProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Add(::core::mem::transmute(&guid), ::core::mem::transmute(&data)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inkextendedproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inkextendedproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2646,7 +2646,7 @@ impl IInkExtendedProperties_Vtbl {
             let this = (*this).get_impl();
             match this.DoesPropertyExist(::core::mem::transmute(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *doespropertyexist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(doespropertyexist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2683,7 +2683,7 @@ impl IInkExtendedProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Guid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *guid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(guid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2694,7 +2694,7 @@ impl IInkExtendedProperty_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *data = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(data, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2732,7 +2732,7 @@ impl IInkGesture_Vtbl {
             let this = (*this).get_impl();
             match this.Confidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *confidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(confidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2743,7 +2743,7 @@ impl IInkGesture_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2887,7 +2887,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.hWnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2903,7 +2903,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collecting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collecting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2919,7 +2919,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultDrawingAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2935,7 +2935,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.Renderer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentinkrenderer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentinkrenderer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2951,7 +2951,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.Ink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2967,7 +2967,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.AutoRedraw() {
                 ::core::result::Result::Ok(ok__) => {
-                    *autoredraw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(autoredraw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2983,7 +2983,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.CollectingInk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collecting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collecting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2994,7 +2994,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.CollectionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3010,7 +3010,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.DynamicRendering() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3026,7 +3026,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredPacketDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packetguids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packetguids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3042,7 +3042,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.MouseIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mouseicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mouseicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3063,7 +3063,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.MousePointer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mousepointer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mousepointer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3079,7 +3079,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.EditingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *editingmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(editingmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3095,7 +3095,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.Selection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3111,7 +3111,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.EraserMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *erasermode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(erasermode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3127,7 +3127,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.EraserWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eraserwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eraserwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3143,7 +3143,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.AttachMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attachmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attachmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3159,7 +3159,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.Cursors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cursors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cursors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3170,7 +3170,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.MarginX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *marginx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(marginx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3186,7 +3186,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.MarginY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *marginy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(marginy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3202,7 +3202,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.Tablet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *singletablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(singletablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3213,7 +3213,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.SupportHighContrastInk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *support = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(support, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3229,7 +3229,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.SupportHighContrastSelectionUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *support = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(support, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3245,7 +3245,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.HitTestSelection(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *selarea = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selarea, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3266,7 +3266,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.GetGestureStatus(::core::mem::transmute_copy(&gesture)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listening = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listening, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3297,7 +3297,7 @@ impl IInkOverlay_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventInterest(::core::mem::transmute_copy(&eventid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3442,7 +3442,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.hWnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3453,7 +3453,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultDrawingAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentattributes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentattributes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3469,7 +3469,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Renderer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentinkrenderer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentinkrenderer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3485,7 +3485,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Ink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3501,7 +3501,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.AutoRedraw() {
                 ::core::result::Result::Ok(ok__) => {
-                    *autoredraw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(autoredraw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3517,7 +3517,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.CollectingInk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collecting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collecting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3528,7 +3528,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.CollectionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3544,7 +3544,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.DynamicRendering() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enabled = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enabled, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3560,7 +3560,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.DesiredPacketDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packetguids = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packetguids, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3576,7 +3576,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.MouseIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mouseicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mouseicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3597,7 +3597,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.MousePointer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mousepointer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mousepointer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3613,7 +3613,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.EditingMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *editingmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(editingmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3629,7 +3629,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Selection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *selection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3645,7 +3645,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.EraserMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *erasermode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(erasermode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3661,7 +3661,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.EraserWidth() {
                 ::core::result::Result::Ok(ok__) => {
-                    *eraserwidth = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(eraserwidth, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3687,7 +3687,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Picture() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppicture = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppicture, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3703,7 +3703,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.SizeMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *smsizemode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(smsizemode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3719,7 +3719,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.BackColor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcolor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcolor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3730,7 +3730,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Cursors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cursors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cursors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3741,7 +3741,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.MarginX() {
                 ::core::result::Result::Ok(ok__) => {
-                    *marginx = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(marginx, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3757,7 +3757,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.MarginY() {
                 ::core::result::Result::Ok(ok__) => {
-                    *marginy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(marginy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3773,7 +3773,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Tablet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *singletablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(singletablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3784,7 +3784,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.SupportHighContrastInk() {
                 ::core::result::Result::Ok(ok__) => {
-                    *support = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(support, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3800,7 +3800,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.SupportHighContrastSelectionUI() {
                 ::core::result::Result::Ok(ok__) => {
-                    *support = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(support, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3816,7 +3816,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.HitTestSelection(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *selarea = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(selarea, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3832,7 +3832,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.GetGestureStatus(::core::mem::transmute_copy(&gesture)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listening = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listening, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3863,7 +3863,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.GetEventInterest(::core::mem::transmute_copy(&eventid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *listen = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(listen, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3879,7 +3879,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.InkEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *collecting = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(collecting, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3895,7 +3895,7 @@ impl IInkPicture_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbool = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbool, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4001,7 +4001,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.String() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recostring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recostring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4012,7 +4012,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.Confidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *confidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(confidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4023,7 +4023,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.Baseline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *baseline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(baseline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4034,7 +4034,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.Midline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *midline = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(midline, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4045,7 +4045,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.Ascender() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ascender = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ascender, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4056,7 +4056,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.Descender() {
                 ::core::result::Result::Ok(ok__) => {
-                    *descender = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(descender, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4067,7 +4067,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.LineNumber() {
                 ::core::result::Result::Ok(ok__) => {
-                    *linenumber = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(linenumber, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4078,7 +4078,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4089,7 +4089,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.LineAlternates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *linealternates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(linealternates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4100,7 +4100,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.ConfidenceAlternates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *confidencealternates = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(confidencealternates, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4111,7 +4111,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.GetStrokesFromStrokeRanges(::core::mem::transmute(&strokes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *getstrokesfromstrokeranges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(getstrokesfromstrokeranges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4132,7 +4132,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.AlternatesWithConstantPropertyValues(::core::mem::transmute(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *alternateswithconstantpropertyvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(alternateswithconstantpropertyvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4143,7 +4143,7 @@ impl IInkRecognitionAlternate_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyValue(::core::mem::transmute(&propertytype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *propertyvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(propertyvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4189,7 +4189,7 @@ impl IInkRecognitionAlternates_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4200,7 +4200,7 @@ impl IInkRecognitionAlternates_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4211,7 +4211,7 @@ impl IInkRecognitionAlternates_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4222,7 +4222,7 @@ impl IInkRecognitionAlternates_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inkrecoalternate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inkrecoalternate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4260,7 +4260,7 @@ impl IInkRecognitionResult_Vtbl {
             let this = (*this).get_impl();
             match this.TopString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *topstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(topstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4271,7 +4271,7 @@ impl IInkRecognitionResult_Vtbl {
             let this = (*this).get_impl();
             match this.TopAlternate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *topalternate = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(topalternate, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4282,7 +4282,7 @@ impl IInkRecognitionResult_Vtbl {
             let this = (*this).get_impl();
             match this.TopConfidence() {
                 ::core::result::Result::Ok(ok__) => {
-                    *topconfidence = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(topconfidence, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4293,7 +4293,7 @@ impl IInkRecognitionResult_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4304,7 +4304,7 @@ impl IInkRecognitionResult_Vtbl {
             let this = (*this).get_impl();
             match this.AlternatesFromSelection(::core::mem::transmute_copy(&selectionstart), ::core::mem::transmute_copy(&selectionlength), ::core::mem::transmute_copy(&maximumalternates)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *alternatesfromselection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(alternatesfromselection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4355,7 +4355,7 @@ impl IInkRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4366,7 +4366,7 @@ impl IInkRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Vendor() {
                 ::core::result::Result::Ok(ok__) => {
-                    *vendor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(vendor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4377,7 +4377,7 @@ impl IInkRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Capabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *capabilitiesflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(capabilitiesflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4388,7 +4388,7 @@ impl IInkRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.Languages() {
                 ::core::result::Result::Ok(ok__) => {
-                    *languages = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(languages, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4399,7 +4399,7 @@ impl IInkRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.SupportedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *supportedproperties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supportedproperties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4410,7 +4410,7 @@ impl IInkRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredPacketDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *preferredpacketdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(preferredpacketdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4421,7 +4421,7 @@ impl IInkRecognizer_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRecognizerContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *context = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(context, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4457,7 +4457,7 @@ impl IInkRecognizer2_Vtbl {
             let this = (*this).get_impl();
             match this.Id() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4468,7 +4468,7 @@ impl IInkRecognizer2_Vtbl {
             let this = (*this).get_impl();
             match this.UnicodeRanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *unicoderanges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(unicoderanges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4521,7 +4521,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.Strokes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *strokes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(strokes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4537,7 +4537,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.CharacterAutoCompletionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4553,7 +4553,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.Factoid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *factoid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(factoid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4569,7 +4569,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.Guide() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recognizerguide = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recognizerguide, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4585,7 +4585,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.PrefixText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prefix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prefix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4601,7 +4601,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.SuffixText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *suffix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(suffix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4617,7 +4617,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.RecognitionFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *modes = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(modes, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4633,7 +4633,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.WordList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *wordlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(wordlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4649,7 +4649,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.Recognizer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recognizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recognizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4685,7 +4685,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recocontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recocontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4696,7 +4696,7 @@ impl IInkRecognizerContext_Vtbl {
             let this = (*this).get_impl();
             match this.IsStringSupported(::core::mem::transmute(&string)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4749,7 +4749,7 @@ impl IInkRecognizerContext2_Vtbl {
             let this = (*this).get_impl();
             match this.EnabledUnicodeRanges() {
                 ::core::result::Result::Ok(ok__) => {
-                    *unicoderanges = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(unicoderanges, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4795,7 +4795,7 @@ impl IInkRecognizerGuide_Vtbl {
             let this = (*this).get_impl();
             match this.WritingBox() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4811,7 +4811,7 @@ impl IInkRecognizerGuide_Vtbl {
             let this = (*this).get_impl();
             match this.DrawnBox() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4827,7 +4827,7 @@ impl IInkRecognizerGuide_Vtbl {
             let this = (*this).get_impl();
             match this.Rows() {
                 ::core::result::Result::Ok(ok__) => {
-                    *units = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(units, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4843,7 +4843,7 @@ impl IInkRecognizerGuide_Vtbl {
             let this = (*this).get_impl();
             match this.Columns() {
                 ::core::result::Result::Ok(ok__) => {
-                    *units = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(units, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4859,7 +4859,7 @@ impl IInkRecognizerGuide_Vtbl {
             let this = (*this).get_impl();
             match this.Midline() {
                 ::core::result::Result::Ok(ok__) => {
-                    *units = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(units, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4875,7 +4875,7 @@ impl IInkRecognizerGuide_Vtbl {
             let this = (*this).get_impl();
             match this.GuideData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *precoguide = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(precoguide, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4923,7 +4923,7 @@ impl IInkRecognizers_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4934,7 +4934,7 @@ impl IInkRecognizers_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4945,7 +4945,7 @@ impl IInkRecognizers_Vtbl {
             let this = (*this).get_impl();
             match this.GetDefaultRecognizer(::core::mem::transmute_copy(&lcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *defaultrecognizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(defaultrecognizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4956,7 +4956,7 @@ impl IInkRecognizers_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *inkrecognizer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(inkrecognizer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4999,7 +4999,7 @@ impl IInkRectangle_Vtbl {
             let this = (*this).get_impl();
             match this.Top() {
                 ::core::result::Result::Ok(ok__) => {
-                    *units = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(units, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5015,7 +5015,7 @@ impl IInkRectangle_Vtbl {
             let this = (*this).get_impl();
             match this.Left() {
                 ::core::result::Result::Ok(ok__) => {
-                    *units = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(units, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5031,7 +5031,7 @@ impl IInkRectangle_Vtbl {
             let this = (*this).get_impl();
             match this.Bottom() {
                 ::core::result::Result::Ok(ok__) => {
-                    *units = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(units, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5047,7 +5047,7 @@ impl IInkRectangle_Vtbl {
             let this = (*this).get_impl();
             match this.Right() {
                 ::core::result::Result::Ok(ok__) => {
-                    *units = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(units, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5063,7 +5063,7 @@ impl IInkRectangle_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5182,7 +5182,7 @@ impl IInkRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.Measure(::core::mem::transmute(&strokes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5193,7 +5193,7 @@ impl IInkRenderer_Vtbl {
             let this = (*this).get_impl();
             match this.MeasureStroke(::core::mem::transmute(&stroke), ::core::mem::transmute(&drawingattributes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5283,7 +5283,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5294,7 +5294,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.BezierPoints() {
                 ::core::result::Result::Ok(ok__) => {
-                    *points = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(points, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5305,7 +5305,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.DrawingAttributes() {
                 ::core::result::Result::Ok(ok__) => {
-                    *drawattrs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(drawattrs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5321,7 +5321,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.Ink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5332,7 +5332,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.ExtendedProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *properties = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(properties, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5343,7 +5343,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.PolylineCusps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cusps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cusps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5354,7 +5354,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.BezierCusps() {
                 ::core::result::Result::Ok(ok__) => {
-                    *cusps = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(cusps, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5365,7 +5365,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.SelfIntersections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *intersections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(intersections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5376,7 +5376,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.PacketCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5387,7 +5387,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.PacketSize() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5398,7 +5398,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.PacketDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *packetdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packetdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5409,7 +5409,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.Deleted() {
                 ::core::result::Result::Ok(ok__) => {
-                    *deleted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(deleted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5420,7 +5420,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoundingBox(::core::mem::transmute_copy(&boundingboxmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5431,7 +5431,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.FindIntersections(::core::mem::transmute(&strokes)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *intersections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(intersections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5442,7 +5442,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.GetRectangleIntersections(::core::mem::transmute(&rectangle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *intersections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(intersections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5458,7 +5458,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.HitTestCircle(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&radius)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *intersects = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(intersects, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5474,7 +5474,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.Split(::core::mem::transmute_copy(&splitat)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *newstroke = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(newstroke, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5490,7 +5490,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.GetPoints(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *points = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(points, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5501,7 +5501,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.SetPoints(::core::mem::transmute(&points), ::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *numberofpointsset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numberofpointsset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5512,7 +5512,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.GetPacketData(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packetdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packetdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5523,7 +5523,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.GetPacketValuesByProperty(::core::mem::transmute(&propertyname), ::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *packetvalues = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(packetvalues, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5534,7 +5534,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.SetPacketValuesByProperty(::core::mem::transmute(&bstrpropertyname), ::core::mem::transmute(&packetvalues), ::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&count)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *numberofpacketsset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(numberofpacketsset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5545,7 +5545,7 @@ impl IInkStrokeDisp_Vtbl {
             let this = (*this).get_impl();
             match this.GetFlattenedBezierPoints(::core::mem::transmute_copy(&fittingerror)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *flattenedbezierpoints = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(flattenedbezierpoints, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5655,7 +5655,7 @@ impl IInkStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5666,7 +5666,7 @@ impl IInkStrokes_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5677,7 +5677,7 @@ impl IInkStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.Ink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ink = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ink, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5688,7 +5688,7 @@ impl IInkStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.RecognitionResult() {
                 ::core::result::Result::Ok(ok__) => {
-                    *recognitionresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(recognitionresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5699,7 +5699,7 @@ impl IInkStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.ToString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *tostring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tostring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5710,7 +5710,7 @@ impl IInkStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *stroke = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(stroke, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5746,7 +5746,7 @@ impl IInkStrokes_Vtbl {
             let this = (*this).get_impl();
             match this.GetBoundingBox(::core::mem::transmute_copy(&boundingboxmode)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *boundingbox = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(boundingbox, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5839,7 +5839,7 @@ impl IInkTablet_Vtbl {
             let this = (*this).get_impl();
             match this.Name() {
                 ::core::result::Result::Ok(ok__) => {
-                    *name = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(name, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5850,7 +5850,7 @@ impl IInkTablet_Vtbl {
             let this = (*this).get_impl();
             match this.PlugAndPlayId() {
                 ::core::result::Result::Ok(ok__) => {
-                    *id = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(id, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5861,7 +5861,7 @@ impl IInkTablet_Vtbl {
             let this = (*this).get_impl();
             match this.MaximumInputRectangle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *rectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(rectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5872,7 +5872,7 @@ impl IInkTablet_Vtbl {
             let this = (*this).get_impl();
             match this.HardwareCapabilities() {
                 ::core::result::Result::Ok(ok__) => {
-                    *capabilities = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(capabilities, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5883,7 +5883,7 @@ impl IInkTablet_Vtbl {
             let this = (*this).get_impl();
             match this.IsPacketPropertySupported(::core::mem::transmute(&packetpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5922,7 +5922,7 @@ impl IInkTablet2_Vtbl {
             let this = (*this).get_impl();
             match this.DeviceKind() {
                 ::core::result::Result::Ok(ok__) => {
-                    *kind = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(kind, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5949,7 +5949,7 @@ impl IInkTablet3_Vtbl {
             let this = (*this).get_impl();
             match this.IsMultiTouch() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pismultitouch = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pismultitouch, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5960,7 +5960,7 @@ impl IInkTablet3_Vtbl {
             let this = (*this).get_impl();
             match this.MaximumCursors() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmaximumcursors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmaximumcursors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5994,7 +5994,7 @@ impl IInkTablets_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *count = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(count, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6005,7 +6005,7 @@ impl IInkTablets_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *_newenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(_newenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6016,7 +6016,7 @@ impl IInkTablets_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultTablet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *defaulttablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(defaulttablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6027,7 +6027,7 @@ impl IInkTablets_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *tablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(tablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6038,7 +6038,7 @@ impl IInkTablets_Vtbl {
             let this = (*this).get_impl();
             match this.IsPacketPropertySupported(::core::mem::transmute(&packetpropertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *supported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(supported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6132,7 +6132,7 @@ impl IInkTransform_Vtbl {
             let this = (*this).get_impl();
             match this.eM11() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6148,7 +6148,7 @@ impl IInkTransform_Vtbl {
             let this = (*this).get_impl();
             match this.eM12() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6164,7 +6164,7 @@ impl IInkTransform_Vtbl {
             let this = (*this).get_impl();
             match this.eM21() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6180,7 +6180,7 @@ impl IInkTransform_Vtbl {
             let this = (*this).get_impl();
             match this.eM22() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6196,7 +6196,7 @@ impl IInkTransform_Vtbl {
             let this = (*this).get_impl();
             match this.eDx() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6212,7 +6212,7 @@ impl IInkTransform_Vtbl {
             let this = (*this).get_impl();
             match this.eDy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *value = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(value, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6228,7 +6228,7 @@ impl IInkTransform_Vtbl {
             let this = (*this).get_impl();
             match this.Data() {
                 ::core::result::Result::Ok(ok__) => {
-                    *xform = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(xform, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6340,7 +6340,7 @@ impl IInputPanelWindowHandle_Vtbl {
             let this = (*this).get_impl();
             match this.AttachedEditWindow32() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attachededitwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attachededitwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6356,7 +6356,7 @@ impl IInputPanelWindowHandle_Vtbl {
             let this = (*this).get_impl();
             match this.AttachedEditWindow64() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attachededitwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attachededitwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6419,7 +6419,7 @@ impl IMathInputControl_Vtbl {
             let this = (*this).get_impl();
             match this.IsVisible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvbshown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvbshown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6470,7 +6470,7 @@ impl IMathInputControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreviewHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *height = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(height, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6501,7 +6501,7 @@ impl IMathInputControl_Vtbl {
             let this = (*this).get_impl();
             match this.GetHoverIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *hoverimage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(hoverimage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6570,7 +6570,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.Busy() {
                 ::core::result::Result::Ok(ok__) => {
-                    *busy = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(busy, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6581,7 +6581,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.Factoid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *factoid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(factoid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6597,7 +6597,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.AttachedEditWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attachededitwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attachededitwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6613,7 +6613,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentPanel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentpanel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentpanel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6629,7 +6629,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultPanel() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdefaultpanel = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdefaultpanel, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6645,7 +6645,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.Visible() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6661,7 +6661,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.Top() {
                 ::core::result::Result::Ok(ok__) => {
-                    *top = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(top, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6672,7 +6672,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.Left() {
                 ::core::result::Result::Ok(ok__) => {
-                    *left = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(left, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6683,7 +6683,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.Width() {
                 ::core::result::Result::Ok(ok__) => {
-                    *width = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(width, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6694,7 +6694,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.Height() {
                 ::core::result::Result::Ok(ok__) => {
-                    *height = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(height, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6705,7 +6705,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.VerticalOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *verticaloffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(verticaloffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6721,7 +6721,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.HorizontalOffset() {
                 ::core::result::Result::Ok(ok__) => {
-                    *horizontaloffset = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(horizontaloffset, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6737,7 +6737,7 @@ impl IPenInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.AutoShow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pautoshow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pautoshow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6845,7 +6845,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.Enabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6861,7 +6861,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.HWND() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6877,7 +6877,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.WindowInputRectangle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prcwndinputrect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prcwndinputrect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6908,7 +6908,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetStylusSyncPlugin(::core::mem::transmute_copy(&iindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiplugin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiplugin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6919,7 +6919,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetStylusSyncPluginCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcplugins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcplugins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6945,7 +6945,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetStylusAsyncPlugin(::core::mem::transmute_copy(&iindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiplugin = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiplugin, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6956,7 +6956,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetStylusAsyncPluginCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcplugins = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcplugins, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6967,7 +6967,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.ChildRealTimeStylusPlugin() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppirts = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppirts, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7003,7 +7003,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetTablet() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppisingletablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppisingletablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7014,7 +7014,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetTabletContextIdFromTablet(::core::mem::transmute(&pitablet)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptcid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptcid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7025,7 +7025,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetTabletFromTabletContextId(::core::mem::transmute_copy(&tcid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitablet = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitablet, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7041,7 +7041,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetStyluses() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiinkcursors = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiinkcursors, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7052,7 +7052,7 @@ impl IRealTimeStylus_Vtbl {
             let this = (*this).get_impl();
             match this.GetStylusForId(::core::mem::transmute_copy(&sid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiinkcursor = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiinkcursor, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7127,7 +7127,7 @@ impl IRealTimeStylus2_Vtbl {
             let this = (*this).get_impl();
             match this.FlicksEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7163,7 +7163,7 @@ impl IRealTimeStylus3_Vtbl {
             let this = (*this).get_impl();
             match this.MultiTouchEnabled() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7263,7 +7263,7 @@ impl IStrokeBuilder_Vtbl {
             let this = (*this).get_impl();
             match this.Ink() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiinkobj = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiinkobj, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7411,7 +7411,7 @@ impl IStylusPlugin_Vtbl {
             let this = (*this).get_impl();
             match this.DataInterest() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdatainterest = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdatainterest, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7493,7 +7493,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.AttachedEditWindow() {
                 ::core::result::Result::Ok(ok__) => {
-                    *attachededitwindow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(attachededitwindow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7509,7 +7509,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentInteractionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *currentinteractionmode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(currentinteractionmode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7520,7 +7520,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultInPlaceState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7536,7 +7536,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentInPlaceState() {
                 ::core::result::Result::Ok(ok__) => {
-                    *state = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(state, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7547,7 +7547,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.DefaultInputArea() {
                 ::core::result::Result::Ok(ok__) => {
-                    *area = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(area, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7563,7 +7563,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentInputArea() {
                 ::core::result::Result::Ok(ok__) => {
-                    *area = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(area, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7574,7 +7574,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.CurrentCorrectionMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *mode = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(mode, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7585,7 +7585,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.PreferredInPlaceDirection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *direction = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(direction, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7601,7 +7601,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.ExpandPostInsertionCorrection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *expand = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(expand, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7617,7 +7617,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.InPlaceVisibleOnFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *visible = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(visible, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7633,7 +7633,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.InPlaceBoundingRectangle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *boundingrectangle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(boundingrectangle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7644,7 +7644,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.PopUpCorrectionHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *height = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(height, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7655,7 +7655,7 @@ impl ITextInputPanel_Vtbl {
             let this = (*this).get_impl();
             match this.PopDownCorrectionHeight() {
                 ::core::result::Result::Ok(ok__) => {
-                    *height = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(height, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7838,7 +7838,7 @@ impl ITextInputPanelRunInfo_Vtbl {
             let this = (*this).get_impl();
             match this.IsTipRunning() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfrunning = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfrunning, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7888,7 +7888,7 @@ impl ITipAutoCompleteClient_Vtbl {
             let this = (*this).get_impl();
             match this.RequestShowUI(::core::mem::transmute_copy(&hwndlist)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfallowshowing = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfallowshowing, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
@@ -15,7 +15,7 @@ impl IAccClientDocMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocuments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -26,7 +26,7 @@ impl IAccClientDocMgr_Vtbl {
             let this = (*this).get_impl();
             match this.LookupByHWND(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -37,7 +37,7 @@ impl IAccClientDocMgr_Vtbl {
             let this = (*this).get_impl();
             match this.LookupByPoint(::core::mem::transmute(&pt), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -48,7 +48,7 @@ impl IAccClientDocMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocused(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -89,7 +89,7 @@ impl IAccDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentTerm(::core::mem::transmute_copy(&term)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pparentterm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pparentterm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -100,7 +100,7 @@ impl IAccDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.GetMnemonicString(::core::mem::transmute_copy(&term)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *presult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(presult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -111,7 +111,7 @@ impl IAccDictionary_Vtbl {
             let this = (*this).get_impl();
             match this.LookupMnemonicTerm(::core::mem::transmute(&bstrmnemonic)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pterm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pterm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -199,7 +199,7 @@ impl IAccStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocuments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *enumunknown = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(enumunknown, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -210,7 +210,7 @@ impl IAccStore_Vtbl {
             let this = (*this).get_impl();
             match this.LookupByHWND(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -221,7 +221,7 @@ impl IAccStore_Vtbl {
             let this = (*this).get_impl();
             match this.LookupByPoint(::core::mem::transmute(&pt), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -237,7 +237,7 @@ impl IAccStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocused(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -287,7 +287,7 @@ impl IAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetGravity() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pgravity = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pgravity, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqual(::core::mem::transmute(&pawith)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -309,7 +309,7 @@ impl IAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.Compare(::core::mem::transmute(&pawith)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -330,7 +330,7 @@ impl IAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.ShiftRegion(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dir)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfnoregion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfnoregion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -346,7 +346,7 @@ impl IAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetChangeHistory() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwhistory = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwhistory, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -362,7 +362,7 @@ impl IAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaclone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaclone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -461,7 +461,7 @@ impl IDocWrap_Vtbl {
             let this = (*this).get_impl();
             match this.GetWrappedDoc(::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -491,7 +491,7 @@ impl IEnumITfCompositionView_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -538,7 +538,7 @@ impl IEnumSpeechCommands_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -585,7 +585,7 @@ impl IEnumTfCandidates_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -632,7 +632,7 @@ impl IEnumTfContextViews_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -679,7 +679,7 @@ impl IEnumTfContexts_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -726,7 +726,7 @@ impl IEnumTfDisplayAttributeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -773,7 +773,7 @@ impl IEnumTfDocumentMgrs_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -820,7 +820,7 @@ impl IEnumTfFunctionProviders_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -867,7 +867,7 @@ impl IEnumTfInputProcessorProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -914,7 +914,7 @@ impl IEnumTfLangBarItems_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -964,7 +964,7 @@ impl IEnumTfLanguageProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1014,7 +1014,7 @@ impl IEnumTfLatticeElements_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1061,7 +1061,7 @@ impl IEnumTfProperties_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1111,7 +1111,7 @@ impl IEnumTfPropertyValue_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1158,7 +1158,7 @@ impl IEnumTfRanges_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1205,7 +1205,7 @@ impl IEnumTfUIElements_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1267,7 +1267,7 @@ impl ISpeechCommandProvider_Vtbl {
             let this = (*this).get_impl();
             match this.EnumSpeechCommands(::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1337,7 +1337,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.RequestLock(::core::mem::transmute_copy(&dwlockflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1348,7 +1348,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdcs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdcs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1379,7 +1379,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.SetText(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend), ::core::mem::transmute(&pchtext), ::core::mem::transmute_copy(&cch)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1390,7 +1390,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormattedText(::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1401,7 +1401,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbedded(::core::mem::transmute_copy(&acppos), ::core::mem::transmute_copy(&rguidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1412,7 +1412,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.QueryInsertEmbedded(::core::mem::transmute_copy(&pguidservice), ::core::mem::transmute_copy(&pformatetc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinsertable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinsertable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1423,7 +1423,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.InsertEmbedded(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend), ::core::mem::transmute(&pdataobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1469,7 +1469,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndACP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pacp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pacp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1480,7 +1480,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvcview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvcview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1491,7 +1491,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetACPFromPoint(::core::mem::transmute_copy(&vcview), ::core::mem::transmute_copy(&ptscreen), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pacp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pacp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1507,7 +1507,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetScreenExt(::core::mem::transmute_copy(&vcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1518,7 +1518,7 @@ impl ITextStoreACP_Vtbl {
             let this = (*this).get_impl();
             match this.GetWnd(::core::mem::transmute_copy(&vcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1606,7 +1606,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.RequestLock(::core::mem::transmute_copy(&dwlockflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1617,7 +1617,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdcs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdcs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1648,7 +1648,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.SetText(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend), ::core::mem::transmute(&pchtext), ::core::mem::transmute_copy(&cch)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1659,7 +1659,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormattedText(::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1670,7 +1670,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbedded(::core::mem::transmute_copy(&acppos), ::core::mem::transmute_copy(&rguidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1681,7 +1681,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.QueryInsertEmbedded(::core::mem::transmute_copy(&pguidservice), ::core::mem::transmute_copy(&pformatetc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinsertable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinsertable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1692,7 +1692,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.InsertEmbedded(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend), ::core::mem::transmute(&pdataobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1738,7 +1738,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.GetEndACP() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pacp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pacp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1749,7 +1749,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvcview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvcview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1760,7 +1760,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.GetACPFromPoint(::core::mem::transmute_copy(&vcview), ::core::mem::transmute_copy(&ptscreen), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pacp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pacp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1776,7 +1776,7 @@ impl ITextStoreACP2_Vtbl {
             let this = (*this).get_impl();
             match this.GetScreenExt(::core::mem::transmute_copy(&vcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -1867,7 +1867,7 @@ impl ITextStoreACPServices_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRange(::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2021,7 +2021,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.RequestLock(::core::mem::transmute_copy(&dwlockflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2032,7 +2032,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdcs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdcs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2068,7 +2068,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormattedText(::core::mem::transmute(&pastart), ::core::mem::transmute(&paend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2079,7 +2079,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbedded(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&papos), ::core::mem::transmute_copy(&rguidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2120,7 +2120,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetStart() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppastart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppastart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2131,7 +2131,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppaend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppaend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2142,7 +2142,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvcview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvcview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2153,7 +2153,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetAnchorFromPoint(::core::mem::transmute_copy(&vcview), ::core::mem::transmute_copy(&ptscreen), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppasite = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppasite, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2169,7 +2169,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetScreenExt(::core::mem::transmute_copy(&vcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2180,7 +2180,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.GetWnd(::core::mem::transmute_copy(&vcview)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2191,7 +2191,7 @@ impl ITextStoreAnchor_Vtbl {
             let this = (*this).get_impl();
             match this.QueryInsertEmbedded(::core::mem::transmute_copy(&pguidservice), ::core::mem::transmute_copy(&pformatetc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinsertable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinsertable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2382,7 +2382,7 @@ impl ITfCandidateList_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCandidates() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2393,7 +2393,7 @@ impl ITfCandidateList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCandidate(::core::mem::transmute_copy(&nindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcand = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcand, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2404,7 +2404,7 @@ impl ITfCandidateList_Vtbl {
             let this = (*this).get_impl();
             match this.GetCandidateNum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pncnt = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pncnt, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2448,7 +2448,7 @@ impl ITfCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdatedFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2459,7 +2459,7 @@ impl ITfCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentMgr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdim = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdim, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2470,7 +2470,7 @@ impl ITfCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCount() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pucount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pucount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2481,7 +2481,7 @@ impl ITfCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2492,7 +2492,7 @@ impl ITfCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetString(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2513,7 +2513,7 @@ impl ITfCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentPage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pupage = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pupage, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2587,7 +2587,7 @@ impl ITfCandidateString_Vtbl {
             let this = (*this).get_impl();
             match this.GetString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2598,7 +2598,7 @@ impl ITfCandidateString_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pnindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pnindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2651,7 +2651,7 @@ impl ITfCategoryMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCategoriesInItem(::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2662,7 +2662,7 @@ impl ITfCategoryMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumItemsInCategory(::core::mem::transmute_copy(&rcatid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2688,7 +2688,7 @@ impl ITfCategoryMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUIDDescription(::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2709,7 +2709,7 @@ impl ITfCategoryMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUIDDWORD(::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2720,7 +2720,7 @@ impl ITfCategoryMgr_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterGUID(::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguidatom = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguidatom, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2731,7 +2731,7 @@ impl ITfCategoryMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUID(::core::mem::transmute_copy(&guidatom)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2742,7 +2742,7 @@ impl ITfCategoryMgr_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqualTfGuidAtom(::core::mem::transmute_copy(&guidatom), ::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2825,7 +2825,7 @@ impl ITfClientId_Vtbl {
             let this = (*this).get_impl();
             match this.GetClientId(::core::mem::transmute_copy(&rclsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2857,7 +2857,7 @@ impl ITfCompartment_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2906,7 +2906,7 @@ impl ITfCompartmentMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetCompartment(::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2922,7 +2922,7 @@ impl ITfCompartmentMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCompartments() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -2953,7 +2953,7 @@ impl ITfComposition_Vtbl {
             let this = (*this).get_impl();
             match this.GetRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3015,7 +3015,7 @@ impl ITfCompositionView_Vtbl {
             let this = (*this).get_impl();
             match this.GetOwnerClsid() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3026,7 +3026,7 @@ impl ITfCompositionView_Vtbl {
             let this = (*this).get_impl();
             match this.GetRange() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3097,7 +3097,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.RequestEditSession(::core::mem::transmute_copy(&tid), ::core::mem::transmute(&pes), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phrsession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phrsession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3108,7 +3108,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.InWriteSession(::core::mem::transmute_copy(&tid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfwritesession = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfwritesession, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3129,7 +3129,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetStart(::core::mem::transmute_copy(&ec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstart = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstart, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3140,7 +3140,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetEnd(::core::mem::transmute_copy(&ec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppend = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppend, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3151,7 +3151,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveView() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppview = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppview, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3162,7 +3162,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.EnumViews() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3173,7 +3173,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdcs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdcs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3184,7 +3184,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&guidprop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3195,7 +3195,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetAppProperty(::core::mem::transmute_copy(&guidprop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppprop = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppprop, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3206,7 +3206,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.TrackProperties(::core::mem::transmute_copy(&prgprop), ::core::mem::transmute_copy(&cprop), ::core::mem::transmute_copy(&prgappprop), ::core::mem::transmute_copy(&cappprop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppproperty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppproperty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3217,7 +3217,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.EnumProperties() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3228,7 +3228,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentMgr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdm = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdm, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3239,7 +3239,7 @@ impl ITfContext_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRangeBackup(::core::mem::transmute_copy(&ec), ::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbackup = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbackup, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3282,7 +3282,7 @@ impl ITfContextComposition_Vtbl {
             let this = (*this).get_impl();
             match this.StartComposition(::core::mem::transmute_copy(&ecwrite), ::core::mem::transmute(&pcompositionrange), ::core::mem::transmute(&psink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3293,7 +3293,7 @@ impl ITfContextComposition_Vtbl {
             let this = (*this).get_impl();
             match this.EnumCompositions() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3304,7 +3304,7 @@ impl ITfContextComposition_Vtbl {
             let this = (*this).get_impl();
             match this.FindComposition(::core::mem::transmute_copy(&ecread), ::core::mem::transmute(&ptestrange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3315,7 +3315,7 @@ impl ITfContextComposition_Vtbl {
             let this = (*this).get_impl();
             match this.TakeOwnership(::core::mem::transmute_copy(&ecwrite), ::core::mem::transmute(&pcomposition), ::core::mem::transmute(&psink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcomposition = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcomposition, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3350,7 +3350,7 @@ impl ITfContextKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnKeyDown(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3361,7 +3361,7 @@ impl ITfContextKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnKeyUp(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3372,7 +3372,7 @@ impl ITfContextKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnTestKeyDown(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3383,7 +3383,7 @@ impl ITfContextKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnTestKeyUp(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3420,7 +3420,7 @@ impl ITfContextOwner_Vtbl {
             let this = (*this).get_impl();
             match this.GetACPFromPoint(::core::mem::transmute_copy(&ptscreen), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pacp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pacp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3436,7 +3436,7 @@ impl ITfContextOwner_Vtbl {
             let this = (*this).get_impl();
             match this.GetScreenExt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3447,7 +3447,7 @@ impl ITfContextOwner_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdcs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdcs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3458,7 +3458,7 @@ impl ITfContextOwner_Vtbl {
             let this = (*this).get_impl();
             match this.GetWnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3469,7 +3469,7 @@ impl ITfContextOwner_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttribute(::core::mem::transmute_copy(&rguidattribute)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3522,7 +3522,7 @@ impl ITfContextOwnerCompositionSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnStartComposition(::core::mem::transmute(&pcomposition)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfok = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfok, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3599,7 +3599,7 @@ impl ITfContextOwnerServices_Vtbl {
             let this = (*this).get_impl();
             match this.CreateRange(::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3637,7 +3637,7 @@ impl ITfContextView_Vtbl {
             let this = (*this).get_impl();
             match this.GetRangeFromPoint(::core::mem::transmute_copy(&ec), ::core::mem::transmute_copy(&ppt), ::core::mem::transmute_copy(&dwflags)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3653,7 +3653,7 @@ impl ITfContextView_Vtbl {
             let this = (*this).get_impl();
             match this.GetScreenExt() {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3664,7 +3664,7 @@ impl ITfContextView_Vtbl {
             let this = (*this).get_impl();
             match this.GetWnd() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phwnd = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phwnd, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3697,7 +3697,7 @@ impl ITfCreatePropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.IsStoreSerializable(::core::mem::transmute_copy(&guidprop), ::core::mem::transmute(&prange), ::core::mem::transmute(&ppropstore)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfserializable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfserializable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3708,7 +3708,7 @@ impl ITfCreatePropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.CreatePropertyStore(::core::mem::transmute_copy(&guidprop), ::core::mem::transmute(&prange), ::core::mem::transmute_copy(&cb), ::core::mem::transmute(&pstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3742,7 +3742,7 @@ impl ITfDisplayAttributeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3753,7 +3753,7 @@ impl ITfDisplayAttributeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3764,7 +3764,7 @@ impl ITfDisplayAttributeInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetAttributeInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pda = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pda, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3811,7 +3811,7 @@ impl ITfDisplayAttributeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDisplayAttributeInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3862,7 +3862,7 @@ impl ITfDisplayAttributeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDisplayAttributeInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3873,7 +3873,7 @@ impl ITfDisplayAttributeProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayAttributeInfo(::core::mem::transmute_copy(&guid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3920,7 +3920,7 @@ impl ITfDocumentMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetTop() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3931,7 +3931,7 @@ impl ITfDocumentMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetBase() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3942,7 +3942,7 @@ impl ITfDocumentMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumContexts() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3977,7 +3977,7 @@ impl ITfEditRecord_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectionStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfchanged = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfchanged, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -3988,7 +3988,7 @@ impl ITfEditRecord_Vtbl {
             let this = (*this).get_impl();
             match this.GetTextAndPropertyUpdates(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&prgproperties), ::core::mem::transmute_copy(&cproperties)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4189,7 +4189,7 @@ impl ITfFnGetLinguisticAlternates_Vtbl {
             let this = (*this).get_impl();
             match this.GetAlternates(::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcandidatelist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcandidatelist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4235,7 +4235,7 @@ impl ITfFnGetSAPIObject_Vtbl {
             let this = (*this).get_impl();
             match this.Get(::core::mem::transmute_copy(&sobj)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4292,7 +4292,7 @@ impl ITfFnLMProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.QueryLangID(::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaccepted = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaccepted, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4303,7 +4303,7 @@ impl ITfFnLMProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.GetReconversion(::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcandlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcandlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4319,7 +4319,7 @@ impl ITfFnLMProcessor_Vtbl {
             let this = (*this).get_impl();
             match this.QueryKey(::core::mem::transmute_copy(&fup), ::core::mem::transmute_copy(&vkey), ::core::mem::transmute_copy(&lparamkeydata)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinterested = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinterested, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4370,7 +4370,7 @@ impl ITfFnLangProfileUtil_Vtbl {
             let this = (*this).get_impl();
             match this.IsProfileAvailableForLang(::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfavailable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfavailable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4431,7 +4431,7 @@ impl ITfFnPropertyUIStatus_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus(::core::mem::transmute_copy(&refguidprop)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdw = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdw, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4473,7 +4473,7 @@ impl ITfFnReconversion_Vtbl {
             let this = (*this).get_impl();
             match this.GetReconversion(::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcandlist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcandlist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4510,7 +4510,7 @@ impl ITfFnSearchCandidateProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetSearchCandidates(::core::mem::transmute(&bstrquery), ::core::mem::transmute(&bstrapplicationid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4565,7 +4565,7 @@ impl ITfFunction_Vtbl {
             let this = (*this).get_impl();
             match this.GetDisplayName() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrname = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrname, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4593,7 +4593,7 @@ impl ITfFunctionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4604,7 +4604,7 @@ impl ITfFunctionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4615,7 +4615,7 @@ impl ITfFunctionProvider_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunction(::core::mem::transmute_copy(&rguid), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4680,7 +4680,7 @@ impl ITfInputProcessorProfileMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetProfile(::core::mem::transmute_copy(&dwprofiletype), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&clsid), ::core::mem::transmute_copy(&guidprofile), ::core::mem::transmute_copy(&hkl)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4691,7 +4691,7 @@ impl ITfInputProcessorProfileMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumProfiles(::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4731,7 +4731,7 @@ impl ITfInputProcessorProfileMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveProfile(::core::mem::transmute_copy(&catid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4764,7 +4764,7 @@ impl ITfInputProcessorProfileSubstituteLayout_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubstituteKeyboardLayout(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&guidprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phkl = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phkl, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4830,7 +4830,7 @@ impl ITfInputProcessorProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.EnumInputProcessorInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4861,7 +4861,7 @@ impl ITfInputProcessorProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.GetLanguageProfileDescription(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&guidprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrprofile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrprofile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4872,7 +4872,7 @@ impl ITfInputProcessorProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.GetCurrentLanguage() {
                 ::core::result::Result::Ok(ok__) => {
-                    *plangid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plangid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4893,7 +4893,7 @@ impl ITfInputProcessorProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.EnumLanguageProfiles(::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -4909,7 +4909,7 @@ impl ITfInputProcessorProfiles_Vtbl {
             let this = (*this).get_impl();
             match this.IsEnabledLanguageProfile(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&guidprofile)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfenable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfenable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5002,7 +5002,7 @@ impl ITfInputScope_Vtbl {
             let this = (*this).get_impl();
             match this.GetRegularExpression() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrregexp = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrregexp, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5013,7 +5013,7 @@ impl ITfInputScope_Vtbl {
             let this = (*this).get_impl();
             match this.GetSRGS() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrsrgs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrsrgs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5024,7 +5024,7 @@ impl ITfInputScope_Vtbl {
             let this = (*this).get_impl();
             match this.GetXML() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrxml = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrxml, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5057,7 +5057,7 @@ impl ITfInputScope2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumWordList() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenumstring = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenumstring, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5084,7 +5084,7 @@ impl ITfInsertAtSelection_Vtbl {
             let this = (*this).get_impl();
             match this.InsertTextAtSelection(::core::mem::transmute_copy(&ec), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pchtext), ::core::mem::transmute_copy(&cch)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5095,7 +5095,7 @@ impl ITfInsertAtSelection_Vtbl {
             let this = (*this).get_impl();
             match this.InsertEmbeddedAtSelection(::core::mem::transmute_copy(&ec), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pdataobject)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pprange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pprange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5134,7 +5134,7 @@ impl ITfIntegratableCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetSelectionStyle() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptfselectionstyle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptfselectionstyle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5145,7 +5145,7 @@ impl ITfIntegratableCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.OnKeyDown(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5156,7 +5156,7 @@ impl ITfIntegratableCandidateListUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.ShowCandidateNumbers() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfshow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfshow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5204,7 +5204,7 @@ impl ITfKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnTestKeyDown(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5215,7 +5215,7 @@ impl ITfKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnTestKeyUp(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5226,7 +5226,7 @@ impl ITfKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnKeyDown(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5237,7 +5237,7 @@ impl ITfKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnKeyUp(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5248,7 +5248,7 @@ impl ITfKeyEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnPreservedKey(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5335,7 +5335,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetForeground() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5346,7 +5346,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.TestKeyDown(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5357,7 +5357,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.TestKeyUp(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5368,7 +5368,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.KeyDown(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5379,7 +5379,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.KeyUp(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5390,7 +5390,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreservedKey(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&pprekey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5401,7 +5401,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.IsPreservedKey(::core::mem::transmute_copy(&rguid), ::core::mem::transmute_copy(&pprekey)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfregistered = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfregistered, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5427,7 +5427,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreservedKeyDescription(::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdesc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdesc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5438,7 +5438,7 @@ impl ITfKeystrokeMgr_Vtbl {
             let this = (*this).get_impl();
             match this.SimulatePreservedKey(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5481,7 +5481,7 @@ impl ITfLMLattice_Vtbl {
             let this = (*this).get_impl();
             match this.QueryType(::core::mem::transmute_copy(&rguidtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsupported = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsupported, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5492,7 +5492,7 @@ impl ITfLMLattice_Vtbl {
             let this = (*this).get_impl();
             match this.EnumLatticeElements(::core::mem::transmute_copy(&dwframestart), ::core::mem::transmute_copy(&rguidtype)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5552,7 +5552,7 @@ impl ITfLangBarEventSink_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemFloatingRect(::core::mem::transmute_copy(&dwthreadid), ::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5589,7 +5589,7 @@ impl ITfLangBarItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5600,7 +5600,7 @@ impl ITfLangBarItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwstatus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwstatus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5616,7 +5616,7 @@ impl ITfLangBarItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetTooltipString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtooltip = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtooltip, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5655,7 +5655,7 @@ impl ITfLangBarItemBalloon_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredSize(::core::mem::transmute_copy(&pszdefault)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5666,7 +5666,7 @@ impl ITfLangBarItemBalloon_Vtbl {
             let this = (*this).get_impl();
             match this.GetBalloonInfo() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5704,7 +5704,7 @@ impl ITfLangBarItemBitmap_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredSize(::core::mem::transmute_copy(&pszdefault)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5760,7 +5760,7 @@ impl ITfLangBarItemBitmapButton_Vtbl {
             let this = (*this).get_impl();
             match this.GetPreferredSize(::core::mem::transmute_copy(&pszdefault)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *psz = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(psz, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5776,7 +5776,7 @@ impl ITfLangBarItemBitmapButton_Vtbl {
             let this = (*this).get_impl();
             match this.GetText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5829,7 +5829,7 @@ impl ITfLangBarItemButton_Vtbl {
             let this = (*this).get_impl();
             match this.GetIcon() {
                 ::core::result::Result::Ok(ok__) => {
-                    *phicon = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phicon, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5840,7 +5840,7 @@ impl ITfLangBarItemButton_Vtbl {
             let this = (*this).get_impl();
             match this.GetText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5884,7 +5884,7 @@ impl ITfLangBarItemMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumItems() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5895,7 +5895,7 @@ impl ITfLangBarItemMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetItem(::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppitem = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppitem, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5926,7 +5926,7 @@ impl ITfLangBarItemMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemFloatingRect(::core::mem::transmute_copy(&dwthreadid), ::core::mem::transmute_copy(&rguid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prc = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prc, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -5942,7 +5942,7 @@ impl ITfLangBarItemMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemNum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6032,7 +6032,7 @@ impl ITfLangBarMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetThreadMarshalInterface(::core::mem::transmute_copy(&dwthreadid), ::core::mem::transmute_copy(&dwtype), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6068,7 +6068,7 @@ impl ITfLangBarMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetShowFloatingStatus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6106,7 +6106,7 @@ impl ITfLanguageProfileNotifySink_Vtbl {
             let this = (*this).get_impl();
             match this.OnLanguageChange(::core::mem::transmute_copy(&langid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaccept = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaccept, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6232,7 +6232,7 @@ impl ITfMouseSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnMouseEvent(::core::mem::transmute_copy(&uedge), ::core::mem::transmute_copy(&uquadrant), ::core::mem::transmute_copy(&dwbtnstatus)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfeaten = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfeaten, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6256,7 +6256,7 @@ impl ITfMouseTracker_Vtbl {
             let this = (*this).get_impl();
             match this.AdviseMouseSink(::core::mem::transmute(&range), ::core::mem::transmute(&psink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6289,7 +6289,7 @@ impl ITfMouseTrackerACP_Vtbl {
             let this = (*this).get_impl();
             match this.AdviseMouseSink(::core::mem::transmute(&range), ::core::mem::transmute(&psink)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6324,7 +6324,7 @@ impl ITfPersistentPropertyLoaderACP_Vtbl {
             let this = (*this).get_impl();
             match this.LoadProperty(::core::mem::transmute_copy(&phdr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppstream = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppstream, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6419,7 +6419,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6430,7 +6430,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetDataType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwreserved = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwreserved, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6441,7 +6441,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6452,7 +6452,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.OnTextUpdated(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&prangenew)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaccept = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaccept, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6463,7 +6463,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.Shrink(::core::mem::transmute(&prangenew)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pffree = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pffree, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6474,7 +6474,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.Divide(::core::mem::transmute(&prangethis), ::core::mem::transmute(&prangenew)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pppropstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pppropstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6485,7 +6485,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropstore = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropstore, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6496,7 +6496,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyRangeCreator() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pclsid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pclsid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6507,7 +6507,7 @@ impl ITfPropertyStore_Vtbl {
             let this = (*this).get_impl();
             match this.Serialize(::core::mem::transmute(&pstream)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcb = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcb, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6544,7 +6544,7 @@ impl ITfQueryEmbedded_Vtbl {
             let this = (*this).get_impl();
             match this.QueryInsertEmbedded(::core::mem::transmute_copy(&pguidservice), ::core::mem::transmute_copy(&pformatetc)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinsertable = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinsertable, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6601,7 +6601,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormattedText(::core::mem::transmute_copy(&ec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdataobject = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdataobject, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6612,7 +6612,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetEmbedded(::core::mem::transmute_copy(&ec), ::core::mem::transmute_copy(&rguidservice), ::core::mem::transmute_copy(&riid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppunk = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppunk, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6648,7 +6648,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.ShiftStartRegion(::core::mem::transmute_copy(&ec), ::core::mem::transmute_copy(&dir)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfnoregion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfnoregion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6659,7 +6659,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.ShiftEndRegion(::core::mem::transmute_copy(&ec), ::core::mem::transmute_copy(&dir)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfnoregion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfnoregion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6670,7 +6670,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.IsEmpty(::core::mem::transmute_copy(&ec)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfempty = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfempty, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6686,7 +6686,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqualStart(::core::mem::transmute_copy(&ec), ::core::mem::transmute(&pwith), ::core::mem::transmute_copy(&apos)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6697,7 +6697,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.IsEqualEnd(::core::mem::transmute_copy(&ec), ::core::mem::transmute(&pwith), ::core::mem::transmute_copy(&apos)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfequal = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfequal, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6708,7 +6708,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.CompareStart(::core::mem::transmute_copy(&ec), ::core::mem::transmute(&pwith), ::core::mem::transmute_copy(&apos)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6719,7 +6719,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.CompareEnd(::core::mem::transmute_copy(&ec), ::core::mem::transmute(&pwith), ::core::mem::transmute_copy(&apos)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *plresult = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(plresult, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6730,7 +6730,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.AdjustForInsert(::core::mem::transmute_copy(&ec), ::core::mem::transmute_copy(&cchinsert)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfinsertok = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfinsertok, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6751,7 +6751,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.Clone() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppclone = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppclone, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6762,7 +6762,7 @@ impl ITfRange_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6862,7 +6862,7 @@ impl ITfReadOnlyProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetType() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6878,7 +6878,7 @@ impl ITfReadOnlyProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetValue(::core::mem::transmute_copy(&ec), ::core::mem::transmute(&prange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvarvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvarvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6889,7 +6889,7 @@ impl ITfReadOnlyProperty_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6926,7 +6926,7 @@ impl ITfReadingInformationUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetUpdatedFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6937,7 +6937,7 @@ impl ITfReadingInformationUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppic = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppic, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6948,7 +6948,7 @@ impl ITfReadingInformationUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6959,7 +6959,7 @@ impl ITfReadingInformationUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetMaxReadingStringLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcchmax = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcchmax, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6970,7 +6970,7 @@ impl ITfReadingInformationUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetErrorIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *perrorindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(perrorindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -6981,7 +6981,7 @@ impl ITfReadingInformationUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.IsVerticalOrderPreferred() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvertical = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvertical, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7012,7 +7012,7 @@ impl ITfReverseConversion_Vtbl {
             let this = (*this).get_impl();
             match this.DoReverseConversion(::core::mem::transmute(&lpstr)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplist = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplist, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7039,7 +7039,7 @@ impl ITfReverseConversionList_Vtbl {
             let this = (*this).get_impl();
             match this.GetLength() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7050,7 +7050,7 @@ impl ITfReverseConversionList_Vtbl {
             let this = (*this).get_impl();
             match this.GetString(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7077,7 +7077,7 @@ impl ITfReverseConversionMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetReverseConversion(::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&guidprofile), ::core::mem::transmute_copy(&dwflag)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppreverseconversion = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppreverseconversion, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7101,7 +7101,7 @@ impl ITfSource_Vtbl {
             let this = (*this).get_impl();
             match this.AdviseSink(::core::mem::transmute_copy(&riid), ::core::mem::transmute(&punk)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwcookie = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwcookie, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7220,7 +7220,7 @@ impl ITfSystemDeviceTypeLangBarItem_Vtbl {
             let this = (*this).get_impl();
             match this.GetIconMode() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7313,7 +7313,7 @@ impl ITfSystemLangBarItemText_Vtbl {
             let this = (*this).get_impl();
             match this.GetItemText() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrtext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrtext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7458,7 +7458,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.Activate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7474,7 +7474,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDocumentMgr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdim = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdim, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7485,7 +7485,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDocumentMgrs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7496,7 +7496,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdimfocus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdimfocus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7512,7 +7512,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.AssociateFocus(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&pdimnew)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdimprev = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdimprev, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7523,7 +7523,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.IsThreadFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfthreadfocus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfthreadfocus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7534,7 +7534,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionProvider(::core::mem::transmute_copy(&clsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfuncprov = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfuncprov, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7545,7 +7545,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFunctionProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7556,7 +7556,7 @@ impl ITfThreadMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlobalCompartment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcompmgr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcompmgr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7608,7 +7608,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.Activate() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ptid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ptid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7624,7 +7624,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.CreateDocumentMgr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdim = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdim, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7635,7 +7635,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumDocumentMgrs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7646,7 +7646,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdimfocus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdimfocus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7662,7 +7662,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.IsThreadFocus() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfthreadfocus = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfthreadfocus, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7673,7 +7673,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.GetFunctionProvider(::core::mem::transmute_copy(&clsid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppfuncprov = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppfuncprov, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7684,7 +7684,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.EnumFunctionProviders() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7695,7 +7695,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.GetGlobalCompartment() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcompmgr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcompmgr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7711,7 +7711,7 @@ impl ITfThreadMgr2_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7817,7 +7817,7 @@ impl ITfThreadMgrEx_Vtbl {
             let this = (*this).get_impl();
             match this.GetActiveFlags() {
                 ::core::result::Result::Ok(ok__) => {
-                    *lpdwflags = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(lpdwflags, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7847,7 +7847,7 @@ impl ITfToolTipUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetString() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7873,7 +7873,7 @@ impl ITfTransitoryExtensionSink_Vtbl {
             let this = (*this).get_impl();
             match this.OnTransitoryExtensionUpdated(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&ecreadonly), ::core::mem::transmute(&presultrange), ::core::mem::transmute(&pcompositionrange)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfdeleteresultrange = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfdeleteresultrange, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7902,7 +7902,7 @@ impl ITfTransitoryExtensionUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetDocumentMgr() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdim = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdim, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7931,7 +7931,7 @@ impl ITfUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbstrdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbstrdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7942,7 +7942,7 @@ impl ITfUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.GetGUID() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pguid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pguid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -7958,7 +7958,7 @@ impl ITfUIElement_Vtbl {
             let this = (*this).get_impl();
             match this.IsShown() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbshow = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbshow, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8009,7 +8009,7 @@ impl ITfUIElementMgr_Vtbl {
             let this = (*this).get_impl();
             match this.GetUIElement(::core::mem::transmute_copy(&dwuielementid)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppelement = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppelement, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8020,7 +8020,7 @@ impl ITfUIElementMgr_Vtbl {
             let this = (*this).get_impl();
             match this.EnumUIElements() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppenum = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppenum, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8152,7 +8152,7 @@ impl IVersionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetSubcomponentCount(::core::mem::transmute_copy(&ulsub)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ulcount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ulcount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8163,7 +8163,7 @@ impl IVersionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetImplementationID(::core::mem::transmute_copy(&ulsub)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *implid = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(implid, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8179,7 +8179,7 @@ impl IVersionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetComponentDescription(::core::mem::transmute_copy(&ulsub)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pimplstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pimplstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -8190,7 +8190,7 @@ impl IVersionInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetInstanceDescription(::core::mem::transmute_copy(&ulsub)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pimplstr = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pimplstr, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
@@ -14,7 +14,7 @@ impl IMILBitmapEffect_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutput(::core::mem::transmute_copy(&uiindex), ::core::mem::transmute(&pcontext)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbitmapsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbitmapsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -25,7 +25,7 @@ impl IMILBitmapEffect_Vtbl {
             let this = (*this).get_impl();
             match this.GetParentEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppparenteffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppparenteffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -59,7 +59,7 @@ impl IMILBitmapEffectConnections_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputConnector(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -70,7 +70,7 @@ impl IMILBitmapEffectConnections_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputConnector(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -100,7 +100,7 @@ impl IMILBitmapEffectConnectionsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberInputs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puinuminputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puinuminputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -111,7 +111,7 @@ impl IMILBitmapEffectConnectionsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberOutputs() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puinumoutputs = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puinumoutputs, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -122,7 +122,7 @@ impl IMILBitmapEffectConnectionsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputConnectorInfo(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnectorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnectorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -133,7 +133,7 @@ impl IMILBitmapEffectConnectionsInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputConnectorInfo(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnectorinfo = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnectorinfo, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -163,7 +163,7 @@ impl IMILBitmapEffectConnector_Vtbl {
             let this = (*this).get_impl();
             match this.IsConnected() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfconnected = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfconnected, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -174,7 +174,7 @@ impl IMILBitmapEffectConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitmapEffect() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -204,7 +204,7 @@ impl IMILBitmapEffectConnectorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetIndex() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puiindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puiindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -215,7 +215,7 @@ impl IMILBitmapEffectConnectorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetOptimalFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -226,7 +226,7 @@ impl IMILBitmapEffectConnectorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberFormats() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pulnumberformats = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pulnumberformats, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -237,7 +237,7 @@ impl IMILBitmapEffectConnectorInfo_Vtbl {
             let this = (*this).get_impl();
             match this.GetFormat(::core::mem::transmute_copy(&ulindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -298,7 +298,7 @@ impl IMILBitmapEffectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEffect(::core::mem::transmute_copy(&pguideffect)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -309,7 +309,7 @@ impl IMILBitmapEffectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateContext() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppcontext = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppcontext, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -320,7 +320,7 @@ impl IMILBitmapEffectFactory_Vtbl {
             let this = (*this).get_impl();
             match this.CreateEffectOuter() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -350,7 +350,7 @@ impl IMILBitmapEffectGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetInteriorInputConnector(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -361,7 +361,7 @@ impl IMILBitmapEffectGroup_Vtbl {
             let this = (*this).get_impl();
             match this.GetInteriorOutputConnector(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -401,7 +401,7 @@ impl IMILBitmapEffectGroupImpl_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puinumberchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puinumberchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -412,7 +412,7 @@ impl IMILBitmapEffectGroupImpl_Vtbl {
             let this = (*this).get_impl();
             match this.GetChildren() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pchildren = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pchildren, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -449,7 +449,7 @@ impl IMILBitmapEffectImpl_Vtbl {
             let this = (*this).get_impl();
             match this.IsInPlaceModificationAllowed(::core::mem::transmute(&poutputconnector)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfmodifyinplace = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfmodifyinplace, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -465,7 +465,7 @@ impl IMILBitmapEffectImpl_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputSource(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbitmapsource = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbitmapsource, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -476,7 +476,7 @@ impl IMILBitmapEffectImpl_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputSourceBounds(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *prect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(prect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -529,7 +529,7 @@ impl IMILBitmapEffectInputConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnection() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -556,7 +556,7 @@ impl IMILBitmapEffectInteriorInputConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetInputConnector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinputconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinputconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -579,7 +579,7 @@ impl IMILBitmapEffectInteriorOutputConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputConnector() {
                 ::core::result::Result::Ok(ok__) => {
-                    *poutputconnector = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(poutputconnector, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -603,7 +603,7 @@ impl IMILBitmapEffectOutputConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetNumberConnections() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puinumberconnections = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puinumberconnections, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -614,7 +614,7 @@ impl IMILBitmapEffectOutputConnector_Vtbl {
             let this = (*this).get_impl();
             match this.GetConnection(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppconnection = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppconnection, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -691,7 +691,7 @@ impl IMILBitmapEffectPrimitive_Vtbl {
             let this = (*this).get_impl();
             match this.HasAffineTransform(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfaffine = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfaffine, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -702,7 +702,7 @@ impl IMILBitmapEffectPrimitive_Vtbl {
             let this = (*this).get_impl();
             match this.HasInverseTransform(::core::mem::transmute_copy(&uiindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfhasinverse = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfhasinverse, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -744,7 +744,7 @@ impl IMILBitmapEffectPrimitiveImpl_Vtbl {
             let this = (*this).get_impl();
             match this.IsVolatile(::core::mem::transmute_copy(&uioutputindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfvolatile = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfvolatile, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -783,7 +783,7 @@ impl IMILBitmapEffectRenderContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetOutputPixelFormat() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pformat = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pformat, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -804,7 +804,7 @@ impl IMILBitmapEffectRenderContext_Vtbl {
             let this = (*this).get_impl();
             match this.GetFinalTransform() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pmatrix = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pmatrix, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -856,7 +856,7 @@ impl IMILBitmapEffectRenderContextImpl_Vtbl {
             let this = (*this).get_impl();
             match this.GetUseSoftwareRenderer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pfsoftware = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pfsoftware, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -909,7 +909,7 @@ impl IMILBitmapEffects_Vtbl {
             let this = (*this).get_impl();
             match this._NewEnum() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppiureturn = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppiureturn, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -920,7 +920,7 @@ impl IMILBitmapEffects_Vtbl {
             let this = (*this).get_impl();
             match this.Parent() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -931,7 +931,7 @@ impl IMILBitmapEffects_Vtbl {
             let this = (*this).get_impl();
             match this.Item(::core::mem::transmute_copy(&uindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppeffect = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppeffect, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -942,7 +942,7 @@ impl IMILBitmapEffects_Vtbl {
             let this = (*this).get_impl();
             match this.Count() {
                 ::core::result::Result::Ok(ok__) => {
-                    *puicount = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(puicount, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/impl.rs
@@ -20,7 +20,7 @@ impl IBitmapData_Vtbl {
             let this = (*this).get_impl();
             match this.GetStride() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pstride = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pstride, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -31,7 +31,7 @@ impl IBitmapData_Vtbl {
             let this = (*this).get_impl();
             match this.GetBitmapDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbitmapdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbitmapdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -42,7 +42,7 @@ impl IBitmapData_Vtbl {
             let this = (*this).get_impl();
             match this.GetSourceBitmapDescription() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pbitmapdescription = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pbitmapdescription, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -100,7 +100,7 @@ impl IVisualTreeService_Vtbl {
             let this = (*this).get_impl();
             match this.CreateInstance(::core::mem::transmute(&typename), ::core::mem::transmute(&value)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinstancehandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinstancehandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -126,7 +126,7 @@ impl IVisualTreeService_Vtbl {
             let this = (*this).get_impl();
             match this.GetCollectionCount(::core::mem::transmute_copy(&instancehandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pcollectionsize = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pcollectionsize, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -189,7 +189,7 @@ impl IVisualTreeService2_Vtbl {
             let this = (*this).get_impl();
             match this.GetPropertyIndex(::core::mem::transmute_copy(&object), ::core::mem::transmute(&propertyname)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppropertyindex = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppropertyindex, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -200,7 +200,7 @@ impl IVisualTreeService2_Vtbl {
             let this = (*this).get_impl();
             match this.GetProperty(::core::mem::transmute_copy(&object), ::core::mem::transmute_copy(&propertyindex)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pvalue = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -216,7 +216,7 @@ impl IVisualTreeService2_Vtbl {
             let this = (*this).get_impl();
             match this.RenderTargetBitmap(::core::mem::transmute_copy(&handle), ::core::mem::transmute_copy(&options), ::core::mem::transmute_copy(&maxpixelwidth), ::core::mem::transmute_copy(&maxpixelheight)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppbitmapdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppbitmapdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -256,7 +256,7 @@ impl IVisualTreeService3_Vtbl {
             let this = (*this).get_impl();
             match this.GetDictionaryItem(::core::mem::transmute_copy(&dictionaryhandle), ::core::mem::transmute(&resourcename), ::core::mem::transmute_copy(&resourceisimplicitstyle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *resourcehandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(resourcehandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -345,7 +345,7 @@ impl IXamlDiagnostics_Vtbl {
             let this = (*this).get_impl();
             match this.GetDispatcher() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppdispatcher = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppdispatcher, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -356,7 +356,7 @@ impl IXamlDiagnostics_Vtbl {
             let this = (*this).get_impl();
             match this.GetUiLayer() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pplayer = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pplayer, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -367,7 +367,7 @@ impl IXamlDiagnostics_Vtbl {
             let this = (*this).get_impl();
             match this.GetApplication() {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppapplication = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppapplication, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -378,7 +378,7 @@ impl IXamlDiagnostics_Vtbl {
             let this = (*this).get_impl();
             match this.GetIInspectableFromHandle(::core::mem::transmute_copy(&instancehandle)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *ppinstance = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(ppinstance, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -389,7 +389,7 @@ impl IXamlDiagnostics_Vtbl {
             let this = (*this).get_impl();
             match this.GetHandleFromIInspectable(::core::mem::transmute(&pinstance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *phandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(phandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -405,7 +405,7 @@ impl IXamlDiagnostics_Vtbl {
             let this = (*this).get_impl();
             match this.RegisterInstance(::core::mem::transmute(&pinstance)) {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinstancehandle = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinstancehandle, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),
@@ -416,7 +416,7 @@ impl IXamlDiagnostics_Vtbl {
             let this = (*this).get_impl();
             match this.GetInitializationData() {
                 ::core::result::Result::Ok(ok__) => {
-                    *pinitializationdata = ::core::mem::transmute(ok__);
+                    ::core::ptr::write(pinitializationdata, ::core::mem::transmute(ok__));
                     ::windows::core::HRESULT(0)
                 }
                 ::core::result::Result::Err(err) => err.into(),


### PR DESCRIPTION
Fixes #1680 

When COM interfaces are used from Rust, out params are initialized before being passed to the vtable. However, this is not always the case from other languages where an uninitialized value might be passed as an out param. Using the `*ptr = value` syntax in Rust causes `ptr` to be read (and dropped) which is obviously not correct for uninitialized values. The docs clearly state that one should prefer using `core::ptr::write` when writing to uninitialized values. 

*Please review commit by commit as the codegen is run in separate commits*