### PR TITLE
Implement equality and hash for GUID

### DIFF
--- a/crates/libs/sys/src/core/mod.rs
+++ b/crates/libs/sys/src/core/mod.rs
@@ -1,3 +1,4 @@
+#[derive(PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct GUID {
     pub data1: u32,


### PR DESCRIPTION
In `winapi` we had the function [`IsEqualGUID`](https://docs.rs/winapi/latest/winapi/shared/guiddef/fn.IsEqualGUID.html) to check GUID equality. `windows-sys` currently does not have this.

Is there a reason `Copy` and `Clone` are not implemented with `#[derive]`? If so, I can implement these traits manually also.

I also threw in `Hash`, since I did not see why it would not implement it. Could be useful in some cases I imagine.