### PR TITLE
Version 0.37.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -83,7 +83,7 @@ body:
         # ...
 
         [dependencies.windows]
-        version = "0.36.1"
+        version = "0.37.0"
         features = [
             "alloc",
             "Win32_Foundation",

--- a/.github/publish.cmd
+++ b/.github/publish.cmd
@@ -1,0 +1,11 @@
+cargo publish windows_aarch64_msvc
+cargo publish windows_i686_gnu
+cargo publish windows_i686_msvc
+cargo publish windows_x86_64_gnu
+cargo publish windows_x86_64_msvc
+cargo publish windows-tokens
+cargo publish windows-metadata
+cargo publish windows-interface
+cargo publish windows-implement
+cargo publish windows-bindgen
+cargo publish windows

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -15,7 +15,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows]
-version = "0.36.1"
+version = "0.37.0"
 features = [
     "alloc",
     "Data_Xml_Dom",

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-bindgen"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -12,5 +12,5 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies]
-tokens = { package = "windows-tokens", path = "../tokens", version = "0.36.1" }
-metadata = { package = "windows-metadata", path = "../metadata", version = "0.36.1" }
+tokens = { package = "windows-tokens", path = "../tokens", version = "0.37.0" }
+metadata = { package = "windows-metadata", path = "../metadata", version = "0.37.0" }

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-implement"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,4 +16,4 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "1.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "derive"] }
-tokens = { package = "windows-tokens", path = "../tokens", version = "0.36.1" }
+tokens = { package = "windows-tokens", path = "../tokens", version = "0.37.0" }

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-interface"
-version = "0.36.1"
+version = "0.37.0"
 edition = "2018"
 authors = ["Microsoft"]
 license = "MIT OR Apache-2.0"

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-metadata"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,34 +16,34 @@ targets = []
 all-features = true
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [features]
 default = []

--- a/crates/libs/tokens/Cargo.toml
+++ b/crates/libs/tokens/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-tokens"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,38 +16,38 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [dependencies]
-windows-implement = { path = "../implement",  version = "0.36.1", optional = true }
-windows-interface = { path = "../interface",  version = "0.36.1", optional = true }
+windows-implement = { path = "../implement",  version = "0.37.0", optional = true }
+windows-interface = { path = "../interface",  version = "0.37.0", optional = true }
 
 [features]
 default = []

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/tools/bindings/Cargo.toml
+++ b/crates/tools/bindings/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.36.1" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.36.1" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.37.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.37.0" }

--- a/crates/tools/gnu/Cargo.toml
+++ b/crates/tools/gnu/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.36.1" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.37.0" }

--- a/crates/tools/ilrs/Cargo.toml
+++ b/crates/tools/ilrs/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.36.1" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.37.0" }

--- a/crates/tools/msvc/Cargo.toml
+++ b/crates/tools/msvc/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.36.1" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.37.0" }

--- a/crates/tools/sys/Cargo.toml
+++ b/crates/tools/sys/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.36.1" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.36.1" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.37.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.37.0" }
 rayon = "1.5.1"

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         r#"
 [package]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -40,34 +40,34 @@ targets = []
 all-features = true
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [features]
 default = []

--- a/crates/tools/windows/Cargo.toml
+++ b/crates/tools/windows/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.36.1" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.36.1" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.37.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.37.0" }
 rayon = "1.5.1"

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         r#"
 [package]
 name = "windows"
-version = "0.36.1"
+version = "0.37.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -40,38 +40,38 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.36.1" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.37.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.36.1" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.37.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.36.1" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.37.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.36.1" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.37.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.36.1" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.37.0" }
 
 [dependencies]
-windows-implement = { path = "../implement",  version = "0.36.1", optional = true }
-windows-interface = { path = "../interface",  version = "0.36.1", optional = true }
+windows-implement = { path = "../implement",  version = "0.37.0", optional = true }
+windows-interface = { path = "../interface",  version = "0.37.0", optional = true }
 
 [features]
 default = []

--- a/crates/tools/yml/Cargo.toml
+++ b/crates/tools/yml/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.36.1" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.37.0" }


### PR DESCRIPTION
This is the regular 3-week release of the `windows` crate. The `windows-sys` crate will be excluded from this release cycle as it remains stable and unchanged. 