### PR TITLE
Remove need for allocation inside Reader

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -419,8 +419,8 @@ impl<'a> Gen<'a> {
     }
     fn scoped_name(&self, def: TypeDef) -> String {
         if let Some(enclosing_type) = self.reader.type_def_enclosing_type(def) {
-            for (index, nested_type) in self.reader.nested_types(enclosing_type).iter().enumerate() {
-                if self.reader.type_def_name(*nested_type) == self.reader.type_def_name(def) {
+            for (index, nested_type) in self.reader.nested_types(enclosing_type).enumerate() {
+                if self.reader.type_def_name(nested_type) == self.reader.type_def_name(def) {
                     return format!("{}_{}", &self.scoped_name(enclosing_type), index);
                 }
             }

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -92,19 +92,17 @@ pub fn namespace(gen: &Gen, tree: &Tree) -> String {
     // TODO: replace with Vec once parity is achieved - BTreeMap just used to make diffing simpler.
     let mut types = BTreeMap::<&str, TokenStream>::new();
 
-    if let Some(namespace_types) = gen.reader.namespace_types(tree.namespace) {
-        for def in namespace_types {
-            if let Some(tokens) = gen.define(def) {
-                combine_type(&mut types, gen.reader.type_def_type_name(def), tokens);
-            } else {
-                if !gen.sys {
-                    for method in gen.reader.type_def_methods(def) {
-                        combine(&mut types, gen.reader.method_def_name(method), functions::gen(gen, method));
-                    }
+    for def in gen.reader.namespace_types(tree.namespace) {
+        if let Some(tokens) = gen.define(def) {
+            combine_type(&mut types, gen.reader.type_def_type_name(def), tokens);
+        } else {
+            if !gen.sys {
+                for method in gen.reader.type_def_methods(def) {
+                    combine(&mut types, gen.reader.method_def_name(method), functions::gen(gen, method));
                 }
-                for field in gen.reader.type_def_fields(def) {
-                    combine(&mut types, gen.reader.field_name(field), constants::gen(gen, field));
-                }
+            }
+            for field in gen.reader.type_def_fields(def) {
+                combine(&mut types, gen.reader.field_name(field), constants::gen(gen, field));
             }
         }
     }
@@ -123,10 +121,8 @@ pub fn namespace(gen: &Gen, tree: &Tree) -> String {
 pub fn namespace_impl(gen: &Gen, tree: &Tree) -> String {
     let mut types = BTreeMap::<&str, TokenStream>::new();
 
-    if let Some(namespace_types) = gen.reader.namespace_types(tree.namespace) {
-        for def in namespace_types {
-            combine_type(&mut types, gen.reader.type_def_type_name(def), implements::gen(gen, def));
-        }
+    for def in gen.reader.namespace_types(tree.namespace) {
+        combine_type(&mut types, gen.reader.type_def_type_name(def), implements::gen(gen, def));
     }
 
     let types = types.values();

--- a/crates/libs/bindgen/src/structs.rs
+++ b/crates/libs/bindgen/src/structs.rs
@@ -96,9 +96,9 @@ fn gen_struct_with_name(gen: &Gen, def: TypeDef, struct_name: &str, cfg: &Cfg) -
         tokens.combine(&extensions::gen(gen.reader.type_def_type_name(def)));
     }
 
-    for (index, nested_type) in gen.reader.nested_types(def).iter().enumerate() {
+    for (index, nested_type) in gen.reader.nested_types(def).enumerate() {
         let nested_name = format!("{}_{}", struct_name, index);
-        tokens.combine(&gen_struct_with_name(gen, *nested_type, &nested_name, &cfg));
+        tokens.combine(&gen_struct_with_name(gen, nested_type, &nested_name, &cfg));
     }
 
     tokens

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -232,24 +232,19 @@ impl<'a> Reader<'a> {
     // Hash functions for fast type lookup
     //
 
-    // TODO: do this same Option trick for other iterators below.
-    pub fn namespace_types(&self, namespace: &str) -> Option<impl Iterator<Item = TypeDef> + '_> {
-        if let Some(types) = self.types.get(namespace) {
-            return Some(types.values().flatten().copied());
-        }
-        None
+    pub fn namespace_types(&self, namespace: &str) -> impl Iterator<Item = TypeDef> + '_ {
+        OptionalIterator::new(self.types.get(namespace).map(|types| types.values().flatten().copied()))
     }
-    pub fn nested_types(&'a self, type_def: TypeDef) -> Vec<TypeDef> {
-        // TODO: shouldn't have to collect, like we do in the `get` function below...
-        self.nested.get(&type_def).iter().flat_map(|map| map.values()).copied().collect()
+    pub fn nested_types(&self, type_def: TypeDef) -> impl Iterator<Item = TypeDef> + '_ {
+        OptionalIterator::new(self.nested.get(&type_def).map(|map| map.values().copied()))
     }
     pub fn get(&self, type_name: TypeName) -> impl Iterator<Item = TypeDef> + '_ {
         if let Some(types) = self.types.get(type_name.namespace) {
             if let Some(definitions) = types.get(type_name.name) {
-                return definitions.iter().copied();
+                return OptionalIterator::Some(definitions.iter().copied());
             }
         }
-        [].iter().copied()
+        OptionalIterator::None
     }
     pub fn get_nested(&self, outer: TypeDef, name: &str) -> TypeDef {
         self.nested[&outer][name]
@@ -1677,3 +1672,28 @@ pub fn type_deref(ty: &Type) -> Type {
 const REMAP_TYPES: [(TypeName, TypeName); 1] = [(TypeName::D2D_MATRIX_3X2_F, TypeName::Matrix3x2)];
 
 pub const CORE_TYPES: [(TypeName, Type); 11] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HRESULT, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::IInspectable, Type::IInspectable), (TypeName::LARGE_INTEGER, Type::I64), (TypeName::ULARGE_INTEGER, Type::U64), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::Type, Type::TypeName)];
+
+/// Like an `Option<T>` but with a different iterator implementation when `T: Iterator`
+enum OptionalIterator<T> {
+    Some(T),
+    None,
+}
+
+impl<T> OptionalIterator<T> {
+    fn new(item: Option<T>) -> Self {
+        match item {
+            Some(inner) => Self::Some(inner),
+            None => Self::None,
+        }
+    }
+}
+
+impl<T: Iterator> Iterator for OptionalIterator<T> {
+    type Item = T::Item;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Some(inner) => inner.next(),
+            Self::None => None,
+        }
+    }
+}


### PR DESCRIPTION
This should be easier to understand, less code, have less rightward drift, completely eliminate all allocation, and be much less hacky than some alternatives. 