### PR TITLE
Inline `HSTRING::clear` into the `Drop` impl

### DIFF
--- a/crates/libs/windows/src/core/hstring.rs
+++ b/crates/libs/windows/src/core/hstring.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// A WinRT string ([HSTRING](https://docs.microsoft.com/en-us/windows/win32/winrt/hstring)),
+/// A WinRT string ([HSTRING](https://docs.microsoft.com/en-us/windows/win32/winrt/hstring))
 /// is reference-counted and immutable.
 #[repr(transparent)]
 pub struct HSTRING(*mut Header);
@@ -51,27 +51,6 @@ impl HSTRING {
     /// Get the contents of this `HSTRING` as a OsString.
     pub fn to_os_string(&self) -> std::ffi::OsString {
         std::os::windows::ffi::OsStringExt::from_wide(self.as_wide())
-    }
-
-    /// Clear the contents of the string and free the memory if `self` holds the
-    /// last reference to the string data.
-    pub fn clear(&mut self) {
-        if self.is_empty() {
-            return;
-        }
-
-        unsafe {
-            // This flag indicates a "fast pass" string created by some languages where the
-            // header is allocated on the stack. Such strings must never be freed.
-            let header = self.0;
-            debug_assert!((*header).flags & REFERENCE_FLAG == 0);
-
-            if (*header).count.release() == 0 {
-                heap_free(self.0 as RawPtr);
-            }
-        }
-
-        self.0 = core::ptr::null_mut();
     }
 
     /// # Safety
@@ -128,7 +107,23 @@ impl Clone for HSTRING {
 
 impl Drop for HSTRING {
     fn drop(&mut self) {
-        self.clear();
+        if self.is_empty() {
+            return;
+        }
+
+        unsafe {
+            let header = std::mem::replace(&mut self.0, core::ptr::null_mut());
+            // This flag indicates a "fast pass" string created by some languages where the
+            // header is allocated on the stack. "Fast pass" strings can only ever be used
+            // as non-owned input params and as such `drop` will never be called. This check
+            // just ensures the Rust translation never accidentally modeled "fast pass" input
+            // params as owned `HSTRING` types which would be a bug in the translation.
+            debug_assert!((*header).flags & REFERENCE_FLAG == 0);
+
+            if (*header).count.release() == 0 {
+                heap_free(header as RawPtr);
+            }
+        }
     }
 }
 

--- a/crates/tests/core/tests/hstrings.rs
+++ b/crates/tests/core/tests/hstrings.rs
@@ -7,7 +7,7 @@ fn hstring_works() {
     assert!(empty.is_empty());
     assert!(empty.is_empty());
 
-    let mut hello = HSTRING::from("Hello");
+    let hello = HSTRING::from("Hello");
     assert!(!hello.is_empty());
     assert!(hello.len() == 5);
 
@@ -16,10 +16,6 @@ fn hstring_works() {
     assert!(rust.len() == 5);
 
     let hello2 = hello.clone();
-    hello.clear();
-    assert!(hello.is_empty());
-    hello.clear();
-    assert!(hello.is_empty());
     assert!(!hello2.is_empty());
     assert!(hello2.len() == 5);
 


### PR DESCRIPTION
As I've asked in [another PR](https://github.com/microsoft/windows-rs/pull/1747#issuecomment-1122352608), there was some confusion about a `debug_assert!` in the `HSTRING::clear` method which would panic in debug mode if it was detected we were trying to clear a "fast pass" string (i.e., an `HSTRING` which allocates its header on the stake which is used in some languages).

It struck me as odd that we were using a `debug_assert!` since it seemed like something we'd always want to prevent, and @kennykerr let me know that "fast pass" `HSTRING`s are only used as `in` arguments (and only can be since their headers are stack allocated). Because `in` arguments are not "owned" and thus should not have their destructors run, the `Drop` impl where `HSTRING::clear` was (and continues) being called would never run, and if it did it was because of a bad translation from the Rust side (hence the `debug_assert!`). 

However, this means that calling `HSTRING::clear` should not be called directly on a "fast pass" `HSTRING`, but it was possible to do so from otherwise correct and safe code. Since `HSTRING::clear` is not really necessary to expose, I've decided to inline the implementation into the `Drop` impl, and I've made some of the comments around it more clear.