### PR TITLE
Avoid truncating error codes when converting from `windows::core::Error` to `std::io::Error`

### DIFF
--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -77,7 +77,7 @@ impl core::convert::From<Error> for HRESULT {
 
 impl core::convert::From<Error> for std::io::Error {
     fn from(from: Error) -> Self {
-        Self::from_raw_os_error((from.code.0 & 0xFFFF) as _)
+        Self::from_raw_os_error(from.code.0)
     }
 }
 

--- a/crates/tests/error/tests/std.rs
+++ b/crates/tests/error/tests/std.rs
@@ -1,0 +1,34 @@
+use windows::Win32::Foundation::*;
+
+#[test]
+fn conversions() {
+    // Baseline HRESULT
+    assert_eq!(E_INVALIDARG.message(), "The parameter is incorrect.");
+    assert_eq!(E_INVALIDARG.0, -2147024809);
+
+    // Baseline WIN32_ERROR
+    assert_eq!(ERROR_INVALID_DATA.to_hresult().message(), "The data is invalid.");
+    assert_eq!(ERROR_INVALID_DATA.0, 13);
+
+    // std::io::Error from HRESULT
+    let std_error = std::io::Error::from_raw_os_error(E_INVALIDARG.0);
+    assert_eq!(std_error.raw_os_error().unwrap(), E_INVALIDARG.0);
+    assert_eq!(format!("{}", std_error), "The parameter is incorrect. (os error -2147024809)");
+
+    // std::io::Error from WIN32_ERROR
+    let std_error = std::io::Error::from_raw_os_error(ERROR_INVALID_DATA.0 as _);
+    assert_eq!(std_error.raw_os_error().unwrap(), ERROR_INVALID_DATA.0 as _);
+    assert_eq!(format!("{}", std_error), "The data is invalid. (os error 13)");
+
+    // Starting with WIN32_ERROR...
+    let win_error: windows::core::Error = ERROR_INVALID_DATA.into();
+    let std_error: std::io::Error = win_error.into();
+    assert_eq!(std_error.raw_os_error().unwrap(), ERROR_INVALID_DATA.to_hresult().0);
+    assert_eq!(format!("{}", std_error), "The data is invalid. (os error -2147024883)");
+
+    // Starting with HRESULT...
+    let win_error: windows::core::Error = E_INVALIDARG.into();
+    let std_error: std::io::Error = win_error.into();
+    assert_eq!(std_error.raw_os_error().unwrap(), E_INVALIDARG.0);
+    assert_eq!(format!("{}", std_error), "The parameter is incorrect. (os error -2147024809)");
+}


### PR DESCRIPTION
Fixes #1807
