### PR TITLE
Remove `flatten` comment

### DIFF
--- a/crates/libs/metadata/src/reader/tree.rs
+++ b/crates/libs/metadata/src/reader/tree.rs
@@ -19,7 +19,6 @@ impl<'a> Tree<'a> {
         }
     }
     pub fn flatten(&self) -> Vec<&Self> {
-        // TODO: surely there's a way to do this without a ton of intermediate Vec's...
         std::iter::once(self).chain(self.nested.values().flat_map(|tree| tree.flatten())).collect()
     }
     pub fn seek(mut self, namespace: &'a str) -> Option<Self> {


### PR DESCRIPTION
Based on #1795 and analysis by @AronParker and @rylev, `flatten` cannot be turned into a pure iterator as Rust doesn't appear to support recursive iterators. https://github.com/rust-lang/rust/issues/97686

Here I'm just removing the comment as there's no more work to be done here. 