### PR TITLE
Test error propagation

### DIFF
--- a/crates/tests/error/Cargo.toml
+++ b/crates/tests/error/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
+    "implement",
+    "Foundation",
     "Win32_Foundation",
 ]

--- a/crates/tests/error/tests/propagate.rs
+++ b/crates/tests/error/tests/propagate.rs
@@ -1,0 +1,19 @@
+use windows::{core::*, Foundation::*, Win32::Foundation::*};
+
+#[implement(IStringable)]
+struct Test;
+
+impl IStringable_Impl for Test {
+    fn ToString(&self) -> Result<HSTRING> {
+        Err(Error::new(E_INVALIDARG, "Test message".into()))
+    }
+}
+
+#[test]
+fn test() {
+    let test: IStringable = Test.into();
+    let result = test.ToString();
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), E_INVALIDARG);
+    assert_eq!(error.message(), "Test message");
+}


### PR DESCRIPTION
As I work on splitting the `core` modules out as separate crates, I noticed we don't have a specific test to ensure error propagation does not regress. 