### PR TITLE
Reduce allocations in Tree::flatten()

### DIFF
--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -18,3 +18,10 @@ features = [
     "Win32_System_SystemServices",
     "Win32_System_Diagnostics_Debug",
 ]
+
+[dev-dependencies]
+criterion = "0.3.5"
+
+[[bench]]
+name = "my_benchmark"
+harness = false

--- a/crates/libs/metadata/benches/my_benchmark.rs
+++ b/crates/libs/metadata/benches/my_benchmark.rs
@@ -1,0 +1,37 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use windows_metadata::reader::File;
+use windows_metadata::reader::Reader;
+
+const EXCLUDE_NAMESPACES: [&str; 1] = ["Windows.Win32.Interop"];
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let files = vec![File::new("default/Windows.winmd").unwrap(), File::new("default/Windows.Win32.winmd").unwrap(), File::new("default/Windows.Win32.Interop.winmd").unwrap()];
+    let reader = &Reader::new(&files);
+    let root = reader.tree("Windows", &EXCLUDE_NAMESPACES).expect("`Windows` namespace not found");
+
+    let mut group = c.benchmark_group("flatten");
+
+    group.bench_function("flatten", |b| {
+        b.iter(|| {
+            let root = black_box(&root);
+            root.flatten()
+        })
+    });
+
+    group.bench_function("flatten_iterative", |b| {
+        b.iter(|| {
+            let root = black_box(&root);
+            root.flatten_iter()
+        })
+    });
+
+    group.bench_function("flatten_recursive", |b| {
+        b.iter(|| {
+            let root = black_box(&root);
+            root.flatten_rec()
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/libs/metadata/benches/my_benchmark.rs
+++ b/crates/libs/metadata/benches/my_benchmark.rs
@@ -11,7 +11,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("flatten");
 
-    group.bench_function("flatten", |b| {
+    group.bench_function("flatten_master", |b| {
         b.iter(|| {
             let root = black_box(&root);
             root.flatten()

--- a/crates/libs/metadata/src/reader/tree.rs
+++ b/crates/libs/metadata/src/reader/tree.rs
@@ -22,6 +22,34 @@ impl<'a> Tree<'a> {
         // TODO: surely there's a way to do this without a ton of intermediate Vec's...
         std::iter::once(self).chain(self.nested.values().flat_map(|tree| tree.flatten())).collect()
     }
+
+    pub fn flatten_iter(&self) -> Vec<&Self> {
+        let mut res = Vec::new();
+        let mut stack = vec![self];
+
+        while let Some(tree) = stack.pop() {
+            res.push(tree);
+            stack.extend(tree.nested.values().rev());
+        }
+
+        res
+    }
+
+    pub fn flatten_rec(&'a self) -> Vec<&'a Self> {
+        fn visit<'a>(this: &'a Tree<'a>, res: &mut Vec<&'a Tree<'a>>) {
+            res.push(this);
+
+            for child in this.nested.values() {
+                visit(child, res);
+            }
+        }
+
+        let mut res = Vec::new();
+
+        visit(self, &mut res);
+
+        res
+    }
     pub fn seek(mut self, namespace: &'a str) -> Option<Self> {
         if let Some(next) = namespace.find('.') {
             self.nested.remove(&namespace[..next]).and_then(|tree| tree.seek(&namespace[next + 1..]))

--- a/crates/libs/metadata/src/reader/tree.rs
+++ b/crates/libs/metadata/src/reader/tree.rs
@@ -19,17 +19,9 @@ impl<'a> Tree<'a> {
         }
     }
     pub fn flatten(&self) -> Vec<&Self> {
-        let mut res = Vec::new();
-        let mut stack = vec![self];
-
-        while let Some(tree) = stack.pop() {
-            res.push(tree);
-            stack.extend(tree.nested.values().rev());
-        }
-
-        res
+        // TODO: surely there's a way to do this without a ton of intermediate Vec's...
+        std::iter::once(self).chain(self.nested.values().flat_map(|tree| tree.flatten())).collect()
     }
-
     pub fn seek(mut self, namespace: &'a str) -> Option<Self> {
         if let Some(next) = namespace.find('.') {
             self.nested.remove(&namespace[..next]).and_then(|tree| tree.seek(&namespace[next + 1..]))

--- a/crates/libs/metadata/src/reader/tree.rs
+++ b/crates/libs/metadata/src/reader/tree.rs
@@ -19,9 +19,17 @@ impl<'a> Tree<'a> {
         }
     }
     pub fn flatten(&self) -> Vec<&Self> {
-        // TODO: surely there's a way to do this without a ton of intermediate Vec's...
-        std::iter::once(self).chain(self.nested.values().flat_map(|tree| tree.flatten())).collect()
+        let mut res = Vec::new();
+        let mut stack = vec![self];
+
+        while let Some(tree) = stack.pop() {
+            res.push(tree);
+            stack.extend(tree.nested.values().rev());
+        }
+
+        res
     }
+
     pub fn seek(mut self, namespace: &'a str) -> Option<Self> {
         if let Some(next) = namespace.find('.') {
             self.nested.remove(&namespace[..next]).and_then(|tree| tree.seek(&namespace[next + 1..]))


### PR DESCRIPTION
Initial draft for eliminating allocations in `Tree::flatten`.

Warning: this code is untested so far.

Fixes #1795