### PR TITLE
Add cross compilation tests

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -25,7 +25,7 @@ jobs:
         # https://github.com/rust-lang/rust/issues/79577
         # https://sourceforge.net/p/mingw-w64/wiki2/Exception%20Handling/
         #
-        image: [macos-latest, ubuntu-22.04]
+        image: [macos-latest, ubuntu-latest]
         version: [stable, nightly]
         target: [x86_64-pc-windows-gnu]
     runs-on: ${{ matrix.image }}

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,0 +1,54 @@
+name: Test (cross-compilation)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      matrix:
+        #
+        # i686 cross compilation requires mingw packages that are configured
+        # to use DWARF-2 exception handling (vice SJLJ).
+        #
+        # The mingw package ecosystem is fragmented so we avoid that target
+        # for now. (e.g. macOS hosts will require mingw recompile)
+        #
+        # See also:
+        # https://github.com/rust-lang/rust/issues/79577
+        # https://sourceforge.net/p/mingw-w64/wiki2/Exception%20Handling/
+        #
+        image: [macos-latest, ubuntu-22.04]
+        version: [stable, nightly]
+        target: [x86_64-pc-windows-gnu]
+    runs-on: ${{ matrix.image }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Add toolchain target
+      run: rustup target add ${{ matrix.target }}
+
+    - name: Install gcc-mingw-w64-x86-64
+      run: sudo apt-get install -y gcc-mingw-w64-x86-64
+      if: startsWith(matrix.image, 'ubuntu-') && matrix.target == 'x86_64-pc-windows-gnu'
+
+    - name: Install mingw-w64
+      run: brew install mingw-w64
+      if: startsWith(matrix.image, 'macos-') && matrix.target == 'x86_64-pc-windows-gnu'
+
+    - name: Test
+      shell: pwsh
+      run: |
+        cargo test --no-run --target ${{ matrix.target }} -p test_win32
+        if (-Not (Resolve-Path "target/*/debug/deps/test_win32-*.exe" | Test-Path)) {
+          throw "Failed to find test_win32 executable."
+        }


### PR DESCRIPTION
Adds a simple cross compile smoke test to the CI pipeline.

Subsequent PRs can address the i686 gap and spin up a Windows image to exercise the cross compiled executables.

Fixes: #1799 