### PR TITLE
Remove `cast` method produces by `implement` macro

### DIFF
--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -53,10 +53,10 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
             impl <#constraints> ::core::convert::From<#original_ident::<#(#generics,)*>> for #interface_ident {
                 fn from(this: #original_ident::<#(#generics,)*>) -> Self {
                     let this = #impl_ident::<#(#generics,)*>::new(this);
-                    let mut this = ::std::boxed::Box::new(this);
-                    let vtable_ptr = &mut this.vtables.#offset as *mut *const <#interface_ident as ::windows::core::Interface>::Vtable;
-                    let _ = ::std::boxed::Box::leak(this);
-                    unsafe { ::core::mem::transmute_copy(&vtable_ptr) }
+                    let mut this = ::core::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+                    let vtable_ptr = &this.vtables.#offset;
+                    // SAFETY: interfaces are in-memory equivalent to pointers to their vtables.
+                    unsafe { ::core::mem::transmute(vtable_ptr) }
                 }
             }
             impl <#constraints> ::windows::core::AsImpl<#original_ident::<#(#generics,)*>> for #interface_ident {
@@ -163,23 +163,19 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
         }
         impl <#constraints> ::core::convert::From<#original_ident::<#(#generics,)*>> for ::windows::core::IUnknown {
             fn from(this: #original_ident::<#(#generics,)*>) -> Self {
+                let this = #impl_ident::<#(#generics,)*>::new(this);
+                let boxed = ::core::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
                 unsafe {
-                    let this = #impl_ident::<#(#generics,)*>::new(this);
-                    let ptr = ::std::boxed::Box::into_raw(::std::boxed::Box::new(this));
-                    ::core::mem::transmute_copy(&::core::ptr::NonNull::new_unchecked(
-                        &mut (*ptr).identity as *mut _ as _
-                    ))
+                    ::core::mem::transmute(&boxed.identity)
                 }
             }
         }
         impl <#constraints> ::core::convert::From<#original_ident::<#(#generics,)*>> for ::windows::core::IInspectable {
             fn from(this: #original_ident::<#(#generics,)*>) -> Self {
+                let this = #impl_ident::<#(#generics,)*>::new(this);
+                let boxed = ::core::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
                 unsafe {
-                    let this = #impl_ident::<#(#generics,)*>::new(this);
-                    let ptr = ::std::boxed::Box::into_raw(::std::boxed::Box::new(this));
-                    ::core::mem::transmute_copy(&::core::ptr::NonNull::new_unchecked(
-                        &mut (*ptr).identity as *mut _ as _
-                    ))
+                    ::core::mem::transmute(&boxed.identity)
                 }
             }
         }

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -8,7 +8,6 @@ use tokens::*;
 pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let attributes = syn::parse_macro_input!(attributes as ImplementAttributes);
     let generics = attributes.generics();
-    let interfaces_len = Literal::usize_unsuffixed(attributes.implement.len());
 
     let constraints = quote! {
         #(#generics: ::windows::core::RuntimeType + 'static,)*
@@ -145,10 +144,11 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
             }
         }
         impl <#constraints> #original_ident::<#(#generics,)*> {
-            fn cast<ResultType: ::windows::core::Interface>(&self) -> ::windows::core::Result<ResultType> {
+            fn alloc<ResultType: ::windows::core::Interface>(self) -> ::windows::core::Result<ResultType> {
+                let this = #impl_ident::<#(#generics,)*>::new(self);
+                let boxed = ::core::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+                let mut result = None;
                 unsafe {
-                    let boxed = (self as *const #original_ident::<#(#generics,)*> as *mut #original_ident::<#(#generics,)*> as *mut ::windows::core::RawPtr).sub(2 + #interfaces_len) as *mut #impl_ident::<#(#generics,)*>;
-                    let mut result = None;
                     <#impl_ident::<#(#generics,)*> as ::windows::core::IUnknownImpl>::QueryInterface(&*boxed, &ResultType::IID, &mut result as *mut _ as _).and_some(result)
                 }
             }

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -144,13 +144,18 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
             }
         }
         impl <#constraints> #original_ident::<#(#generics,)*> {
