### PR TITLE
Make `Type` methods simpler to use

### DIFF
--- a/crates/libs/bindgen/src/com_methods.rs
+++ b/crates/libs/bindgen/src/com_methods.rs
@@ -52,7 +52,7 @@ pub fn gen(gen: &Gen, def: TypeDef, kind: InterfaceKind, method: MethodDef, meth
             let leading_params = &signature.params[..signature.params.len() - 1];
             let args = gen.win32_args(leading_params);
             let params = gen.win32_params(leading_params);
-            let return_type = type_deref(&signature.params[signature.params.len() - 1].ty);
+            let return_type = signature.params[signature.params.len() - 1].ty.deref();
             let return_type_tokens = gen.type_name(&return_type);
             let abi_return_type_tokens = gen.type_abi_name(&return_type);
 
@@ -166,7 +166,7 @@ pub fn gen_upcall(gen: &Gen, sig: &Signature, inner: TokenStream) -> TokenStream
 fn gen_win32_invoke_arg(gen: &Gen, param: &SignatureParam) -> TokenStream {
     let name = gen.param_name(param.def);
 
-    if (!gen.reader.type_is_pointer(&param.ty) && gen.reader.type_is_nullable(&param.ty)) || (gen.reader.param_flags(param.def).input() && !gen.reader.type_is_primitive(&param.ty)) {
+    if (!param.ty.is_pointer() && gen.reader.type_is_nullable(&param.ty)) || (gen.reader.param_flags(param.def).input() && !gen.reader.type_is_primitive(&param.ty)) {
         quote! { ::core::mem::transmute(&#name) }
     } else {
         quote! { ::core::mem::transmute_copy(&#name) }

--- a/crates/libs/bindgen/src/constants.rs
+++ b/crates/libs/bindgen/src/constants.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn gen(gen: &Gen, def: Field) -> TokenStream {
     let name = to_ident(gen.reader.field_name(def));
-    let ty = type_to_const(gen.reader.field_type(def, None));
+    let ty = gen.reader.field_type(def, None).to_const();
     let cfg = gen.reader.field_cfg(def);
     let doc = gen.cfg_doc(&cfg);
     let features = gen.cfg_features(&cfg);

--- a/crates/libs/bindgen/src/functions.rs
+++ b/crates/libs/bindgen/src/functions.rs
@@ -116,7 +116,7 @@ fn gen_win_function(gen: &Gen, def: MethodDef) -> TokenStream {
             let leading_params = &signature.params[..signature.params.len() - 1];
             let args = gen.win32_args(leading_params);
             let params = gen.win32_params(leading_params);
-            let return_type = type_deref(&signature.params[signature.params.len() - 1].ty);
+            let return_type = signature.params[signature.params.len() - 1].ty.deref();
             let return_type_tokens = gen.type_name(&return_type);
             let abi_return_type_tokens = gen.type_abi_name(&return_type);
 
@@ -247,7 +247,7 @@ fn handle_last_error(gen: &Gen, def: MethodDef, signature: &Signature) -> bool {
         if gen.reader.impl_map_flags(map).last_error() {
             if let Some(Type::TypeDef((return_type, _))) = &signature.return_type {
                 if gen.reader.type_def_is_handle(*return_type) {
-                    if gen.reader.type_is_pointer(&gen.reader.type_def_underlying_type(*return_type)) {
+                    if gen.reader.type_def_underlying_type(*return_type).is_pointer() {
                         return true;
                     }
                     if !gen.reader.type_def_invalid_values(*return_type).is_empty() {

--- a/crates/libs/bindgen/src/handles.rs
+++ b/crates/libs/bindgen/src/handles.rs
@@ -22,7 +22,7 @@ pub fn gen_win_handle(gen: &Gen, def: TypeDef) -> TokenStream {
     let ident = to_ident(name);
     let underlying_type = gen.reader.type_def_underlying_type(def);
     let signature = gen.type_default_name(&underlying_type);
-    let check = if gen.reader.type_is_pointer(&underlying_type) {
+    let check = if underlying_type.is_pointer() {
         quote! {
             impl #ident {
                 pub fn is_invalid(&self) -> bool {
@@ -37,7 +37,7 @@ pub fn gen_win_handle(gen: &Gen, def: TypeDef) -> TokenStream {
             let invalid = invalid.iter().map(|value| {
                 let literal = Literal::i64_unsuffixed(*value);
 
-                if *value < 0 && gen.reader.type_is_unsigned(&underlying_type) {
+                if *value < 0 && underlying_type.is_unsigned() {
                     quote! { self.0 == #literal as _ }
                 } else {
                     quote! { self.0 == #literal }

--- a/crates/libs/bindgen/src/structs.rs
+++ b/crates/libs/bindgen/src/structs.rs
@@ -210,7 +210,7 @@ fn gen_debug(gen: &Gen, def: TypeDef, ident: &TokenStream, cfg: &Cfg) -> TokenSt
                 let name = gen.reader.field_name(f);
                 let ident = to_ident(name);
                 let ty = gen.reader.field_type(f, Some(def));
-                if !gen.reader.type_is_pointer(&ty) && gen.reader.type_is_callback(&ty) {
+                if !ty.is_pointer() && gen.reader.type_is_callback(&ty) {
                     quote! { .field(#name, &self.#ident.map(|f| f as usize)) }
                 } else if gen.reader.type_is_callback_array(&ty) {
                     quote! {}

--- a/crates/libs/metadata/src/reader/type.rs
+++ b/crates/libs/metadata/src/reader/type.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord)]
+pub enum Type {
+    Void,
+    Bool,
+    Char,
+    I8,
+    U8,
+    I16,
+    U16,
+    I32,
+    U32,
+    I64,
+    U64,
+    F32,
+    F64,
+    ISize,
+    USize,
+    String,
+    GUID,
+    IUnknown,
+    IInspectable,
+    HRESULT,
+    PSTR,
+    PWSTR,
+    PCSTR,
+    PCWSTR,
+    TypeName,
+    GenericParam(GenericParam),
+    TypeDef((TypeDef, Vec<Self>)),
+    MutPtr((Box<Self>, usize)),
+    ConstPtr((Box<Self>, usize)),
+    Win32Array((Box<Self>, usize)),
+    WinrtArray(Box<Self>),
+    WinrtArrayRef(Box<Self>),
+    WinrtConstRef(Box<Self>),
+}
+
+impl Type {
+    pub fn from_code(code: usize) -> Option<Self> {
+        match code {
+            0x01 => Some(Self::Void),
+            0x02 => Some(Self::Bool),
+            0x03 => Some(Self::Char),
+            0x04 => Some(Self::I8),
+            0x05 => Some(Self::U8),
+            0x06 => Some(Self::I16),
+            0x07 => Some(Self::U16),
+            0x08 => Some(Self::I32),
+            0x09 => Some(Self::U32),
+            0x0a => Some(Self::I64),
+            0x0b => Some(Self::U64),
+            0x0c => Some(Self::F32),
+            0x0d => Some(Self::F64),
+            0x18 => Some(Self::ISize),
+            0x19 => Some(Self::USize),
+            0x0e => Some(Self::String),
+            0x1c => Some(Self::IInspectable),
+            _ => None,
+        }
+    }
+    pub fn to_const(self) -> Self {
+        match self {
+            Self::MutPtr((kind, pointers)) => Self::ConstPtr((kind, pointers)),
+            Self::PSTR => Self::PCSTR,
+            Self::PWSTR => Self::PCWSTR,
+            _ => self,
+        }
+    }
+    pub fn deref(&self) -> Self {
+        match self {
+            Self::ConstPtr((kind, 1)) | Self::MutPtr((kind, 1)) => {
+                if **kind == Self::Void {
+                    Self::U8
+                } else {
+                    *kind.clone()
+                }
+            }
+            Self::ConstPtr((kind, pointers)) => Self::ConstPtr((kind.clone(), pointers - 1)),
+            Self::MutPtr((kind, pointers)) => Self::MutPtr((kind.clone(), pointers - 1)),
+            Self::PSTR | Self::PCSTR => Self::U8,
+            Self::PWSTR | Self::PCWSTR => Self::U16,
+            _ => unimplemented!(),
+        }
+    }
+    pub fn is_winrt_array(&self) -> bool {
+        matches!(self, Type::WinrtArray(_))
+    }
+    pub fn is_winrt_array_ref(&self) -> bool {
+        matches!(self, Type::WinrtArrayRef(_))
+    }
+    pub fn is_winrt_const_ref(&self) -> bool {
+        matches!(self, Type::WinrtConstRef(_))
+    }
+    pub fn is_generic(&self) -> bool {
+        matches!(self, Type::GenericParam(_))
+    }
+    pub fn is_pointer(&self) -> bool {
+        matches!(self, Type::ConstPtr(_) | Type::MutPtr(_))
+    }
+    pub fn is_unsigned(&self) -> bool {
+        matches!(self, Type::U8 | Type::U16 | Type::U32 | Type::U64 | Type::USize)
+    }
+    pub fn is_void(&self) -> bool {
+        match self {
+            // TODO: do we care about void behind pointers?
+            Type::ConstPtr((kind, _)) | Type::MutPtr((kind, _)) => kind.is_void(),
+            Type::Void => true,
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
Most type queries require the `Reader` but some simple queries can be made into methods for a more streamlined experience.