### PR TITLE
Remove reverse dependency from core module

### DIFF
--- a/crates/libs/bindgen/src/extensions/win32_error.rs
+++ b/crates/libs/bindgen/src/extensions/win32_error.rs
@@ -16,6 +16,15 @@ pub fn gen() -> TokenStream {
                 ::windows::core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
             }
             #[inline]
+            pub fn from_error(error: &::windows::core::Error) -> ::core::option::Option<Self> {
+                let hresult = error.code().0 as u32;
+                if ((hresult >> 16) & 0x7FF) == 7 {
+                    Some(Self(hresult & 0xFFFF))
+                } else {
+                    None
+                }
+            }
+            #[inline]
             pub const fn ok(self) -> ::windows::core::Result<()> {
                 if self.is_ok() {
                     Ok(())

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -20640,6 +20640,15 @@ impl WIN32_ERROR {
         ::windows::core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
     }
     #[inline]
+    pub fn from_error(error: &::windows::core::Error) -> ::core::option::Option<Self> {
+        let hresult = error.code().0 as u32;
+        if ((hresult >> 16) & 0x7FF) == 7 {
+            Some(Self(hresult & 0xFFFF))
+        } else {
+            None
+        }
+    }
+    #[inline]
     pub const fn ok(self) -> ::windows::core::Result<()> {
         if self.is_ok() {
             Ok(())

--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -1503,6 +1503,15 @@ impl WIN32_ERROR {
         ::windows::core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
     }
     #[inline]
+    pub fn from_error(error: &::windows::core::Error) -> ::core::option::Option<Self> {
+        let hresult = error.code().0 as u32;
+        if ((hresult >> 16) & 0x7FF) == 7 {
+            Some(Self(hresult & 0xFFFF))
+        } else {
+            None
+        }
+    }
+    #[inline]
     pub const fn ok(self) -> ::windows::core::Result<()> {
         if self.is_ok() {
             Ok(())

--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -60,17 +60,6 @@ impl Error {
 
         self.code.message()
     }
-
-    /// Returns the win32 error code if the underlying HRESULT's facility is win32
-    #[cfg(feature = "Win32_Foundation")]
-    pub fn win32_error(&self) -> Option<crate::Win32::Foundation::WIN32_ERROR> {
-        let hresult = self.code.0 as u32;
-        if ((hresult >> 16) & 0x7FF) == 7 {
-            Some(crate::Win32::Foundation::WIN32_ERROR(hresult & 0xFFFF))
-        } else {
-            None
-        }
-    }
 }
 
 impl core::convert::From<Error> for HRESULT {

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -37,7 +37,7 @@ fn win32_error() {
 
     let e: Error = h.into();
     assert_eq!("Error { code: 0x80070005, message: Access is denied.\r\n }", format!("{:?}", e));
-    let e: WIN32_ERROR = e.win32_error().unwrap();
+    let e = WIN32_ERROR::from_error(&e).unwrap();
     assert!(e == ERROR_ACCESS_DENIED);
 }
 

--- a/crates/tests/error/tests/test.rs
+++ b/crates/tests/error/tests/test.rs
@@ -26,7 +26,7 @@ fn win32_error() -> Result<()> {
     let hresult: HRESULT = ERROR_BAD_ARGUMENTS.into();
 
     assert_eq!(error.code(), hresult);
-    assert_eq!(error.win32_error(), Some(ERROR_BAD_ARGUMENTS));
+    assert_eq!(WIN32_ERROR::from_error(&error), Some(ERROR_BAD_ARGUMENTS));
     assert_eq!(ERROR_BAD_ARGUMENTS.is_ok(), false);
     assert_eq!(ERROR_BAD_ARGUMENTS.is_err(), true);
     assert_eq!(ERROR_SUCCESS.is_ok(), true);


### PR DESCRIPTION
As I work toward multi-crate support, I need to isolate the `core` modules in both the `windows` and `windows-sys` crates so that they can in fact be independent crates that the various namespace crates would depend on. This update removes the only dependency - `Error::win32_error` - that the `core` modules have on namespace modules. 