-            fn alloc<ResultType: ::windows::core::Interface>(self) -> ::windows::core::Result<ResultType> {
+            fn alloc<I: ::windows::core::Interface>(self) -> ::windows::core::Result<I> {
                 let this = #impl_ident::<#(#generics,)*>::new(self);
                 let boxed = ::core::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
                 let mut result = None;
-                unsafe {
-                    <#impl_ident::<#(#generics,)*> as ::windows::core::IUnknownImpl>::QueryInterface(&*boxed, &ResultType::IID, &mut result as *mut _ as _).and_some(result)
+                let result = unsafe {
+                    <#impl_ident::<#(#generics,)*> as ::windows::core::IUnknownImpl>::QueryInterface(&*boxed, &I::IID, &mut result as *mut _ as _).and_some(result)
+                };
+                // If querying for the supplied interface fails, we must free the underlying implementation, otherwise that memory will be leaked
+                if result.is_err() {
+                    let _ = ::core::mem::ManuallyDrop::into_inner(boxed);
                 }
+                result
             }
         }
         impl <#constraints> ::windows::core::Compose for #original_ident::<#(#generics,)*> {

--- a/crates/tests/nightly_implement/tests/cast_self.rs
+++ b/crates/tests/nightly_implement/tests/cast_self.rs
@@ -5,7 +5,7 @@ use windows::UI::Xaml::*;
 // TODO: This is a compile-only test for now until #81 is further along and can provide composable test classes.
 
 #[implement(IApplicationOverrides)]
-struct App();
+struct App;
 
 #[allow(non_snake_case)]
 impl IApplicationOverrides_Impl for App {

--- a/crates/tests/nightly_implement/tests/com.rs
+++ b/crates/tests/nightly_implement/tests/com.rs
@@ -52,6 +52,5 @@ fn mix() -> Result<()> {
     let f: IStringable = Mix.alloc()?;
     assert!(f.ToString()? == "Mix");
 
-
     Ok(())
 }

--- a/crates/tests/nightly_implement/tests/com.rs
+++ b/crates/tests/nightly_implement/tests/com.rs
@@ -7,7 +7,7 @@ use windows::Win32::System::WinRT::Composition::*;
 use windows::Win32::System::WinRT::Display::*;
 
 #[implement(windows::Foundation::IStringable, windows::Win32::System::WinRT::Composition::ISwapChainInterop, windows::Win32::System::WinRT::Display::IDisplayPathInterop)]
-struct Mix();
+struct Mix;
 
 impl IStringable_Impl for Mix {
     fn ToString(&self) -> Result<HSTRING> {
@@ -32,13 +32,13 @@ impl IDisplayPathInterop_Impl for Mix {
 
 #[test]
 fn mix() -> Result<()> {
-    let a: ISwapChainInterop = Mix().into();
+    let a: ISwapChainInterop = Mix.into();
     unsafe { a.SetSwapChain(None)? };
 
     let b: IStringable = a.cast()?;
     assert!(b.ToString()? == "Mix");
 
-    let c: IStringable = Mix().into();
+    let c: IStringable = Mix.into();
     assert!(c.ToString()? == "Mix");
 
     let d: ISwapChainInterop = c.cast()?;
@@ -47,6 +47,11 @@ fn mix() -> Result<()> {
     let e: IDisplayPathInterop = d.cast()?;
     unsafe { assert!(e.GetSourceId()? == 123) };
     unsafe { assert!(e.CreateSourcePresentationHandle()? == HANDLE::default()) };
+
+    // `alloc` allows querying for arbitrary interfaces
+    let f: IStringable = Mix.alloc()?;
+    assert!(f.ToString()? == "Mix");
+
 
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/windows-rs/issues/1183

Before this PR, the `implement` macro created a `cast` method for the types using `implement` macro that allowed users to query for arbitrary interfaces directly from the implementing type. This method, however, was hard to use properly as it required that not only `self` be heap allocated but that it be allocated inside the `_Impl` struct. 

This PR ditches the `cast` method for an `alloc` method. This method does the dance of placing the type inside the `_Impl` struct, heap allocating it, and then calling `QueryInterface` to query for the supplied interface. This is essentially the dynamic equivalent of the various `From` impls the `implement` macro already creates (which can skip calling `QueryInterface` since we know those interfaces are implemented). 

`alloc` still has the issue of consuming `self` meaning that once `alloc` is called the user can no longer use the original implementation type. However, if the user needs access to the original type, the user can query for one of the interfaces used in the `implement` macro which will implement the `AsImpl` trait allowing the user to retrieve an `&` reference to the original type. Unfortunately, if the call to `alloc` fails (presumably because the type does not implement the interface being queried for), the user will no longer have any access to the underlying type (and it will be freed). 

Some questions:
* Is this `alloc` function actually useful? Would it perhaps be a better idea to remove it?
* If we keep `alloc`, should we consider returning `self` on failure so the user can keep using it?
* Would this have been better as an issue or an RFC? The change seemed to be mostly in service of a bug fix and rather small in scope, so a PR felt appropriate. 