### PR TITLE
Trim error messages

### DIFF
--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -54,7 +54,7 @@ impl Error {
 
             if self.code == code {
                 let message = if !message.is_empty() { message } else { fallback };
-                return HSTRING::from_wide(message.as_wide());
+                return HSTRING::from_wide(wide_trim_end(message.as_wide()));
             }
         }
 

--- a/crates/libs/windows/src/core/hresult.rs
+++ b/crates/libs/windows/src/core/hresult.rs
@@ -88,7 +88,7 @@ impl HRESULT {
         unsafe {
             let size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, core::ptr::null(), self.0 as _, 0, PWSTR(core::mem::transmute(&mut message.0)), 0, core::ptr::null_mut());
 
-            HSTRING::from_wide(core::slice::from_raw_parts(message.0 as *const u16, size as usize))
+            HSTRING::from_wide(wide_trim_end(core::slice::from_raw_parts(message.0 as *const u16, size as usize)))
         }
     }
 }

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -113,3 +113,13 @@ pub fn as_mut_ptr_or_null<T>(value: &mut [T]) -> *mut T {
         value.as_mut_ptr()
     }
 }
+
+fn wide_trim_end(mut wide: &[u16]) -> &[u16] {
+    while let Some(last) = wide.last() {
+        match last {
+            32 | 9..=13 => wide = &wide[..wide.len() - 1],
+            _ => break,
+        }
+    }
+    wide
+}

--- a/crates/samples/direct2d/src/main.rs
+++ b/crates/samples/direct2d/src/main.rs
@@ -409,7 +409,7 @@ fn create_factory() -> Result<ID2D1Factory1> {
 
     let mut result = None;
 
-    unsafe { D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, &ID2D1Factory1::IID, &options, std::mem::transmute(&mut result)).map(|()| result.unwrap()) }
+    unsafe { D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, &ID2D1Factory1::IID, &options, &mut result as *mut _ as _).map(|()| result.unwrap()) }
 }
 
 fn create_style(factory: &ID2D1Factory1) -> Result<ID2D1StrokeStyle> {

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -36,7 +36,7 @@ fn win32_error() {
     assert!("WIN32_ERROR(5)" == format!("{:?}", e));
 
     let e: Error = h.into();
-    assert_eq!("Error { code: 0x80070005, message: Access is denied.\r\n }", format!("{:?}", e));
+    assert_eq!("Error { code: 0x80070005, message: Access is denied. }", format!("{:?}", e));
     let e: WIN32_ERROR = e.win32_error().unwrap();
     assert!(e == ERROR_ACCESS_DENIED);
 }

--- a/crates/tests/error/tests/trim.rs
+++ b/crates/tests/error/tests/trim.rs
@@ -1,0 +1,8 @@
+use windows::{core::*,Win32::Foundation::*};
+
+#[test]
+fn test() {
+    assert_eq!(E_FAIL.message(), "Unspecified error");
+
+    assert_eq!(Error::new(E_FAIL, "Test \t\n\r".into()).message(), "Test");
+}

--- a/crates/tests/error/tests/trim.rs
+++ b/crates/tests/error/tests/trim.rs
@@ -1,8 +1,10 @@
-use windows::{core::*,Win32::Foundation::*};
+use windows::{core::*, Win32::Foundation::*};
 
 #[test]
 fn test() {
     assert_eq!(E_FAIL.message(), "Unspecified error");
 
     assert_eq!(Error::new(E_FAIL, "Test \t\n\r".into()).message(), "Test");
+
+    assert_eq!(Error::new(E_FAIL, " \t\n\r ".into()).message(), "");
 }

--- a/crates/tests/win32/tests/hresult.rs
+++ b/crates/tests/win32/tests/hresult.rs
@@ -8,9 +8,9 @@ fn test_message() {
 
     let code: HRESULT = ERROR_SUCCESS.into();
     let message: String = code.message().try_into().unwrap();
-    assert_eq!(message.trim_end(), "The operation completed successfully.");
+    assert_eq!(message, "The operation completed successfully.");
 
     let code: HRESULT = ERROR_IO_PENDING.into();
     let message: String = code.message().try_into().unwrap();
-    assert_eq!(message.trim_end(), "Overlapped I/O operation is in progress.");
+    assert_eq!(message, "Overlapped I/O operation is in progress.");
 }

--- a/crates/tests/win32/tests/win32.rs
+++ b/crates/tests/win32/tests/win32.rs
@@ -115,7 +115,7 @@ fn bool_as_error() {
         let error: windows::core::Error = result.unwrap_err();
         assert_eq!(error.code(), windows::core::HRESULT(-2147024890));
         let message: String = error.message().try_into().unwrap();
-        assert_eq!(message.trim_end(), "The handle is invalid.");
+        assert_eq!(message, "The handle is invalid.");
     }
 }
 

--- a/crates/tests/winrt/tests/error.rs
+++ b/crates/tests/winrt/tests/error.rs
@@ -9,7 +9,7 @@ fn from_hresult() {
 
     assert_eq!(error.code(), windows::core::HRESULT(-2147467260));
     let message: String = error.message().try_into().unwrap();
-    assert_eq!(message.trim_end(), "Operation aborted");
+    assert_eq!(message, "Operation aborted");
 }
 
 #[test]


### PR DESCRIPTION
`FormatMessageW` returns strings with trailing white space characters for certain system error codes. This can then propagate through error objects. It is customary to trim these off for display purposes. 

Fixes https://github.com/microsoft/windows-rs/pull/1803#issuecomment-1148068317