### PR TITLE
Remove unused types

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -166,8 +166,6 @@ impl<'a> Gen<'a> {
                 quote! { [#name; #len] }
             }
             Type::GenericParam(generic) => self.reader.generic_param_name(*generic).into(),
-            //Type::MethodDef(def) => self.reader.method_def_name(def).into(),
-            //Type::Field(field) => field.name().into(),
             Type::TypeDef((def, generics)) => self.type_def_name(*def, generics),
             Type::MutPtr((ty, pointers)) => {
                 let pointers = mut_ptrs(*pointers);

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -78,8 +78,6 @@ pub enum Type {
     PCWSTR,
     TypeName,
     GenericParam(GenericParam),
-    MethodDef(MethodDef),
-    Field(Field),
     TypeDef((TypeDef, Vec<Self>)),
     MutPtr((Box<Self>, usize)),
     ConstPtr((Box<Self>, usize)),
@@ -1286,8 +1284,6 @@ impl<'a> Reader<'a> {
     }
     fn type_cfg_combine(&self, ty: &Type, cfg: &mut Cfg) {
         match ty {
-            Type::MethodDef(row) => self.method_def_cfg_combine(*row, cfg),
-            Type::Field(row) => self.field_cfg_combine(*row, None, cfg),
             Type::TypeDef((row, generics)) => self.type_def_cfg_combine(*row, generics, cfg),
             Type::Win32Array((ty, _)) => self.type_cfg_combine(ty, cfg),
             Type::ConstPtr((ty, _)) => self.type_cfg_combine(ty, cfg),
@@ -1539,7 +1535,7 @@ impl<'a> Reader<'a> {
     pub fn type_is_nullable(&self, ty: &Type) -> bool {
         match ty {
             Type::TypeDef((row, _)) => self.type_def_is_nullable(*row),
-            Type::IInspectable | Type::IUnknown | Type::MethodDef(_) => true,
+            Type::IInspectable | Type::IUnknown => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Functions and fields aren't types but were used by the older type reader to make them queryable. That's no longer needed by the faster type reader cache.