### PR TITLE
Selective `rustfmt` configuration

### DIFF
--- a/crates/libs/rustfmt.toml
+++ b/crates/libs/rustfmt.toml
@@ -1,1 +1,2 @@
 newline_style = "Unix"
+max_width = 800

--- a/crates/samples/consent/src/main.rs
+++ b/crates/samples/consent/src/main.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Foundation::*, Security::Credentials::UI::*, Win32::Foundation::*, Win32::System::WinRT::*};
+use windows::{
+    core::*, Foundation::*, Security::Credentials::UI::*, Win32::Foundation::*,
+    Win32::System::WinRT::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
@@ -6,7 +9,8 @@ fn main() -> Result<()> {
 
         let window = HWND(0); // <== replace with your app's window handle
 
-        let operation: IAsyncOperation<UserConsentVerificationResult> = interop.RequestVerificationForWindowAsync(window, "Hello from Rust")?;
+        let operation: IAsyncOperation<UserConsentVerificationResult> =
+            interop.RequestVerificationForWindowAsync(window, "Hello from Rust")?;
 
         let result: UserConsentVerificationResult = operation.get()?;
 

--- a/crates/samples/core_app/src/main.rs
+++ b/crates/samples/core_app/src/main.rs
@@ -59,7 +59,12 @@ fn main() -> Result<()> {
         CoInitializeEx(std::ptr::null(), COINIT_MULTITHREADED)?;
 
         if let Err(result) = Package::Current() {
-            MessageBoxW(HWND::default(), "This sample must be registered (via register.cmd) and launched from Start.", "Error", MB_ICONSTOP | MB_OK);
+            MessageBoxW(
+                HWND::default(),
+                "This sample must be registered (via register.cmd) and launched from Start.",
+                "Error",
+                MB_ICONSTOP | MB_OK,
+            );
             return Err(result);
         }
     }

--- a/crates/samples/create_window/src/main.rs
+++ b/crates/samples/create_window/src/main.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect, Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*};
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect,
+    Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
@@ -20,7 +23,20 @@ fn main() -> Result<()> {
         let atom = RegisterClassA(&wc);
         debug_assert!(atom != 0);
 
-        CreateWindowExA(Default::default(), window_class, "This is a sample window", WS_OVERLAPPEDWINDOW | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, None, None, instance, std::ptr::null());
+        CreateWindowExA(
+            Default::default(),
+            window_class,
+            "This is a sample window",
+            WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            None,
+            None,
+            instance,
+            std::ptr::null(),
+        );
 
         let mut message = MSG::default();
 

--- a/crates/samples/create_window_sys/src/main.rs
+++ b/crates/samples/create_window_sys/src/main.rs
@@ -1,4 +1,7 @@
-use windows_sys::{Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect, Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*};
+use windows_sys::{
+    Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect,
+    Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*,
+};
 
 fn main() {
     unsafe {
@@ -23,7 +26,20 @@ fn main() {
         let atom = RegisterClassA(&wc);
         debug_assert!(atom != 0);
 
-        CreateWindowExA(0, window_class, b"This is a sample window\0".as_ptr(), WS_OVERLAPPEDWINDOW | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, 0, 0, instance, std::ptr::null());
+        CreateWindowExA(
+            0,
+            window_class,
+            b"This is a sample window\0".as_ptr(),
+            WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            0,
+            0,
+            instance,
+            std::ptr::null(),
+        );
 
         let mut message = std::mem::zeroed();
 

--- a/crates/samples/data_protection/src/main.rs
+++ b/crates/samples/data_protection/src/main.rs
@@ -1,8 +1,12 @@
-use windows::{core::*, Security::Cryptography::DataProtection::*, Security::Cryptography::*, Storage::Streams::*, Win32::System::WinRT::*};
+use windows::{
+    core::*, Security::Cryptography::DataProtection::*, Security::Cryptography::*,
+    Storage::Streams::*, Win32::System::WinRT::*,
+};
 
 fn main() -> std::io::Result<()> {
     let provider = DataProtectionProvider::CreateOverloadExplicit("LOCAL=user")?;
-    let unprotected = CryptographicBuffer::ConvertStringToBinary("Hello world", BinaryStringEncoding::Utf8)?;
+    let unprotected =
+        CryptographicBuffer::ConvertStringToBinary("Hello world", BinaryStringEncoding::Utf8)?;
 
     let protected = provider.ProtectAsync(unprotected)?.get()?;
     let protected_bytes = unsafe { as_mut_bytes(&protected)? };
@@ -12,7 +16,8 @@ fn main() -> std::io::Result<()> {
     let protected = CryptographicBuffer::CreateFromByteArray(&protected_bytes)?;
     let unprotected = provider.UnprotectAsync(protected)?.get()?;
 
-    let message = CryptographicBuffer::ConvertBinaryToString(BinaryStringEncoding::Utf8, unprotected)?;
+    let message =
+        CryptographicBuffer::ConvertBinaryToString(BinaryStringEncoding::Utf8, unprotected)?;
     println!("{}", message);
     Ok(())
 }

--- a/crates/samples/direct2d/src/main.rs
+++ b/crates/samples/direct2d/src/main.rs
@@ -1,4 +1,11 @@
-use windows::{core::*, Foundation::Numerics::*, Win32::Foundation::*, Win32::Graphics::Direct2D::Common::*, Win32::Graphics::Direct2D::*, Win32::Graphics::Direct3D::*, Win32::Graphics::Direct3D11::*, Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*, Win32::Graphics::Gdi::*, Win32::System::Com::*, Win32::System::LibraryLoader::*, Win32::System::Performance::*, Win32::System::SystemInformation::GetLocalTime, Win32::UI::Animation::*, Win32::UI::WindowsAndMessaging::*};
+use windows::{
+    core::*, Foundation::Numerics::*, Win32::Foundation::*, Win32::Graphics::Direct2D::Common::*,
+    Win32::Graphics::Direct2D::*, Win32::Graphics::Direct3D::*, Win32::Graphics::Direct3D11::*,
+    Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*, Win32::Graphics::Gdi::*,
+    Win32::System::Com::*, Win32::System::LibraryLoader::*, Win32::System::Performance::*,
+    Win32::System::SystemInformation::GetLocalTime, Win32::UI::Animation::*,
+    Win32::UI::WindowsAndMessaging::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
@@ -44,7 +51,11 @@ impl Angles {
         let minute = time.wMinute as f32 * 6.0 + second / 60.0;
         let hour = (time.wHour % 12) as f32 * 30.0 + minute / 12.0;
 
-        Self { second, minute, hour }
+        Self {
+            second,
+            minute,
+            hour,
+        }
     }
 }
 
@@ -53,7 +64,8 @@ impl Window {
         let factory = create_factory()?;
         let dxfactory: IDXGIFactory2 = unsafe { CreateDXGIFactory1()? };
         let style = create_style(&factory)?;
-        let manager: IUIAnimationManager = unsafe { CoCreateInstance(&UIAnimationManager, None, CLSCTX_ALL)? };
+        let manager: IUIAnimationManager =
+            unsafe { CoCreateInstance(&UIAnimationManager, None, CLSCTX_ALL)? };
         let transition = create_transition()?;
 
         let mut dpi = 0.0;
@@ -116,7 +128,10 @@ impl Window {
 
         if let Err(error) = self.present(1, 0) {
             if error.code() == DXGI_STATUS_OCCLUDED {
-                self.occlusion = unsafe { self.dxfactory.RegisterOcclusionStatusWindow(self.handle, WM_USER)? };
+                self.occlusion = unsafe {
+                    self.dxfactory
+                        .RegisterOcclusionStatusWindow(self.handle, WM_USER)?
+                };
                 self.visible = false;
             } else {
                 self.release_device();
@@ -149,7 +164,12 @@ impl Window {
         unsafe {
             self.manager.Update(get_time(self.frequency)?)?;
 
-            target.Clear(&D2D1_COLOR_F { r: 1.0, g: 1.0, b: 1.0, a: 1.0 });
+            target.Clear(&D2D1_COLOR_F {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            });
 
             let mut previous = None;
             target.GetTarget(&mut previous);
@@ -162,11 +182,23 @@ impl Window {
             let mut output = None;
             shadow.GetOutput(&mut output);
 
-            target.DrawImage(output, std::ptr::null(), std::ptr::null(), D2D1_INTERPOLATION_MODE_LINEAR, D2D1_COMPOSITE_MODE_SOURCE_OVER);
+            target.DrawImage(
+                output,
+                std::ptr::null(),
+                std::ptr::null(),
+                D2D1_INTERPOLATION_MODE_LINEAR,
+                D2D1_COMPOSITE_MODE_SOURCE_OVER,
+            );
 
             target.SetTransform(&Matrix3x2::identity());
 
-            target.DrawImage(clock, std::ptr::null(), std::ptr::null(), D2D1_INTERPOLATION_MODE_LINEAR, D2D1_COMPOSITE_MODE_SOURCE_OVER);
+            target.DrawImage(
+                clock,
+                std::ptr::null(),
+                std::ptr::null(),
+                D2D1_INTERPOLATION_MODE_LINEAR,
+                D2D1_COMPOSITE_MODE_SOURCE_OVER,
+            );
         }
 
         Ok(())
@@ -182,7 +214,11 @@ impl Window {
         let translation = Matrix3x2::translation(size.width / 2.0, size.height / 2.0);
         unsafe { target.SetTransform(&translation) };
 
-        let ellipse = D2D1_ELLIPSE { point: D2D_POINT_2F::default(), radiusX: radius, radiusY: radius };
+        let ellipse = D2D1_ELLIPSE {
+            point: D2D_POINT_2F::default(),
+            radiusX: radius,
+            radiusY: radius,
+        };
 
         let swing = unsafe {
             target.DrawEllipse(&ellipse, brush, radius / 20.0, None);
@@ -209,15 +245,42 @@ impl Window {
         unsafe {
             target.SetTransform(&(Matrix3x2::rotation(angles.second, 0.0, 0.0) * translation));
 
-            target.DrawLine(D2D_POINT_2F::default(), D2D_POINT_2F { x: 0.0, y: -(radius * 0.75) }, brush, radius / 25.0, &self.style);
+            target.DrawLine(
+                D2D_POINT_2F::default(),
+                D2D_POINT_2F {
+                    x: 0.0,
+                    y: -(radius * 0.75),
+                },
+                brush,
+                radius / 25.0,
+                &self.style,
+            );
 
             target.SetTransform(&(Matrix3x2::rotation(angles.minute, 0.0, 0.0) * translation));
 
-            target.DrawLine(D2D_POINT_2F::default(), D2D_POINT_2F { x: 0.0, y: -(radius * 0.75) }, brush, radius / 15.0, &self.style);
+            target.DrawLine(
+                D2D_POINT_2F::default(),
+                D2D_POINT_2F {
+                    x: 0.0,
+                    y: -(radius * 0.75),
+                },
+                brush,
+                radius / 15.0,
+                &self.style,
+            );
 
             target.SetTransform(&(Matrix3x2::rotation(angles.hour, 0.0, 0.0) * translation));
 
-            target.DrawLine(D2D_POINT_2F::default(), D2D_POINT_2F { x: 0.0, y: -(radius * 0.5) }, brush, radius / 10.0, &self.style);
+            target.DrawLine(
+                D2D_POINT_2F::default(),
+                D2D_POINT_2F {
+                    x: 0.0,
+                    y: -(radius * 0.5),
+                },
+                brush,
+                radius / 10.0,
+                &self.style,
+            );
         }
 
         Ok(())
@@ -235,10 +298,16 @@ impl Window {
     fn create_clock(&self, target: &ID2D1DeviceContext) -> Result<ID2D1Bitmap1> {
         let size_f = unsafe { target.GetSize() };
 
-        let size_u = D2D_SIZE_U { width: (size_f.width * self.dpi / 96.0) as u32, height: (size_f.height * self.dpi / 96.0) as u32 };
+        let size_u = D2D_SIZE_U {
+            width: (size_f.width * self.dpi / 96.0) as u32,
+            height: (size_f.height * self.dpi / 96.0) as u32,
+        };
 
         let properties = D2D1_BITMAP_PROPERTIES1 {
-            pixelFormat: D2D1_PIXEL_FORMAT { format: DXGI_FORMAT_B8G8R8A8_UNORM, alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED },
+            pixelFormat: D2D1_PIXEL_FORMAT {
+                format: DXGI_FORMAT_B8G8R8A8_UNORM,
+                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+            },
             dpiX: self.dpi,
             dpiY: self.dpi,
             bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET,
@@ -253,7 +322,11 @@ impl Window {
             let swapchain = self.swapchain.as_ref().unwrap();
             unsafe { target.SetTarget(None) };
 
-            if unsafe { swapchain.ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0).is_ok() } {
+            if unsafe {
+                swapchain
+                    .ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0)
+                    .is_ok()
+            } {
                 create_swapchain_bitmap(swapchain, target)?;
                 self.create_device_size_resources()?;
             } else {
@@ -325,7 +398,20 @@ impl Window {
             let atom = RegisterClassA(&wc);
             debug_assert!(atom != 0);
 
-            let handle = CreateWindowExA(Default::default(), PCSTR(b"window\0".as_ptr()), PCSTR(b"Sample Window\0".as_ptr()), WS_OVERLAPPEDWINDOW | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, None, None, instance, self as *mut _ as _);
+            let handle = CreateWindowExA(
+                Default::default(),
+                PCSTR(b"window\0".as_ptr()),
+                PCSTR(b"Sample Window\0".as_ptr()),
+                WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                None,
+                None,
+                instance,
+                self as *mut _ as _,
+            );
 
             debug_assert!(handle.0 != 0);
             debug_assert!(handle == self.handle);
@@ -354,7 +440,12 @@ impl Window {
         }
     }
 
-    extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    extern "system" fn wndproc(
+        window: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
         unsafe {
             if message == WM_NCCREATE {
                 let cs = lparam.0 as *const CREATESTRUCTA;
@@ -384,9 +475,17 @@ fn get_time(frequency: i64) -> Result<f64> {
 }
 
 fn create_brush(target: &ID2D1DeviceContext) -> Result<ID2D1SolidColorBrush> {
-    let color = D2D1_COLOR_F { r: 0.92, g: 0.38, b: 0.208, a: 1.0 };
+    let color = D2D1_COLOR_F {
+        r: 0.92,
+        g: 0.38,
+        b: 0.208,
+        a: 1.0,
+    };
 
-    let properties = D2D1_BRUSH_PROPERTIES { opacity: 0.8, transform: Matrix3x2::identity() };
+    let properties = D2D1_BRUSH_PROPERTIES {
+        opacity: 0.8,
+        transform: Matrix3x2::identity(),
+    };
 
     unsafe { target.CreateSolidColorBrush(&color, &properties) }
 }
@@ -409,18 +508,31 @@ fn create_factory() -> Result<ID2D1Factory1> {
 
     let mut result = None;
 
-    unsafe { D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, &ID2D1Factory1::IID, &options, &mut result as *mut _ as _).map(|()| result.unwrap()) }
+    unsafe {
+        D2D1CreateFactory(
+            D2D1_FACTORY_TYPE_SINGLE_THREADED,
+            &ID2D1Factory1::IID,
+            &options,
+            &mut result as *mut _ as _,
+        )
+        .map(|()| result.unwrap())
+    }
 }
 
 fn create_style(factory: &ID2D1Factory1) -> Result<ID2D1StrokeStyle> {
-    let props = D2D1_STROKE_STYLE_PROPERTIES { startCap: D2D1_CAP_STYLE_ROUND, endCap: D2D1_CAP_STYLE_TRIANGLE, ..Default::default() };
+    let props = D2D1_STROKE_STYLE_PROPERTIES {
+        startCap: D2D1_CAP_STYLE_ROUND,
+        endCap: D2D1_CAP_STYLE_TRIANGLE,
+        ..Default::default()
+    };
 
     unsafe { factory.CreateStrokeStyle(&props, &[]) }
 }
 
 fn create_transition() -> Result<IUIAnimationTransition> {
     unsafe {
-        let library: IUIAnimationTransitionLibrary = CoCreateInstance(&UIAnimationTransitionLibrary, None, CLSCTX_ALL)?;
+        let library: IUIAnimationTransitionLibrary =
+            CoCreateInstance(&UIAnimationTransitionLibrary, None, CLSCTX_ALL)?;
         library.CreateAccelerateDecelerateTransition(5.0, 1.0, 0.2, 0.8)
     }
 }
@@ -434,7 +546,20 @@ fn create_device_with_type(drive_type: D3D_DRIVER_TYPE) -> Result<ID3D11Device> 
 
     let mut device = None;
 
-    unsafe { D3D11CreateDevice(None, drive_type, HINSTANCE::default(), flags, &[], D3D11_SDK_VERSION, &mut device, std::ptr::null_mut(), &mut None).map(|()| device.unwrap()) }
+    unsafe {
+        D3D11CreateDevice(
+            None,
+            drive_type,
+            HINSTANCE::default(),
+            flags,
+            &[],
+            D3D11_SDK_VERSION,
+            &mut device,
+            std::ptr::null_mut(),
+            &mut None,
+        )
+        .map(|()| device.unwrap())
+    }
 }
 
 fn create_device() -> Result<ID3D11Device> {
@@ -449,7 +574,10 @@ fn create_device() -> Result<ID3D11Device> {
     result
 }
 
-fn create_render_target(factory: &ID2D1Factory1, device: &ID3D11Device) -> Result<ID2D1DeviceContext> {
+fn create_render_target(
+    factory: &ID2D1Factory1,
+    device: &ID3D11Device,
+) -> Result<ID2D1DeviceContext> {
     unsafe {
         let d2device = factory.CreateDevice(device.cast::<IDXGIDevice>()?)?;
 
@@ -470,7 +598,10 @@ fn create_swapchain_bitmap(swapchain: &IDXGISwapChain1, target: &ID2D1DeviceCont
     let surface: IDXGISurface = unsafe { swapchain.GetBuffer(0)? };
 
     let props = D2D1_BITMAP_PROPERTIES1 {
-        pixelFormat: D2D1_PIXEL_FORMAT { format: DXGI_FORMAT_B8G8R8A8_UNORM, alphaMode: D2D1_ALPHA_MODE_IGNORE },
+        pixelFormat: D2D1_PIXEL_FORMAT {
+            format: DXGI_FORMAT_B8G8R8A8_UNORM,
+            alphaMode: D2D1_ALPHA_MODE_IGNORE,
+        },
         dpiX: 96.0,
         dpiY: 96.0,
         bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
@@ -490,7 +621,10 @@ fn create_swapchain(device: &ID3D11Device, window: HWND) -> Result<IDXGISwapChai
 
     let props = DXGI_SWAP_CHAIN_DESC1 {
         Format: DXGI_FORMAT_B8G8R8A8_UNORM,
-        SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
         BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
         BufferCount: 2,
         SwapEffect: DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL,

--- a/crates/samples/direct3d12/build.rs
+++ b/crates/samples/direct3d12/build.rs
@@ -1,4 +1,8 @@
 fn main() {
     println!("!cargo:rerun-if-changed=src/shaders.hlsl");
-    std::fs::copy("src/shaders.hlsl", std::env::var("OUT_DIR").unwrap() + "/../../../shaders.hlsl").expect("Copy");
+    std::fs::copy(
+        "src/shaders.hlsl",
+        std::env::var("OUT_DIR").unwrap() + "/../../../shaders.hlsl",
+    )
+    .expect("Copy");
 }

--- a/crates/samples/direct3d12/src/main.rs
+++ b/crates/samples/direct3d12/src/main.rs
@@ -1,4 +1,9 @@
-use windows::{core::*, Win32::Foundation::*, Win32::Graphics::Direct3D::Fxc::*, Win32::Graphics::Direct3D::*, Win32::Graphics::Direct3D12::*, Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*, Win32::System::LibraryLoader::*, Win32::System::Threading::*, Win32::System::WindowsProgramming::*, Win32::UI::WindowsAndMessaging::*};
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Graphics::Direct3D::Fxc::*, Win32::Graphics::Direct3D::*,
+    Win32::Graphics::Direct3D12::*, Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*,
+    Win32::System::LibraryLoader::*, Win32::System::Threading::*,
+    Win32::System::WindowsProgramming::*, Win32::UI::WindowsAndMessaging::*,
+};
 
 use std::mem::transmute;
 
@@ -64,7 +69,12 @@ where
     let atom = unsafe { RegisterClassExA(&wc) };
     debug_assert_ne!(atom, 0);
 
-    let mut window_rect = RECT { left: 0, top: 0, right: size.0, bottom: size.1 };
+    let mut window_rect = RECT {
+        left: 0,
+        top: 0,
+        right: size.0,
+        bottom: size.1,
+    };
     unsafe { AdjustWindowRect(&mut window_rect, WS_OVERLAPPEDWINDOW, false) };
 
     let mut title = sample.title();
@@ -154,7 +164,12 @@ unsafe fn GetWindowLong(window: HWND, index: WINDOW_LONG_PTR_INDEX) -> isize {
     GetWindowLongPtrA(window, index)
 }
 
-extern "system" fn wndproc<S: DXSample>(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+extern "system" fn wndproc<S: DXSample>(
+    window: HWND,
+    message: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
     match message {
         WM_CREATE => {
             unsafe {
@@ -170,7 +185,9 @@ extern "system" fn wndproc<S: DXSample>(window: HWND, message: u32, wparam: WPAR
         _ => {
             let user_data = unsafe { GetWindowLong(window, GWLP_USERDATA) };
             let sample = std::ptr::NonNull::<S>::new(user_data as _);
-            let handled = sample.map_or(false, |mut s| sample_wndproc(unsafe { s.as_mut() }, message, wparam));
+            let handled = sample.map_or(false, |mut s| {
+                sample_wndproc(unsafe { s.as_mut() }, message, wparam)
+            });
 
             if handled {
                 LRESULT::default()
@@ -195,7 +212,15 @@ fn get_hardware_adapter(factory: &IDXGIFactory4) -> Result<IDXGIAdapter1> {
 
         // Check to see whether the adapter supports Direct3D 12, but don't
         // create the actual device yet.
-        if unsafe { D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_11_0, std::ptr::null_mut::<Option<ID3D12Device>>()) }.is_ok() {
+        if unsafe {
+            D3D12CreateDevice(
+                &adapter,
+                D3D_FEATURE_LEVEL_11_0,
+                std::ptr::null_mut::<Option<ID3D12Device>>(),
+            )
+        }
+        .is_ok()
+        {
             return Ok(adapter);
         }
     }
@@ -243,11 +268,20 @@ mod d3d12_hello_triangle {
         fn new(command_line: &SampleCommandLine) -> Result<Self> {
             let (dxgi_factory, device) = create_device(command_line)?;
 
-            Ok(Sample { dxgi_factory, device, resources: None })
+            Ok(Sample {
+                dxgi_factory,
+                device,
+                resources: None,
+            })
         }
 
         fn bind_to_window(&mut self, hwnd: &HWND) -> Result<()> {
-            let command_queue: ID3D12CommandQueue = unsafe { self.device.CreateCommandQueue(&D3D12_COMMAND_QUEUE_DESC { Type: D3D12_COMMAND_LIST_TYPE_DIRECT, ..Default::default() })? };
+            let command_queue: ID3D12CommandQueue = unsafe {
+                self.device.CreateCommandQueue(&D3D12_COMMAND_QUEUE_DESC {
+                    Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
+                    ..Default::default()
+                })?
+            };
 
             let (width, height) = self.window_size();
 
@@ -258,40 +292,94 @@ mod d3d12_hello_triangle {
                 Format: DXGI_FORMAT_R8G8B8A8_UNORM,
                 BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
                 SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
-                SampleDesc: DXGI_SAMPLE_DESC { Count: 1, ..Default::default() },
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    ..Default::default()
+                },
                 ..Default::default()
             };
 
-            let swap_chain: IDXGISwapChain3 = unsafe { self.dxgi_factory.CreateSwapChainForHwnd(&command_queue, hwnd, &swap_chain_desc, std::ptr::null(), None)? }.cast()?;
+            let swap_chain: IDXGISwapChain3 = unsafe {
+                self.dxgi_factory.CreateSwapChainForHwnd(
+                    &command_queue,
+                    hwnd,
+                    &swap_chain_desc,
+                    std::ptr::null(),
+                    None,
+                )?
+            }
+            .cast()?;
 
             // This sample does not support fullscreen transitions
             unsafe {
-                self.dxgi_factory.MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER)?;
+                self.dxgi_factory
+                    .MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER)?;
             }
 
             let frame_index = unsafe { swap_chain.GetCurrentBackBufferIndex() };
 
-            let rtv_heap: ID3D12DescriptorHeap = unsafe { self.device.CreateDescriptorHeap(&D3D12_DESCRIPTOR_HEAP_DESC { NumDescriptors: FRAME_COUNT, Type: D3D12_DESCRIPTOR_HEAP_TYPE_RTV, ..Default::default() }) }?;
+            let rtv_heap: ID3D12DescriptorHeap = unsafe {
+                self.device
+                    .CreateDescriptorHeap(&D3D12_DESCRIPTOR_HEAP_DESC {
+                        NumDescriptors: FRAME_COUNT,
+                        Type: D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+                        ..Default::default()
+                    })
+            }?;
 
-            let rtv_descriptor_size = unsafe { self.device.GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV) } as usize;
+            let rtv_descriptor_size = unsafe {
+                self.device
+                    .GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV)
+            } as usize;
             let rtv_handle = unsafe { rtv_heap.GetCPUDescriptorHandleForHeapStart() };
 
-            let render_targets: [ID3D12Resource; FRAME_COUNT as usize] = array_init::try_array_init(|i: usize| -> Result<ID3D12Resource> {
-                let render_target: ID3D12Resource = unsafe { swap_chain.GetBuffer(i as u32) }?;
-                unsafe { self.device.CreateRenderTargetView(&render_target, std::ptr::null(), &D3D12_CPU_DESCRIPTOR_HANDLE { ptr: rtv_handle.ptr + i * rtv_descriptor_size }) };
-                Ok(render_target)
-            })?;
+            let render_targets: [ID3D12Resource; FRAME_COUNT as usize] =
+                array_init::try_array_init(|i: usize| -> Result<ID3D12Resource> {
+                    let render_target: ID3D12Resource = unsafe { swap_chain.GetBuffer(i as u32) }?;
+                    unsafe {
+                        self.device.CreateRenderTargetView(
+                            &render_target,
+                            std::ptr::null(),
+                            &D3D12_CPU_DESCRIPTOR_HANDLE {
+                                ptr: rtv_handle.ptr + i * rtv_descriptor_size,
+                            },
+                        )
+                    };
+                    Ok(render_target)
+                })?;
 
-            let viewport = D3D12_VIEWPORT { TopLeftX: 0.0, TopLeftY: 0.0, Width: width as f32, Height: height as f32, MinDepth: D3D12_MIN_DEPTH, MaxDepth: D3D12_MAX_DEPTH };
+            let viewport = D3D12_VIEWPORT {
+                TopLeftX: 0.0,
+                TopLeftY: 0.0,
+                Width: width as f32,
+                Height: height as f32,
+                MinDepth: D3D12_MIN_DEPTH,
+                MaxDepth: D3D12_MAX_DEPTH,
+            };
 
-            let scissor_rect = RECT { left: 0, top: 0, right: width, bottom: height };
+            let scissor_rect = RECT {
+                left: 0,
+                top: 0,
+                right: width,
+                bottom: height,
+            };
 
-            let command_allocator = unsafe { self.device.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT) }?;
+            let command_allocator = unsafe {
+                self.device
+                    .CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT)
+            }?;
 
             let root_signature = create_root_signature(&self.device)?;
             let pso = create_pipeline_state(&self.device, &root_signature)?;
 
-            let command_list: ID3D12GraphicsCommandList = unsafe { self.device.CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, &command_allocator, &pso) }?;
+            let command_list: ID3D12GraphicsCommandList = unsafe {
+                self.device.CreateCommandList(
+                    0,
+                    D3D12_COMMAND_LIST_TYPE_DIRECT,
+                    &command_allocator,
+                    &pso,
+                )
+            }?;
             unsafe {
                 command_list.Close()?;
             };
@@ -343,7 +431,11 @@ mod d3d12_hello_triangle {
 
                 // Execute the command list.
                 let command_list = ID3D12CommandList::from(&resources.command_list);
-                unsafe { resources.command_queue.ExecuteCommandLists(&[Some(command_list)]) };
+                unsafe {
+                    resources
+                        .command_queue
+                        .ExecuteCommandLists(&[Some(command_list)])
+                };
 
                 // Present the frame.
                 unsafe { resources.swap_chain.Present(1, 0) }.ok().unwrap();
@@ -378,10 +470,17 @@ mod d3d12_hello_triangle {
         }
 
         // Indicate that the back buffer will be used as a render target.
-        let barrier = transition_barrier(&resources.render_targets[resources.frame_index as usize], D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+        let barrier = transition_barrier(
+            &resources.render_targets[resources.frame_index as usize],
+            D3D12_RESOURCE_STATE_PRESENT,
+            D3D12_RESOURCE_STATE_RENDER_TARGET,
+        );
         unsafe { command_list.ResourceBarrier(&[barrier]) };
 
-        let rtv_handle = D3D12_CPU_DESCRIPTOR_HANDLE { ptr: unsafe { resources.rtv_heap.GetCPUDescriptorHandleForHeapStart() }.ptr + resources.frame_index as usize * resources.rtv_descriptor_size };
+        let rtv_handle = D3D12_CPU_DESCRIPTOR_HANDLE {
+            ptr: unsafe { resources.rtv_heap.GetCPUDescriptorHandleForHeapStart() }.ptr
+                + resources.frame_index as usize * resources.rtv_descriptor_size,
+        };
 
         unsafe { command_list.OMSetRenderTargets(1, &rtv_handle, false, std::ptr::null()) };
 
@@ -393,18 +492,31 @@ mod d3d12_hello_triangle {
             command_list.DrawInstanced(3, 1, 0, 0);
 
             // Indicate that the back buffer will now be used to present.
-            command_list.ResourceBarrier(&[transition_barrier(&resources.render_targets[resources.frame_index as usize], D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT)]);
+            command_list.ResourceBarrier(&[transition_barrier(
+                &resources.render_targets[resources.frame_index as usize],
+                D3D12_RESOURCE_STATE_RENDER_TARGET,
+                D3D12_RESOURCE_STATE_PRESENT,
+            )]);
         }
 
         unsafe { command_list.Close() }
     }
 
-    fn transition_barrier(resource: &ID3D12Resource, state_before: D3D12_RESOURCE_STATES, state_after: D3D12_RESOURCE_STATES) -> D3D12_RESOURCE_BARRIER {
+    fn transition_barrier(
+        resource: &ID3D12Resource,
+        state_before: D3D12_RESOURCE_STATES,
+        state_after: D3D12_RESOURCE_STATES,
+    ) -> D3D12_RESOURCE_BARRIER {
         D3D12_RESOURCE_BARRIER {
             Type: D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
             Flags: D3D12_RESOURCE_BARRIER_FLAG_NONE,
             Anonymous: D3D12_RESOURCE_BARRIER_0 {
-                Transition: std::mem::ManuallyDrop::new(D3D12_RESOURCE_TRANSITION_BARRIER { pResource: Some(resource.clone()), StateBefore: state_before, StateAfter: state_after, Subresource: D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES }),
+                Transition: std::mem::ManuallyDrop::new(D3D12_RESOURCE_TRANSITION_BARRIER {
+                    pResource: Some(resource.clone()),
+                    StateBefore: state_before,
+                    StateAfter: state_after,
+                    Subresource: D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                }),
             },
         }
     }
@@ -419,11 +531,19 @@ mod d3d12_hello_triangle {
             }
         }
 
-        let dxgi_factory_flags = if cfg!(debug_assertions) { DXGI_CREATE_FACTORY_DEBUG } else { 0 };
+        let dxgi_factory_flags = if cfg!(debug_assertions) {
+            DXGI_CREATE_FACTORY_DEBUG
+        } else {
+            0
+        };
 
         let dxgi_factory: IDXGIFactory4 = unsafe { CreateDXGIFactory2(dxgi_factory_flags) }?;
 
-        let adapter = if command_line.use_warp_device { unsafe { dxgi_factory.EnumWarpAdapter() } } else { get_hardware_adapter(&dxgi_factory) }?;
+        let adapter = if command_line.use_warp_device {
+            unsafe { dxgi_factory.EnumWarpAdapter() }
+        } else {
+            get_hardware_adapter(&dxgi_factory)
+        }?;
 
         let mut device: Option<ID3D12Device> = None;
         unsafe { D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0, &mut device) }?;
@@ -431,17 +551,43 @@ mod d3d12_hello_triangle {
     }
 
     fn create_root_signature(device: &ID3D12Device) -> Result<ID3D12RootSignature> {
-        let desc = D3D12_ROOT_SIGNATURE_DESC { Flags: D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT, ..Default::default() };
+        let desc = D3D12_ROOT_SIGNATURE_DESC {
+            Flags: D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
+            ..Default::default()
+        };
 
         let mut signature = None;
 
-        let signature = unsafe { D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &mut signature, std::ptr::null_mut()) }.map(|()| signature.unwrap())?;
+        let signature = unsafe {
+            D3D12SerializeRootSignature(
+                &desc,
+                D3D_ROOT_SIGNATURE_VERSION_1,
+                &mut signature,
+                std::ptr::null_mut(),
+            )
+        }
+        .map(|()| signature.unwrap())?;
 
-        unsafe { device.CreateRootSignature(0, std::slice::from_raw_parts(signature.GetBufferPointer() as _, signature.GetBufferSize())) }
+        unsafe {
+            device.CreateRootSignature(
+                0,
+                std::slice::from_raw_parts(
+                    signature.GetBufferPointer() as _,
+                    signature.GetBufferSize(),
+                ),
+            )
+        }
     }
 
-    fn create_pipeline_state(device: &ID3D12Device, root_signature: &ID3D12RootSignature) -> Result<ID3D12PipelineState> {
-        let compile_flags = if cfg!(debug_assertions) { D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION } else { 0 };
+    fn create_pipeline_state(
+        device: &ID3D12Device,
+        root_signature: &ID3D12RootSignature,
+    ) -> Result<ID3D12PipelineState> {
+        let compile_flags = if cfg!(debug_assertions) {
+            D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION
+        } else {
+            0
+        };
 
         let exe_path = std::env::current_exe().ok().unwrap();
         let asset_path = exe_path.parent().unwrap();
@@ -449,10 +595,36 @@ mod d3d12_hello_triangle {
         let shaders_hlsl = shaders_hlsl_path.to_str().unwrap();
 
         let mut vertex_shader = None;
-        let vertex_shader = unsafe { D3DCompileFromFile(shaders_hlsl, std::ptr::null(), None, "VSMain", "vs_5_0", compile_flags, 0, &mut vertex_shader, std::ptr::null_mut()) }.map(|()| vertex_shader.unwrap())?;
+        let vertex_shader = unsafe {
+            D3DCompileFromFile(
+                shaders_hlsl,
+                std::ptr::null(),
+                None,
+                "VSMain",
+                "vs_5_0",
+                compile_flags,
+                0,
+                &mut vertex_shader,
+                std::ptr::null_mut(),
+            )
+        }
+        .map(|()| vertex_shader.unwrap())?;
 
         let mut pixel_shader = None;
-        let pixel_shader = unsafe { D3DCompileFromFile(shaders_hlsl, std::ptr::null(), None, "PSMain", "ps_5_0", compile_flags, 0, &mut pixel_shader, std::ptr::null_mut()) }.map(|()| pixel_shader.unwrap())?;
+        let pixel_shader = unsafe {
+            D3DCompileFromFile(
+                shaders_hlsl,
+                std::ptr::null(),
+                None,
+                "PSMain",
+                "ps_5_0",
+                compile_flags,
+                0,
+                &mut pixel_shader,
+                std::ptr::null_mut(),
+            )
+        }
+        .map(|()| pixel_shader.unwrap())?;
 
         let mut input_element_descs: [D3D12_INPUT_ELEMENT_DESC; 2] = [
             D3D12_INPUT_ELEMENT_DESC {
@@ -476,11 +648,24 @@ mod d3d12_hello_triangle {
         ];
 
         let mut desc = D3D12_GRAPHICS_PIPELINE_STATE_DESC {
-            InputLayout: D3D12_INPUT_LAYOUT_DESC { pInputElementDescs: input_element_descs.as_mut_ptr(), NumElements: input_element_descs.len() as u32 },
+            InputLayout: D3D12_INPUT_LAYOUT_DESC {
+                pInputElementDescs: input_element_descs.as_mut_ptr(),
+                NumElements: input_element_descs.len() as u32,
+            },
             pRootSignature: Some(root_signature.clone()), // << https://github.com/microsoft/windows-rs/discussions/623
-            VS: D3D12_SHADER_BYTECODE { pShaderBytecode: unsafe { vertex_shader.GetBufferPointer() }, BytecodeLength: unsafe { vertex_shader.GetBufferSize() } },
-            PS: D3D12_SHADER_BYTECODE { pShaderBytecode: unsafe { pixel_shader.GetBufferPointer() }, BytecodeLength: unsafe { pixel_shader.GetBufferSize() } },
-            RasterizerState: D3D12_RASTERIZER_DESC { FillMode: D3D12_FILL_MODE_SOLID, CullMode: D3D12_CULL_MODE_NONE, ..Default::default() },
+            VS: D3D12_SHADER_BYTECODE {
+                pShaderBytecode: unsafe { vertex_shader.GetBufferPointer() },
+                BytecodeLength: unsafe { vertex_shader.GetBufferSize() },
+            },
+            PS: D3D12_SHADER_BYTECODE {
+                pShaderBytecode: unsafe { pixel_shader.GetBufferPointer() },
+                BytecodeLength: unsafe { pixel_shader.GetBufferSize() },
+            },
+            RasterizerState: D3D12_RASTERIZER_DESC {
+                FillMode: D3D12_FILL_MODE_SOLID,
+                CullMode: D3D12_CULL_MODE_NONE,
+                ..Default::default()
+            },
             BlendState: D3D12_BLEND_DESC {
                 AlphaToCoverageEnable: false.into(),
                 IndependentBlendEnable: false.into(),
@@ -510,7 +695,10 @@ mod d3d12_hello_triangle {
             SampleMask: u32::max_value(),
             PrimitiveTopologyType: D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
             NumRenderTargets: 1,
-            SampleDesc: DXGI_SAMPLE_DESC { Count: 1, ..Default::default() },
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                ..Default::default()
+            },
             ..Default::default()
         };
         desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -518,8 +706,24 @@ mod d3d12_hello_triangle {
         unsafe { device.CreateGraphicsPipelineState(&desc) }
     }
 
-    fn create_vertex_buffer(device: &ID3D12Device, aspect_ratio: f32) -> Result<(ID3D12Resource, D3D12_VERTEX_BUFFER_VIEW)> {
-        let vertices = [Vertex { position: [0.0, 0.25 * aspect_ratio, 0.0], color: [1.0, 0.0, 0.0, 1.0] }, Vertex { position: [0.25, -0.25 * aspect_ratio, 0.0], color: [0.0, 1.0, 0.0, 1.0] }, Vertex { position: [-0.25, -0.25 * aspect_ratio, 0.0], color: [0.0, 0.0, 1.0, 1.0] }];
+    fn create_vertex_buffer(
+        device: &ID3D12Device,
+        aspect_ratio: f32,
+    ) -> Result<(ID3D12Resource, D3D12_VERTEX_BUFFER_VIEW)> {
+        let vertices = [
+            Vertex {
+                position: [0.0, 0.25 * aspect_ratio, 0.0],
+                color: [1.0, 0.0, 0.0, 1.0],
+            },
+            Vertex {
+                position: [0.25, -0.25 * aspect_ratio, 0.0],
+                color: [0.0, 1.0, 0.0, 1.0],
+            },
+            Vertex {
+                position: [-0.25, -0.25 * aspect_ratio, 0.0],
+                color: [0.0, 0.0, 1.0, 1.0],
+            },
+        ];
 
         // Note: using upload heaps to transfer static data like vert buffers is
         // not recommended. Every time the GPU needs it, the upload heap will be
@@ -529,7 +733,10 @@ mod d3d12_hello_triangle {
         let mut vertex_buffer: Option<ID3D12Resource> = None;
         unsafe {
             device.CreateCommittedResource(
-                &D3D12_HEAP_PROPERTIES { Type: D3D12_HEAP_TYPE_UPLOAD, ..Default::default() },
+                &D3D12_HEAP_PROPERTIES {
+                    Type: D3D12_HEAP_TYPE_UPLOAD,
+                    ..Default::default()
+                },
                 D3D12_HEAP_FLAG_NONE,
                 &D3D12_RESOURCE_DESC {
                     Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
@@ -537,7 +744,10 @@ mod d3d12_hello_triangle {
                     Height: 1,
                     DepthOrArraySize: 1,
                     MipLevels: 1,
-                    SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+                    SampleDesc: DXGI_SAMPLE_DESC {
+                        Count: 1,
+                        Quality: 0,
+                    },
                     Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
                     ..Default::default()
                 },
@@ -552,7 +762,11 @@ mod d3d12_hello_triangle {
         unsafe {
             let mut data = std::ptr::null_mut();
             vertex_buffer.Map(0, std::ptr::null(), &mut data)?;
-            std::ptr::copy_nonoverlapping(vertices.as_ptr(), data as *mut Vertex, std::mem::size_of_val(&vertices));
+            std::ptr::copy_nonoverlapping(
+                vertices.as_ptr(),
+                data as *mut Vertex,
+                std::mem::size_of_val(&vertices),
+            );
             vertex_buffer.Unmap(0, std::ptr::null());
         }
 
@@ -580,13 +794,21 @@ mod d3d12_hello_triangle {
         // Signal and increment the fence value.
         let fence = resources.fence_value;
 
-        unsafe { resources.command_queue.Signal(&resources.fence, fence) }.ok().unwrap();
+        unsafe { resources.command_queue.Signal(&resources.fence, fence) }
+            .ok()
+            .unwrap();
 
         resources.fence_value += 1;
 
         // Wait until the previous frame is finished.
         if unsafe { resources.fence.GetCompletedValue() } < fence {
-            unsafe { resources.fence.SetEventOnCompletion(fence, resources.fence_event) }.ok().unwrap();
+            unsafe {
+                resources
+                    .fence
+                    .SetEventOnCompletion(fence, resources.fence_event)
+            }
+            .ok()
+            .unwrap();
 
             unsafe { WaitForSingleObject(resources.fence_event, INFINITE) };
         }

--- a/crates/samples/overlapped/src/main.rs
+++ b/crates/samples/overlapped/src/main.rs
@@ -1,14 +1,30 @@
-use windows::{core::*, Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::System::Threading::*, Win32::System::IO::*};
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::System::Threading::*,
+    Win32::System::IO::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
         let mut filename = std::env::current_dir().unwrap();
         filename.push("message.txt");
 
-        let file = CreateFileA(filename.as_path().to_str().unwrap(), FILE_GENERIC_READ, FILE_SHARE_READ, std::ptr::null(), OPEN_EXISTING, FILE_FLAG_OVERLAPPED, None)?;
+        let file = CreateFileA(
+            filename.as_path().to_str().unwrap(),
+            FILE_GENERIC_READ,
+            FILE_SHARE_READ,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OVERLAPPED,
+            None,
+        )?;
 
         let mut overlapped = OVERLAPPED {
-            Anonymous: OVERLAPPED_0 { Anonymous: OVERLAPPED_0_0 { Offset: 9, OffsetHigh: 0 } },
+            Anonymous: OVERLAPPED_0 {
+                Anonymous: OVERLAPPED_0_0 {
+                    Offset: 9,
+                    OffsetHigh: 0,
+                },
+            },
             hEvent: CreateEventA(std::ptr::null(), true, false, None)?,
             Internal: 0,
             InternalHigh: 0,
@@ -16,7 +32,13 @@ fn main() -> Result<()> {
 
         let mut buffer: [u8; 12] = Default::default();
 
-        let read_ok = ReadFile(file, buffer.as_mut_ptr() as _, 12, std::ptr::null_mut(), &mut overlapped);
+        let read_ok = ReadFile(
+            file,
+            buffer.as_mut_ptr() as _,
+            12,
+            std::ptr::null_mut(),
+            &mut overlapped,
+        );
 
         if !read_ok.as_bool() {
             assert_eq!(GetLastError(), ERROR_IO_PENDING);

--- a/crates/samples/spellchecker/src/main.rs
+++ b/crates/samples/spellchecker/src/main.rs
@@ -1,14 +1,17 @@
 use windows::{core::*, Win32::Globalization::*, Win32::System::Com::*};
 
 fn main() -> Result<()> {
-    let input = std::env::args().nth(1).expect("Expected one command line argument for text to be spell-corrected");
+    let input = std::env::args()
+        .nth(1)
+        .expect("Expected one command line argument for text to be spell-corrected");
     // Initialize the COM runtime for this thread
     unsafe {
         CoInitializeEx(std::ptr::null(), COINIT_MULTITHREADED)?;
     }
 
     // Create ISpellCheckerFactory
-    let factory: ISpellCheckerFactory = unsafe { CoCreateInstance(&SpellCheckerFactory, None, CLSCTX_ALL)? };
+    let factory: ISpellCheckerFactory =
+        unsafe { CoCreateInstance(&SpellCheckerFactory, None, CLSCTX_ALL)? };
 
     // Make sure that the "en-US" locale is supported
     let locale = "en-US";
@@ -43,7 +46,9 @@ fn main() -> Result<()> {
                 // Get the replacement as a widestring and convert to a Rust String
                 let replacement = unsafe { error.Replacement()? };
 
-                println!("Replace: {} with {}", substring, unsafe { read_to_string(replacement) });
+                println!("Replace: {} with {}", substring, unsafe {
+                    read_to_string(replacement)
+                });
 
                 unsafe { CoTaskMemFree(replacement.0 as *mut _) };
             }
@@ -62,7 +67,9 @@ fn main() -> Result<()> {
                         break;
                     }
 
-                    println!("Maybe replace: {} with {}", substring, unsafe { read_to_string(suggestion[0]) });
+                    println!("Maybe replace: {} with {}", substring, unsafe {
+                        read_to_string(suggestion[0])
+                    });
 
                     unsafe { CoTaskMemFree(suggestion[0].0 as *mut _) };
                 }

--- a/crates/samples/uiautomation/src/main.rs
+++ b/crates/samples/uiautomation/src/main.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Win32::System::Com::*, Win32::UI::Accessibility::*, Win32::UI::WindowsAndMessaging::*, UI::UIAutomation::*};
+use windows::{
+    core::*, Win32::System::Com::*, Win32::UI::Accessibility::*, Win32::UI::WindowsAndMessaging::*,
+    UI::UIAutomation::*,
+};
 
 fn main() -> Result<()> {
     unsafe {

--- a/crates/samples/xaml_app/src/main.rs
+++ b/crates/samples/xaml_app/src/main.rs
@@ -35,13 +35,21 @@ fn main() -> Result<()> {
         CoInitializeEx(std::ptr::null(), COINIT_MULTITHREADED)?;
 
         if let Err(result) = Package::Current() {
-            MessageBoxW(HWND::default(), "This sample must be registered (via register.cmd) and launched from Start.", "Error", MB_ICONSTOP | MB_OK);
+            MessageBoxW(
+                HWND::default(),
+                "This sample must be registered (via register.cmd) and launched from Start.",
+                "Error",
+                MB_ICONSTOP | MB_OK,
+            );
             return Err(result);
         }
     }
 
     Application::Start(ApplicationInitializationCallback::new(|_| {
-        Application::compose(MyApp { text: "Hello world", placeholder: "What are you going to build today?" })?;
+        Application::compose(MyApp {
+            text: "Hello world",
+            placeholder: "What are you going to build today?",
+        })?;
         Ok(())
     }))
 }

--- a/crates/targets/aarch64_msvc/build.rs
+++ b/crates/targets/aarch64_msvc/build.rs
@@ -6,5 +6,8 @@ fn main() {
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        std::path::Path::new(&dir).join("lib").display()
+    );
 }

--- a/crates/targets/i686_gnu/build.rs
+++ b/crates/targets/i686_gnu/build.rs
@@ -6,5 +6,8 @@ fn main() {
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        std::path::Path::new(&dir).join("lib").display()
+    );
 }

--- a/crates/targets/i686_msvc/build.rs
+++ b/crates/targets/i686_msvc/build.rs
@@ -6,5 +6,8 @@ fn main() {
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        std::path::Path::new(&dir).join("lib").display()
+    );
 }

--- a/crates/targets/x86_64_gnu/build.rs
+++ b/crates/targets/x86_64_gnu/build.rs
@@ -6,5 +6,8 @@ fn main() {
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        std::path::Path::new(&dir).join("lib").display()
+    );
 }

--- a/crates/targets/x86_64_msvc/build.rs
+++ b/crates/targets/x86_64_msvc/build.rs
@@ -6,5 +6,8 @@ fn main() {
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        std::path::Path::new(&dir).join("lib").display()
+    );
 }

--- a/crates/tests/arch_feature/tests/test.rs
+++ b/crates/tests/arch_feature/tests/test.rs
@@ -1,4 +1,7 @@
-use windows::{Win32::System::Diagnostics::Debug::CONTEXT, Win32::System::Environment::VBS_BASIC_ENCLAVE_BASIC_CALL_CREATE_THREAD};
+use windows::{
+    Win32::System::Diagnostics::Debug::CONTEXT,
+    Win32::System::Environment::VBS_BASIC_ENCLAVE_BASIC_CALL_CREATE_THREAD,
+};
 
 #[test]
 #[cfg(target_arch = "x86_64")]

--- a/crates/tests/class_factory/tests/test.rs
+++ b/crates/tests/class_factory/tests/test.rs
@@ -24,7 +24,12 @@ impl IClosable_Impl for Object {
 struct Factory();
 
 impl IClassFactory_Impl for Factory {
-    fn CreateInstance(&self, outer: &Option<IUnknown>, iid: *const GUID, object: *mut *mut core::ffi::c_void) -> Result<()> {
+    fn CreateInstance(
+        &self,
+        outer: &Option<IUnknown>,
+        iid: *const GUID,
+        object: *mut *mut core::ffi::c_void,
+    ) -> Result<()> {
         assert!(outer.is_none());
         let unknown: IInspectable = Object().into();
         // TODO: https://github.com/microsoft/windows-rs/issues/1441

--- a/crates/tests/component/build.rs
+++ b/crates/tests/component/build.rs
@@ -7,15 +7,32 @@ fn main() -> std::io::Result<()> {
     let metadata_dir = format!("{}\\System32\\WinMetadata", env!("windir"));
     std::fs::create_dir_all(".windows/winmd")?;
 
-    Command::new("midlrt.exe").arg("/winrt").arg("/nomidl").arg("/h").arg("nul").arg("/metadata_dir").arg(&metadata_dir).arg("/reference").arg(format!("{}\\Windows.Foundation.winmd", metadata_dir)).arg("/winmd").arg(".windows/winmd/component.winmd").arg("src/component.idl").status()?;
+    Command::new("midlrt.exe")
+        .arg("/winrt")
+        .arg("/nomidl")
+        .arg("/h")
+        .arg("nul")
+        .arg("/metadata_dir")
+        .arg(&metadata_dir)
+        .arg("/reference")
+        .arg(format!("{}\\Windows.Foundation.winmd", metadata_dir))
+        .arg("/winmd")
+        .arg(".windows/winmd/component.winmd")
+        .arg("src/component.idl")
+        .status()?;
 
     std::fs::remove_file("src/bindings.rs").ok();
     let mut bindings = File::create("src/bindings.rs")?;
 
     // TODO: this needs to be simpler
-    let files = vec![metadata::reader::File::new("../../libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new(".windows/winmd/component.winmd").unwrap()];
+    let files = vec![
+        metadata::reader::File::new("../../libs/metadata/default/Windows.winmd").unwrap(),
+        metadata::reader::File::new(".windows/winmd/component.winmd").unwrap(),
+    ];
     let reader = &metadata::reader::Reader::new(&files);
-    let tree = reader.tree("test_component", &[]).expect("`test_component` namespace not found");
+    let tree = reader
+        .tree("test_component", &[])
+        .expect("`test_component` namespace not found");
     let mut gen = bindgen::Gen::new(reader);
     gen.namespace = tree.namespace;
     gen.component = true;

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -4,20 +4,36 @@ impl Class {
     pub fn new() -> ::windows::core::Result<Self> {
         Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
     }
-    fn IActivationFactory<R, F: FnOnce(&::windows::core::IGenericFactory) -> ::windows::core::Result<R>>(callback: F) -> ::windows::core::Result<R> {
-        static mut SHARED: ::windows::core::FactoryCache<Class, ::windows::core::IGenericFactory> = ::windows::core::FactoryCache::new();
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&::windows::core::IGenericFactory) -> ::windows::core::Result<R>,
+    >(
+        callback: F,
+    ) -> ::windows::core::Result<R> {
+        static mut SHARED: ::windows::core::FactoryCache<Class, ::windows::core::IGenericFactory> =
+            ::windows::core::FactoryCache::new();
         unsafe { SHARED.call(callback) }
     }
     pub fn Property(&self) -> ::windows::core::Result<i32> {
         let this = self;
         unsafe {
             let mut result__ = ::core::mem::MaybeUninit::<i32>::zeroed();
-            (::windows::core::Interface::vtable(this).Property)(::windows::core::Interface::as_raw(this), result__.as_mut_ptr()).from_abi::<i32>(result__)
+            (::windows::core::Interface::vtable(this).Property)(
+                ::windows::core::Interface::as_raw(this),
+                result__.as_mut_ptr(),
+            )
+            .from_abi::<i32>(result__)
         }
     }
     pub fn SetProperty(&self, value: i32) -> ::windows::core::Result<()> {
         let this = self;
-        unsafe { (::windows::core::Interface::vtable(this).SetProperty)(::windows::core::Interface::as_raw(this), value).ok() }
+        unsafe {
+            (::windows::core::Interface::vtable(this).SetProperty)(
+                ::windows::core::Interface::as_raw(this),
+                value,
+            )
+            .ok()
+        }
     }
 }
 impl ::core::clone::Clone for Class {
@@ -37,7 +53,9 @@ impl ::core::fmt::Debug for Class {
     }
 }
 unsafe impl ::windows::core::RuntimeType for Class {
-    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"rc(test_component.Class;{a3307453-713a-5c8d-80e4-d73a7bd5e500})");
+    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(
+        b"rc(test_component.Class;{a3307453-713a-5c8d-80e4-d73a7bd5e500})",
+    );
     type DefaultType = ::core::option::Option<Self>;
     fn from_default(from: &Self::DefaultType) -> ::windows::core::Result<Self> {
         from.as_ref().cloned().ok_or(::windows::core::Error::OK)
@@ -97,14 +115,21 @@ unsafe impl ::core::marker::Sync for Class {}
 pub struct IClass(::windows::core::IUnknown);
 unsafe impl ::windows::core::Interface for IClass {
     type Vtable = IClass_Vtbl;
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3307453_713a_5c8d_80e4_d73a7bd5e500);
+    const IID: ::windows::core::GUID =
+        ::windows::core::GUID::from_u128(0xa3307453_713a_5c8d_80e4_d73a7bd5e500);
 }
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClass_Vtbl {
     pub base__: ::windows::core::IInspectableVtbl,
-    pub Property: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut i32) -> ::windows::core::HRESULT,
-    pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT,
+    pub Property: unsafe extern "system" fn(
+        this: *mut ::core::ffi::c_void,
+        result__: *mut i32,
+    ) -> ::windows::core::HRESULT,
+    pub SetProperty: unsafe extern "system" fn(
+        this: *mut ::core::ffi::c_void,
+        value: i32,
+    ) -> ::windows::core::HRESULT,
 }
 pub trait IClass_Impl: Sized {
     fn Property(&self) -> ::windows::core::Result<i32>;
@@ -114,8 +139,19 @@ impl ::windows::core::RuntimeName for IClass {
     const NAME: &'static str = "test_component.IClass";
 }
 impl IClass_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>() -> IClass_Vtbl {
-        unsafe extern "system" fn Property<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut i32) -> ::windows::core::HRESULT {
+    pub const fn new<
+        Identity: ::windows::core::IUnknownImpl<Impl = Impl>,
+        Impl: IClass_Impl,
+        const OFFSET: isize,
+    >() -> IClass_Vtbl {
+        unsafe extern "system" fn Property<
+            Identity: ::windows::core::IUnknownImpl<Impl = Impl>,
+            Impl: IClass_Impl,
+            const OFFSET: isize,
+        >(
+            this: *mut ::core::ffi::c_void,
+            result__: *mut i32,
+        ) -> ::windows::core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
             match this.Property() {
@@ -127,7 +163,14 @@ impl IClass_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetProperty<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT {
+        unsafe extern "system" fn SetProperty<
+            Identity: ::windows::core::IUnknownImpl<Impl = Impl>,
+            Impl: IClass_Impl,
+            const OFFSET: isize,
+        >(
+            this: *mut ::core::ffi::c_void,
+            value: i32,
+        ) -> ::windows::core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
             this.SetProperty(value).into()

--- a/crates/tests/component/src/lib.rs
+++ b/crates/tests/component/src/lib.rs
@@ -1,4 +1,12 @@
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clashing_extern_declarations, unused_variables, dead_code, clippy::all)]
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    clashing_extern_declarations,
+    unused_variables,
+    dead_code,
+    clippy::all
+)]
 
 mod bindings;
 use std::mem::*;
@@ -30,7 +38,10 @@ impl IActivationFactory_Impl for ClassFactory {
 }
 
 #[no_mangle]
-unsafe extern "stdcall" fn DllGetActivationFactory(name: ManuallyDrop<HSTRING>, result: *mut *mut std::ffi::c_void) -> HRESULT {
+unsafe extern "stdcall" fn DllGetActivationFactory(
+    name: ManuallyDrop<HSTRING>,
+    result: *mut *mut std::ffi::c_void,
+) -> HRESULT {
     let factory: Option<IActivationFactory> = match name.to_string().as_str() {
         "test_component.Class" => Some(ClassFactory.into()),
         _ => None,

--- a/crates/tests/component_client/build.rs
+++ b/crates/tests/component_client/build.rs
@@ -4,15 +4,23 @@ use std::process::*;
 
 fn main() -> std::io::Result<()> {
     create_dir_all(".windows/winmd")?;
-    copy("../component/.windows/winmd/component.winmd", ".windows/winmd/component.winmd")?;
+    copy(
+        "../component/.windows/winmd/component.winmd",
+        ".windows/winmd/component.winmd",
+    )?;
 
     std::fs::remove_file("src/bindings.rs").ok();
     let mut bindings = File::create("src/bindings.rs")?;
 
     // TODO: this needs to be simpler
-    let files = vec![metadata::reader::File::new("../../libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new(".windows/winmd/component.winmd").unwrap()];
+    let files = vec![
+        metadata::reader::File::new("../../libs/metadata/default/Windows.winmd").unwrap(),
+        metadata::reader::File::new(".windows/winmd/component.winmd").unwrap(),
+    ];
     let reader = &metadata::reader::Reader::new(&files);
-    let tree = reader.tree("test_component", &[]).expect("`test_component` namespace not found");
+    let tree = reader
+        .tree("test_component", &[])
+        .expect("`test_component` namespace not found");
     let mut gen = bindgen::Gen::new(reader);
     gen.namespace = tree.namespace;
     gen.component = true;

--- a/crates/tests/component_client/src/bindings.rs
+++ b/crates/tests/component_client/src/bindings.rs
@@ -4,20 +4,36 @@ impl Class {
     pub fn new() -> ::windows::core::Result<Self> {
         Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
     }
-    fn IActivationFactory<R, F: FnOnce(&::windows::core::IGenericFactory) -> ::windows::core::Result<R>>(callback: F) -> ::windows::core::Result<R> {
-        static mut SHARED: ::windows::core::FactoryCache<Class, ::windows::core::IGenericFactory> = ::windows::core::FactoryCache::new();
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&::windows::core::IGenericFactory) -> ::windows::core::Result<R>,
+    >(
+        callback: F,
+    ) -> ::windows::core::Result<R> {
+        static mut SHARED: ::windows::core::FactoryCache<Class, ::windows::core::IGenericFactory> =
+            ::windows::core::FactoryCache::new();
         unsafe { SHARED.call(callback) }
     }
     pub fn Property(&self) -> ::windows::core::Result<i32> {
         let this = self;
         unsafe {
             let mut result__ = ::core::mem::MaybeUninit::<i32>::zeroed();
-            (::windows::core::Interface::vtable(this).Property)(::windows::core::Interface::as_raw(this), result__.as_mut_ptr()).from_abi::<i32>(result__)
+            (::windows::core::Interface::vtable(this).Property)(
+                ::windows::core::Interface::as_raw(this),
+                result__.as_mut_ptr(),
+            )
+            .from_abi::<i32>(result__)
         }
     }
     pub fn SetProperty(&self, value: i32) -> ::windows::core::Result<()> {
         let this = self;
-        unsafe { (::windows::core::Interface::vtable(this).SetProperty)(::windows::core::Interface::as_raw(this), value).ok() }
+        unsafe {
+            (::windows::core::Interface::vtable(this).SetProperty)(
+                ::windows::core::Interface::as_raw(this),
+                value,
+            )
+            .ok()
+        }
     }
 }
 impl ::core::clone::Clone for Class {
@@ -37,7 +53,9 @@ impl ::core::fmt::Debug for Class {
     }
 }
 unsafe impl ::windows::core::RuntimeType for Class {
-    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(b"rc(test_component.Class;{a3307453-713a-5c8d-80e4-d73a7bd5e500})");
+    const SIGNATURE: ::windows::core::ConstBuffer = ::windows::core::ConstBuffer::from_slice(
+        b"rc(test_component.Class;{a3307453-713a-5c8d-80e4-d73a7bd5e500})",
+    );
     type DefaultType = ::core::option::Option<Self>;
     fn from_default(from: &Self::DefaultType) -> ::windows::core::Result<Self> {
         from.as_ref().cloned().ok_or(::windows::core::Error::OK)
@@ -97,12 +115,19 @@ unsafe impl ::core::marker::Sync for Class {}
 pub struct IClass(::windows::core::IUnknown);
 unsafe impl ::windows::core::Interface for IClass {
     type Vtable = IClass_Vtbl;
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3307453_713a_5c8d_80e4_d73a7bd5e500);
+    const IID: ::windows::core::GUID =
+        ::windows::core::GUID::from_u128(0xa3307453_713a_5c8d_80e4_d73a7bd5e500);
 }
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClass_Vtbl {
     pub base__: ::windows::core::IInspectableVtbl,
-    pub Property: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut i32) -> ::windows::core::HRESULT,
-    pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT,
+    pub Property: unsafe extern "system" fn(
+        this: *mut ::core::ffi::c_void,
+        result__: *mut i32,
+    ) -> ::windows::core::HRESULT,
+    pub SetProperty: unsafe extern "system" fn(
+        this: *mut ::core::ffi::c_void,
+        value: i32,
+    ) -> ::windows::core::HRESULT,
 }

--- a/crates/tests/component_client/src/lib.rs
+++ b/crates/tests/component_client/src/lib.rs
@@ -1,4 +1,11 @@
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clashing_extern_declarations, unused_variables, dead_code)]
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    clashing_extern_declarations,
+    unused_variables,
+    dead_code
+)]
 #![cfg(test)]
 
 mod bindings;

--- a/crates/tests/core/tests/guid.rs
+++ b/crates/tests/core/tests/guid.rs
@@ -10,7 +10,12 @@ fn test_new() {
 #[test]
 fn from_u128() {
     let a: GUID = "1FD63FEF-C0D2-42FE-823A-53A4052B8C8F".into();
-    let b = GUID::from_values(0x1fd63fef, 0xc0d2, 0x42fe, [0x82, 0x3a, 0x53, 0xa4, 0x5, 0x2b, 0x8c, 0x8f]);
+    let b = GUID::from_values(
+        0x1fd63fef,
+        0xc0d2,
+        0x42fe,
+        [0x82, 0x3a, 0x53, 0xa4, 0x5, 0x2b, 0x8c, 0x8f],
+    );
     let c = GUID::from_u128(0x1fd63fef_c0d2_42fe_823a_53a4052b8c8f);
 
     assert!(a == b);

--- a/crates/tests/core/tests/hstrings.rs
+++ b/crates/tests/core/tests/hstrings.rs
@@ -180,11 +180,16 @@ fn hstring_compat() -> Result<()> {
         let buffer = WindowsGetStringRawBuffer(&world, &mut len);
         assert_eq!(len, 5);
         // Adding +1 to the length of the slice to validate that it is null terminated.
-        assert_eq!(std::slice::from_raw_parts(buffer.0, 6), [87, 111, 114, 108, 100, 0]);
+        assert_eq!(
+            std::slice::from_raw_parts(buffer.0, 6),
+            [87, 111, 114, 108, 100, 0]
+        );
 
         // We need to drop to windows-sys to call the raw WindowsDeleteString function to avoid double-freeing the HSTRING,
         // but this test is important as it ensures that the allocators match.
-        let hresult = windows_sys::Win32::System::WinRT::WindowsDeleteString(std::mem::transmute_copy(&*std::mem::ManuallyDrop::new(hey)));
+        let hresult = windows_sys::Win32::System::WinRT::WindowsDeleteString(
+            std::mem::transmute_copy(&*std::mem::ManuallyDrop::new(hey)),
+        );
         assert_eq!(hresult, 0);
 
         // An HSTRING reference a.k.a. "fast pass" string is a kind of stack-based HSTRING used by C++ callers
@@ -193,7 +198,12 @@ fn hstring_compat() -> Result<()> {
         // and thereby excercise the windows::core::HSTRING support for HSTRING reference duplication.
         let mut header: windows_sys::Win32::System::WinRT::HSTRING_HEADER = std::mem::zeroed();
         let mut stack_hstring: windows_sys::core::HSTRING = std::mem::zeroed();
-        let hresult = windows_sys::Win32::System::WinRT::WindowsCreateStringReference([87, 111, 114, 108, 100, 0].as_ptr(), 5, &mut header, &mut stack_hstring);
+        let hresult = windows_sys::Win32::System::WinRT::WindowsCreateStringReference(
+            [87, 111, 114, 108, 100, 0].as_ptr(),
+            5,
+            &mut header,
+            &mut stack_hstring,
+        );
         assert_eq!(hresult, 0);
         assert_eq!(header.length, 5);
         let stack_hstring: std::mem::ManuallyDrop<HSTRING> = std::mem::transmute(stack_hstring);
@@ -205,7 +215,10 @@ fn hstring_compat() -> Result<()> {
         let buffer = WindowsGetStringRawBuffer(&duplicate, &mut len);
         assert_eq!(len, 5);
         // Adding +1 to the length of the slice to validate that it is null terminated.
-        assert_eq!(std::slice::from_raw_parts(buffer.0, 6), [87, 111, 114, 108, 100, 0]);
+        assert_eq!(
+            std::slice::from_raw_parts(buffer.0, 6),
+            [87, 111, 114, 108, 100, 0]
+        );
 
         Ok(())
     }

--- a/crates/tests/data_object/tests/test.rs
+++ b/crates/tests/data_object/tests/test.rs
@@ -91,7 +91,8 @@ fn test() -> Result<()> {
         d.GetData(core::ptr::null_mut())?;
         d.GetDataHere(core::ptr::null_mut(), core::ptr::null_mut())?;
         d.QueryGetData(core::ptr::null_mut())?;
-        d.GetCanonicalFormatEtc(core::ptr::null(), core::ptr::null_mut()).ok()?;
+        d.GetCanonicalFormatEtc(core::ptr::null(), core::ptr::null_mut())
+            .ok()?;
         d.SetData(core::ptr::null_mut(), core::ptr::null_mut(), false)?;
         let _ = d.EnumFormatEtc(0);
         d.DAdvise(core::ptr::null_mut(), 0, None)?;

--- a/crates/tests/drop_target/tests/test.rs
+++ b/crates/tests/drop_target/tests/test.rs
@@ -22,7 +22,12 @@ impl IDataObject_Impl for DataObject {
     fn EnumFormatEtc(&self, _: u32) -> Result<IEnumFORMATETC> {
         todo!()
     }
-    fn DAdvise(&self, format: *const FORMATETC, value: u32, sink: &Option<IAdviseSink>) -> Result<u32> {
+    fn DAdvise(
+        &self,
+        format: *const FORMATETC,
+        value: u32,
+        sink: &Option<IAdviseSink>,
+    ) -> Result<u32> {
         assert_eq!(format, std::ptr::null());
         assert_eq!(value, 789);
         assert!(sink.is_none());
@@ -40,9 +45,21 @@ impl IDataObject_Impl for DataObject {
 struct DropTarget();
 
 impl IDropTarget_Impl for DropTarget {
-    fn DragEnter(&self, object: &Option<IDataObject>, state: u32, point: &POINTL, effect: *mut u32) -> Result<()> {
+    fn DragEnter(
+        &self,
+        object: &Option<IDataObject>,
+        state: u32,
+        point: &POINTL,
+        effect: *mut u32,
+    ) -> Result<()> {
         unsafe {
-            assert_eq!(object.as_ref().unwrap().DAdvise(std::ptr::null(), 789, None)?, 123);
+            assert_eq!(
+                object
+                    .as_ref()
+                    .unwrap()
+                    .DAdvise(std::ptr::null(), 789, None)?,
+                123
+            );
             assert_eq!(state, 456);
             assert_eq!(*effect, 741);
             *effect = 147;

--- a/crates/tests/enums/tests/sys.rs
+++ b/crates/tests/enums/tests/sys.rs
@@ -2,7 +2,8 @@ use windows_sys::{Storage::Streams::*, Win32::Foundation::*, Win32::UI::WindowsA
 
 #[test]
 fn nested() {
-    let options: InputStreamOptions = InputStreamOptions(InputStreamOptions::Partial.0 | InputStreamOptions::ReadAhead.0);
+    let options: InputStreamOptions =
+        InputStreamOptions(InputStreamOptions::Partial.0 | InputStreamOptions::ReadAhead.0);
     assert!(options.0 == 3);
 }
 

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -1,4 +1,6 @@
-use windows::{core::*, Storage::Streams::*, Win32::Foundation::*, Win32::UI::WindowsAndMessaging::*};
+use windows::{
+    core::*, Storage::Streams::*, Win32::Foundation::*, Win32::UI::WindowsAndMessaging::*,
+};
 
 #[test]
 fn nested() {
@@ -8,7 +10,8 @@ fn nested() {
     let options = InputStreamOptions::Partial & InputStreamOptions::ReadAhead;
     assert!(options.0 == 0);
 
-    let options = (InputStreamOptions::Partial | InputStreamOptions::ReadAhead) & InputStreamOptions::ReadAhead;
+    let options = (InputStreamOptions::Partial | InputStreamOptions::ReadAhead)
+        & InputStreamOptions::ReadAhead;
     assert!(options.0 == 2);
 
     let mut options = InputStreamOptions::Partial;
@@ -36,7 +39,10 @@ fn win32_error() {
     assert!("WIN32_ERROR(5)" == format!("{:?}", e));
 
     let e: Error = h.into();
-    assert_eq!("Error { code: 0x80070005, message: Access is denied. }", format!("{:?}", e));
+    assert_eq!(
+        "Error { code: 0x80070005, message: Access is denied. }",
+        format!("{:?}", e)
+    );
     let e = WIN32_ERROR::from_error(&e).unwrap();
     assert!(e == ERROR_ACCESS_DENIED);
 }

--- a/crates/tests/error/tests/std.rs
+++ b/crates/tests/error/tests/std.rs
@@ -7,28 +7,46 @@ fn conversions() {
     assert_eq!(E_INVALIDARG.0, -2147024809);
 
     // Baseline WIN32_ERROR
-    assert_eq!(ERROR_INVALID_DATA.to_hresult().message(), "The data is invalid.");
+    assert_eq!(
+        ERROR_INVALID_DATA.to_hresult().message(),
+        "The data is invalid."
+    );
     assert_eq!(ERROR_INVALID_DATA.0, 13);
 
     // std::io::Error from HRESULT
     let std_error = std::io::Error::from_raw_os_error(E_INVALIDARG.0);
     assert_eq!(std_error.raw_os_error().unwrap(), E_INVALIDARG.0);
-    assert_eq!(format!("{}", std_error), "The parameter is incorrect. (os error -2147024809)");
+    assert_eq!(
+        format!("{}", std_error),
+        "The parameter is incorrect. (os error -2147024809)"
+    );
 
     // std::io::Error from WIN32_ERROR
     let std_error = std::io::Error::from_raw_os_error(ERROR_INVALID_DATA.0 as _);
     assert_eq!(std_error.raw_os_error().unwrap(), ERROR_INVALID_DATA.0 as _);
-    assert_eq!(format!("{}", std_error), "The data is invalid. (os error 13)");
+    assert_eq!(
+        format!("{}", std_error),
+        "The data is invalid. (os error 13)"
+    );
 
     // Starting with WIN32_ERROR...
     let win_error: windows::core::Error = ERROR_INVALID_DATA.into();
     let std_error: std::io::Error = win_error.into();
-    assert_eq!(std_error.raw_os_error().unwrap(), ERROR_INVALID_DATA.to_hresult().0);
-    assert_eq!(format!("{}", std_error), "The data is invalid. (os error -2147024883)");
+    assert_eq!(
+        std_error.raw_os_error().unwrap(),
+        ERROR_INVALID_DATA.to_hresult().0
+    );
+    assert_eq!(
+        format!("{}", std_error),
+        "The data is invalid. (os error -2147024883)"
+    );
 
     // Starting with HRESULT...
     let win_error: windows::core::Error = E_INVALIDARG.into();
     let std_error: std::io::Error = win_error.into();
     assert_eq!(std_error.raw_os_error().unwrap(), E_INVALIDARG.0);
-    assert_eq!(format!("{}", std_error), "The parameter is incorrect. (os error -2147024809)");
+    assert_eq!(
+        format!("{}", std_error),
+        "The parameter is incorrect. (os error -2147024809)"
+    );
 }

--- a/crates/tests/handles/tests/win.rs
+++ b/crates/tests/handles/tests/win.rs
@@ -1,4 +1,7 @@
-use windows::{Win32::Devices::Bluetooth::*, Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::ApplicationInstallationAndServicing::*, Win32::System::Registry::*};
+use windows::{
+    Win32::Devices::Bluetooth::*, Win32::Foundation::*, Win32::Graphics::Gdi::*,
+    Win32::System::ApplicationInstallationAndServicing::*, Win32::System::Registry::*,
+};
 
 #[test]
 fn handle() {

--- a/crates/tests/helpers/src/lib.rs
+++ b/crates/tests/helpers/src/lib.rs
@@ -3,6 +3,11 @@ use windows::Win32::Globalization::{SetThreadPreferredUILanguages, MUI_LANGUAGE_
 pub fn set_thread_ui_language(language_tag: &str) -> bool {
     unsafe {
         let mut _languages_set = 0;
-        SetThreadPreferredUILanguages(MUI_LANGUAGE_NAME, format!("{}\0\0", language_tag), _languages_set as *mut _).as_bool()
+        SetThreadPreferredUILanguages(
+            MUI_LANGUAGE_NAME,
+            format!("{}\0\0", language_tag),
+            _languages_set as *mut _,
+        )
+        .as_bool()
     }
 }

--- a/crates/tests/implement/tests/com.rs
+++ b/crates/tests/implement/tests/com.rs
@@ -6,7 +6,11 @@ use windows::Win32::Foundation::HANDLE;
 use windows::Win32::System::WinRT::Composition::*;
 use windows::Win32::System::WinRT::Display::*;
 
-#[implement(windows::Foundation::IStringable, windows::Win32::System::WinRT::Composition::ISwapChainInterop, windows::Win32::System::WinRT::Display::IDisplayPathInterop)]
+#[implement(
+    windows::Foundation::IStringable,
+    windows::Win32::System::WinRT::Composition::ISwapChainInterop,
+    windows::Win32::System::WinRT::Display::IDisplayPathInterop
+)]
 struct Mix;
 
 impl IStringable_Impl for Mix {

--- a/crates/tests/implement/tests/generic_default.rs
+++ b/crates/tests/implement/tests/generic_default.rs
@@ -74,7 +74,12 @@ fn test_implement() -> Result<()> {
     assert_eq!(2, index);
     assert_eq!(false, v.IndexOf("123", &mut index)?);
 
-    let v: IVectorView<IStringable> = Thing(vec![Some(Uri::CreateUri("http://one/")?.try_into().unwrap()), Some(Uri::CreateUri("http://two/")?.try_into().unwrap()), Some(Uri::CreateUri("http://three/")?.try_into().unwrap())]).into();
+    let v: IVectorView<IStringable> = Thing(vec![
+        Some(Uri::CreateUri("http://one/")?.try_into().unwrap()),
+        Some(Uri::CreateUri("http://two/")?.try_into().unwrap()),
+        Some(Uri::CreateUri("http://three/")?.try_into().unwrap()),
+    ])
+    .into();
 
     assert_eq!("http://one/", v.GetAt(0)?.ToString()?);
     assert_eq!("http://two/", v.GetAt(1)?.ToString()?);

--- a/crates/tests/implement/tests/generic_generic.rs
+++ b/crates/tests/implement/tests/generic_generic.rs
@@ -47,7 +47,12 @@ fn test_implement() -> Result<()> {
     assert_eq!("20", v.GetAt(1)?);
     assert_eq!("30", v.GetAt(2)?);
 
-    let v: IVectorView<IStringable> = Thing(vec![Uri::CreateUri("http://one/")?.try_into().unwrap(), Uri::CreateUri("http://two/")?.try_into().unwrap(), Uri::CreateUri("http://three/")?.try_into().unwrap()]).into();
+    let v: IVectorView<IStringable> = Thing(vec![
+        Uri::CreateUri("http://one/")?.try_into().unwrap(),
+        Uri::CreateUri("http://two/")?.try_into().unwrap(),
+        Uri::CreateUri("http://three/")?.try_into().unwrap(),
+    ])
+    .into();
 
     assert_eq!("http://one/", v.GetAt(0)?.ToString()?);
     assert_eq!("http://two/", v.GetAt(1)?.ToString()?);

--- a/crates/tests/implement/tests/generic_stringable.rs
+++ b/crates/tests/implement/tests/generic_stringable.rs
@@ -35,7 +35,12 @@ impl IIterable_Impl<IStringable> for Thing {
 
 #[test]
 fn test_implement() -> Result<()> {
-    let v: IVectorView<IStringable> = Thing(vec![Uri::CreateUri("http://one/")?.try_into().unwrap(), Uri::CreateUri("http://two/")?.try_into().unwrap(), Uri::CreateUri("http://three/")?.try_into().unwrap()]).into();
+    let v: IVectorView<IStringable> = Thing(vec![
+        Uri::CreateUri("http://one/")?.try_into().unwrap(),
+        Uri::CreateUri("http://two/")?.try_into().unwrap(),
+        Uri::CreateUri("http://three/")?.try_into().unwrap(),
+    ])
+    .into();
 
     assert_eq!("http://one/", v.GetAt(0)?.ToString()?);
     assert_eq!("http://two/", v.GetAt(1)?.ToString()?);

--- a/crates/tests/interface/tests/com.rs
+++ b/crates/tests/interface/tests/com.rs
@@ -5,9 +5,19 @@ use windows::{core::*, Win32::Foundation::*, Win32::System::Com::*};
 /// A custom declaration of implementation of `IUri`
 #[interface("a39ee748-6a27-4817-a6f2-13914bef5890")]
 unsafe trait ICustomUri: IUnknown {
-    unsafe fn GetPropertyBSTR(&self, property: Uri_PROPERTY, value: *mut BSTR, flags: u32) -> HRESULT;
+    unsafe fn GetPropertyBSTR(
+        &self,
+        property: Uri_PROPERTY,
+        value: *mut BSTR,
+        flags: u32,
+    ) -> HRESULT;
     unsafe fn GetPropertyLength(&self) -> HRESULT;
-    unsafe fn GetPropertyDWORD(&self, property: Uri_PROPERTY, value: *mut u32, flags: u32) -> HRESULT;
+    unsafe fn GetPropertyDWORD(
+        &self,
+        property: Uri_PROPERTY,
+        value: *mut u32,
+        flags: u32,
+    ) -> HRESULT;
     unsafe fn HasProperty(&self); // Note: this definition is missing its return value
     unsafe fn GetAbsoluteUri(&self) -> HRESULT;
     unsafe fn GetAuthority(&self) -> HRESULT;
@@ -124,7 +134,10 @@ fn test_custom_interface() -> windows::core::Result<()> {
         let p: ICustomPersistMemory = Persist::new().into();
         // This works because `ICustomPersistMemory` and `IPersistMemory` share the same guid
         let p: IPersistMemory = p.cast()?;
-        assert_eq!(p.GetClassID()?, "117fb826-2155-483a-b50d-bc99a2c7cca3".into());
+        assert_eq!(
+            p.GetClassID()?,
+            "117fb826-2155-483a-b50d-bc99a2c7cca3".into()
+        );
         // TODO: can't test IsDirty until this is fixed: https://github.com/microsoft/win32metadata/issues/838
         assert_eq!(p.GetSizeMax()?, 10);
         p.Load(&[0xAAu8, 0xBB, 0xCC])?;
@@ -138,10 +151,12 @@ fn test_custom_interface() -> windows::core::Result<()> {
         p.GetSizeMax(&mut size).ok()?;
         assert_eq!(size, 10);
         assert_eq!(p.IsDirty(), S_FALSE);
-        p.Load(&[0xAAu8, 0xBB, 0xCC] as *const _ as *const _, 3).ok()?;
+        p.Load(&[0xAAu8, 0xBB, 0xCC] as *const _ as *const _, 3)
+            .ok()?;
         assert_eq!(p.IsDirty(), S_OK);
         let mut memory = [0x00u8, 0x00, 0x00, 0x00];
-        p.Save(&mut memory as *mut _ as *mut _, true.into(), 4).ok()?;
+        p.Save(&mut memory as *mut _ as *mut _, true.into(), 4)
+            .ok()?;
         assert_eq!(p.IsDirty(), S_FALSE);
         assert_eq!(memory, [0xAAu8, 0xBB, 0xCC, 0x00]);
 

--- a/crates/tests/lib/tests/test.rs
+++ b/crates/tests/lib/tests/test.rs
@@ -10,6 +10,18 @@ fn linker() -> windows::core::Result<()> {
 fn gdi() {
     use windows::Win32::Graphics::Gdi::*;
     unsafe {
-        AlphaBlend(HDC::default(), 0, 0, 0, 0, HDC::default(), 0, 0, 0, 0, BLENDFUNCTION::default());
+        AlphaBlend(
+            HDC::default(),
+            0,
+            0,
+            0,
+            0,
+            HDC::default(),
+            0,
+            0,
+            0,
+            0,
+            BLENDFUNCTION::default(),
+        );
     }
 }

--- a/crates/tests/map/tests/test.rs
+++ b/crates/tests/map/tests/test.rs
@@ -52,7 +52,11 @@ impl IMapView_Impl<i32, f32> for MapView {
     fn Lookup(&self, _key: &i32) -> Result<f32> {
         Ok(0.0)
     }
-    fn Split(&self, _first: &mut Option<IMapView<i32, f32>>, _second: &mut Option<IMapView<i32, f32>>) -> Result<()> {
+    fn Split(
+        &self,
+        _first: &mut Option<IMapView<i32, f32>>,
+        _second: &mut Option<IMapView<i32, f32>>,
+    ) -> Result<()> {
         Ok(())
     }
     fn Size(&self) -> Result<u32> {

--- a/crates/tests/metadata/tests/fn_call_size.rs
+++ b/crates/tests/metadata/tests/fn_call_size.rs
@@ -1,18 +1,48 @@
 #[test]
 fn size() {
-    assert_eq!(function_size("Windows.Win32.System.Console", "ReadConsoleOutputA"), 20);
-    assert_eq!(function_size("Windows.Win32.System.Console", "ReadConsoleOutputAttribute"), 20);
-    assert_eq!(function_size("Windows.Win32.UI.Accessibility", "ItemContainerPattern_FindItemByProperty"), 32);
+    assert_eq!(
+        function_size("Windows.Win32.System.Console", "ReadConsoleOutputA"),
+        20
+    );
+    assert_eq!(
+        function_size("Windows.Win32.System.Console", "ReadConsoleOutputAttribute"),
+        20
+    );
+    assert_eq!(
+        function_size(
+            "Windows.Win32.UI.Accessibility",
+            "ItemContainerPattern_FindItemByProperty"
+        ),
+        32
+    );
     assert_eq!(function_size("Windows.Win32.System.Ole", "VarI2FromCy"), 12);
-    assert_eq!(function_size("Windows.Win32.UI.Accessibility", "UiaRaiseAutomationPropertyChangedEvent"), 40);
-    assert_eq!(function_size("Windows.Win32.Graphics.Gdi", "AlphaBlend"), 44);
-    assert_eq!(function_size("Windows.Win32.UI.Accessibility", "TextRange_FindAttribute"), 32);
+    assert_eq!(
+        function_size(
+            "Windows.Win32.UI.Accessibility",
+            "UiaRaiseAutomationPropertyChangedEvent"
+        ),
+        40
+    );
+    assert_eq!(
+        function_size("Windows.Win32.Graphics.Gdi", "AlphaBlend"),
+        44
+    );
+    assert_eq!(
+        function_size("Windows.Win32.UI.Accessibility", "TextRange_FindAttribute"),
+        32
+    );
 }
 
 fn function_size(namespace: &str, name: &str) -> usize {
-    let files = vec![metadata::reader::File::new("../../libs/metadata/default/Windows.Win32.winmd").unwrap()];
+    let files =
+        vec![
+            metadata::reader::File::new("../../libs/metadata/default/Windows.Win32.winmd").unwrap(),
+        ];
     let reader = &metadata::reader::Reader::new(&files);
-    if let Some(def) = reader.get(metadata::reader::TypeName::new(namespace, "Apis")).next() {
+    if let Some(def) = reader
+        .get(metadata::reader::TypeName::new(namespace, "Apis"))
+        .next()
+    {
         for method in reader.type_def_methods(def) {
             if reader.method_def_name(method) == name {
                 return reader.method_def_size(method);

--- a/crates/tests/metadata/tests/writer.rs
+++ b/crates/tests/metadata/tests/writer.rs
@@ -13,7 +13,11 @@ fn writer() {
         def.flags.set_interface();
 
         let mut method = MethodDef::new("ToString");
-        method.param_list.push(Param { name: "param123".to_string(), sequence: 123, ..Default::default() });
+        method.param_list.push(Param {
+            name: "param123".to_string(),
+            sequence: 123,
+            ..Default::default()
+        });
         def.method_list.push(method);
 
         tables.type_def.push(def);
@@ -38,7 +42,10 @@ fn writer() {
 
         let files = vec![File::new(temp_file.to_str().unwrap()).unwrap()];
         let reader = &Reader::new(&files);
-        let def = reader.get(TypeName::new("TestWindows.Foundation", "IStringable")).next().unwrap();
+        let def = reader
+            .get(TypeName::new("TestWindows.Foundation", "IStringable"))
+            .next()
+            .unwrap();
         assert_eq!(reader.type_def_kind(def), TypeKind::Interface);
         assert!(reader.type_def_flags(def).winrt());
 
@@ -49,14 +56,20 @@ fn writer() {
         assert_eq!(reader.param_name(param), "param123");
         assert_eq!(reader.param_sequence(param), 123);
 
-        let def = reader.get(TypeName::new("TestWindows.Foundation", "Rect")).next().unwrap();
+        let def = reader
+            .get(TypeName::new("TestWindows.Foundation", "Rect"))
+            .next()
+            .unwrap();
         assert_eq!(reader.type_def_kind(def), TypeKind::Struct);
         assert!(reader.type_def_flags(def).winrt());
 
         let field = reader.type_def_fields(def).next().unwrap();
         assert_eq!(reader.field_name(field), "Height");
 
-        let def = reader.get(TypeName::new("TestWindows.Foundation", "AsyncStatus")).next().unwrap();
+        let def = reader
+            .get(TypeName::new("TestWindows.Foundation", "AsyncStatus"))
+            .next()
+            .unwrap();
         assert_eq!(reader.type_def_kind(def), TypeKind::Enum);
         assert!(reader.type_def_flags(def).winrt());
     }

--- a/crates/tests/ntstatus/tests/ntstatus.rs
+++ b/crates/tests/ntstatus/tests/ntstatus.rs
@@ -23,7 +23,12 @@ fn test() -> Result<()> {
 
         let mut random = GUID::zeroed();
 
-        BCryptGenRandom(provider, &mut random as *mut _ as _, core::mem::size_of::<GUID>() as _, 0)?;
+        BCryptGenRandom(
+            provider,
+            &mut random as *mut _ as _,
+            core::mem::size_of::<GUID>() as _,
+            0,
+        )?;
 
         assert_ne!(random, GUID::zeroed());
     }

--- a/crates/tests/null_result/tests/test.rs
+++ b/crates/tests/null_result/tests/test.rs
@@ -68,7 +68,12 @@ impl IXamlType_Impl for Test {
     fn AddToVector(&self, _: &Option<IInspectable>, _: &Option<IInspectable>) -> Result<()> {
         todo!()
     }
-    fn AddToMap(&self, _: &Option<IInspectable>, _: &Option<IInspectable>, _: &Option<IInspectable>) -> Result<()> {
+    fn AddToMap(
+        &self,
+        _: &Option<IInspectable>,
+        _: &Option<IInspectable>,
+        _: &Option<IInspectable>,
+    ) -> Result<()> {
         todo!()
     }
     fn RunInitializer(&self) -> Result<()> {

--- a/crates/tests/properties/tests/test.rs
+++ b/crates/tests/properties/tests/test.rs
@@ -1,6 +1,9 @@
 #![allow(non_snake_case)]
 
-use windows::{core::*, Win32::System::Com::StructuredStorage::*, Win32::System::Com::*, Win32::UI::Shell::PropertiesSystem::*};
+use windows::{
+    core::*, Win32::System::Com::StructuredStorage::*, Win32::System::Com::*,
+    Win32::UI::Shell::PropertiesSystem::*,
+};
 
 #[implement(IInitializeWithStream, IPropertyStore, IPropertyStoreCapabilities)]
 struct Object();

--- a/crates/tests/return_struct/tests/free_function.rs
+++ b/crates/tests/return_struct/tests/free_function.rs
@@ -8,11 +8,22 @@
 fn test() {
     use windows::Win32::Graphics::Direct2D::{Common::*, *};
 
-    let before = D2D1_COLOR_F { r: 1.0, g: 2.0, b: 3.0, a: 4.0 };
+    let before = D2D1_COLOR_F {
+        r: 1.0,
+        g: 2.0,
+        b: 3.0,
+        a: 4.0,
+    };
 
-    let after = unsafe { D2D1ConvertColorSpace(D2D1_COLOR_SPACE_SRGB, D2D1_COLOR_SPACE_SCRGB, &before) };
+    let after =
+        unsafe { D2D1ConvertColorSpace(D2D1_COLOR_SPACE_SRGB, D2D1_COLOR_SPACE_SCRGB, &before) };
 
-    let expected = D2D1_COLOR_F { r: 1.0, g: 1.0, b: 1.0, a: 4.0 };
+    let expected = D2D1_COLOR_F {
+        r: 1.0,
+        g: 1.0,
+        b: 1.0,
+        a: 4.0,
+    };
 
     assert!(after == expected);
 }

--- a/crates/tests/string_param/tests/pwstr.rs
+++ b/crates/tests/string_param/tests/pwstr.rs
@@ -13,13 +13,47 @@ fn test() {
         assert_eq!(utf8.len(), len);
         assert_eq!(utf16.len(), len);
 
-        assert_eq!(utf8, std::slice::from_raw_parts(IntoParam::<PCSTR>::into_param("test").abi().0, len));
-        assert_eq!(utf8, std::slice::from_raw_parts(IntoParam::<PCSTR>::into_param(String::from("test")).abi().0, len));
+        assert_eq!(
+            utf8,
+            std::slice::from_raw_parts(IntoParam::<PCSTR>::into_param("test").abi().0, len)
+        );
+        assert_eq!(
+            utf8,
+            std::slice::from_raw_parts(
+                IntoParam::<PCSTR>::into_param(String::from("test")).abi().0,
+                len
+            )
+        );
 
-        assert_eq!(utf16, std::slice::from_raw_parts(IntoParam::<PCWSTR>::into_param("test").abi().0, len));
-        assert_eq!(utf16, std::slice::from_raw_parts(IntoParam::<PCWSTR>::into_param(String::from("test")).abi().0, len));
-        assert_eq!(utf16, std::slice::from_raw_parts(IntoParam::<PCWSTR>::into_param(OsStr::new("test")).abi().0, len));
-        assert_eq!(utf16, std::slice::from_raw_parts(IntoParam::<PCWSTR>::into_param(OsString::from("test")).abi().0, len));
+        assert_eq!(
+            utf16,
+            std::slice::from_raw_parts(IntoParam::<PCWSTR>::into_param("test").abi().0, len)
+        );
+        assert_eq!(
+            utf16,
+            std::slice::from_raw_parts(
+                IntoParam::<PCWSTR>::into_param(String::from("test"))
+                    .abi()
+                    .0,
+                len
+            )
+        );
+        assert_eq!(
+            utf16,
+            std::slice::from_raw_parts(
+                IntoParam::<PCWSTR>::into_param(OsStr::new("test")).abi().0,
+                len
+            )
+        );
+        assert_eq!(
+            utf16,
+            std::slice::from_raw_parts(
+                IntoParam::<PCWSTR>::into_param(OsString::from("test"))
+                    .abi()
+                    .0,
+                len
+            )
+        );
 
         assert_eq!(GetLastError(), ERROR_BUSY_DRIVE);
     }

--- a/crates/tests/sys/tests/simple.rs
+++ b/crates/tests/sys/tests/simple.rs
@@ -1,4 +1,6 @@
-use windows_sys::{core::*, Win32::Foundation::*, Win32::System::Threading::*, Win32::UI::WindowsAndMessaging::*};
+use windows_sys::{
+    core::*, Win32::Foundation::*, Win32::System::Threading::*, Win32::UI::WindowsAndMessaging::*,
+};
 
 #[test]
 fn simple() {

--- a/crates/tests/unions/tests/indirect_argument_desc.rs
+++ b/crates/tests/unions/tests/indirect_argument_desc.rs
@@ -8,7 +8,9 @@ fn test() {
 
     let mut desc = D3D12_INDIRECT_ARGUMENT_DESC {
         Type: D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW,
-        Anonymous: D3D12_INDIRECT_ARGUMENT_DESC_0 { VertexBuffer: D3D12_INDIRECT_ARGUMENT_DESC_0_4 { Slot: 123 } },
+        Anonymous: D3D12_INDIRECT_ARGUMENT_DESC_0 {
+            VertexBuffer: D3D12_INDIRECT_ARGUMENT_DESC_0_4 { Slot: 123 },
+        },
     };
 
     assert_eq!(desc.Type, D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW);

--- a/crates/tests/unions/tests/overlapped.rs
+++ b/crates/tests/unions/tests/overlapped.rs
@@ -5,7 +5,12 @@ use windows::Win32::{
 
 #[test]
 fn test() {
-    let mut o = OVERLAPPED { Internal: 1, InternalHigh: 2, Anonymous: unsafe { std::mem::zeroed() }, hEvent: Default::default() };
+    let mut o = OVERLAPPED {
+        Internal: 1,
+        InternalHigh: 2,
+        Anonymous: unsafe { std::mem::zeroed() },
+        hEvent: Default::default(),
+    };
 
     assert_eq!(o.Internal, 1);
     o.Internal = 10;
@@ -36,7 +41,10 @@ fn test() {
         assert_eq!(o.Anonymous.Anonymous.OffsetHigh, 200);
     }
 
-    o.Anonymous.Anonymous = OVERLAPPED_0_0 { Offset: 10, OffsetHigh: 20 };
+    o.Anonymous.Anonymous = OVERLAPPED_0_0 {
+        Offset: 10,
+        OffsetHigh: 20,
+    };
 
     unsafe {
         assert_eq!(o.Anonymous.Anonymous.Offset, 10);

--- a/crates/tests/vector/tests/test.rs
+++ b/crates/tests/vector/tests/test.rs
@@ -119,7 +119,9 @@ impl<T: ::windows::core::RuntimeType + 'static> IVector_Impl<T> for Vector<T> {
     }
     fn ReplaceAll(&self, items: &[T::DefaultType]) -> Result<()> {
         let mut writer = self.0.write().unwrap();
-        writer.try_reserve(items.len() + 1).map_err(|_| err_memory())?;
+        writer
+            .try_reserve(items.len() + 1)
+            .map_err(|_| err_memory())?;
         for item in items {
             writer.push(item.clone());
         }
@@ -154,7 +156,8 @@ fn GetAt() -> Result<()> {
     assert_eq!(v.GetAt(0)?, 123);
     assert_eq!(v.GetAt(1).unwrap_err().code(), E_BOUNDS);
 
-    let v: IVector<IStringable> = Vector::new(vec![Some(Uri::CreateUri("http://test/")?.cast()?), None]).into();
+    let v: IVector<IStringable> =
+        Vector::new(vec![Some(Uri::CreateUri("http://test/")?.cast()?), None]).into();
     assert_eq!(v.GetAt(0)?.ToString()?, "http://test/");
     assert_eq!(v.GetAt(1).unwrap_err().code(), S_OK);
 
@@ -186,7 +189,10 @@ fn IndexOf() -> Result<()> {
     assert_eq!(index, 0);
     assert_eq!(v.IndexOf(None, &mut index)?, true);
     assert_eq!(index, 1);
-    assert_eq!(v.IndexOf(Uri::CreateUri("http://test/")?, &mut index)?, false);
+    assert_eq!(
+        v.IndexOf(Uri::CreateUri("http://test/")?, &mut index)?,
+        false
+    );
 
     Ok(())
 }
@@ -208,7 +214,10 @@ fn test() -> Result<()> {
     assert!(v.GetAt(20).is_err());
     assert_eq!(3, v.Size()?);
     let c: IInspectable = (&v).into();
-    assert_eq!(c.GetRuntimeClassName()?, "Windows.Foundation.Collections.IVector"); // TODO: needs to have `1<Int32>
+    assert_eq!(
+        c.GetRuntimeClassName()?,
+        "Windows.Foundation.Collections.IVector"
+    ); // TODO: needs to have `1<Int32>
 
     let mut index = 0;
     assert_eq!(true, v.IndexOf(20, &mut index)?);
@@ -230,7 +239,12 @@ fn test() -> Result<()> {
     assert_eq!(2, index);
     assert_eq!(false, v.IndexOf("123", &mut index)?);
 
-    let v: IVectorView<IStringable> = Vector::new(vec![Some(Uri::CreateUri("http://one/")?.try_into().unwrap()), Some(Uri::CreateUri("http://two/")?.try_into().unwrap()), Some(Uri::CreateUri("http://three/")?.try_into().unwrap())]).into();
+    let v: IVectorView<IStringable> = Vector::new(vec![
+        Some(Uri::CreateUri("http://one/")?.try_into().unwrap()),
+        Some(Uri::CreateUri("http://two/")?.try_into().unwrap()),
+        Some(Uri::CreateUri("http://three/")?.try_into().unwrap()),
+    ])
+    .into();
 
     assert_eq!("http://one/", v.GetAt(0)?.ToString()?);
     assert_eq!("http://two/", v.GetAt(1)?.ToString()?);

--- a/crates/tests/weak_ref/tests/race.rs
+++ b/crates/tests/weak_ref/tests/race.rs
@@ -21,7 +21,9 @@ fn test_race() {
     let mut threads = Vec::with_capacity(CONCURRENCY);
     for i in 0..CONCURRENCY {
         let ref_count = ref_count.clone();
-        threads.push(std::thread::spawn(move || run_increment(ref_count, &PROGRESS[i])));
+        threads.push(std::thread::spawn(move || {
+            run_increment(ref_count, &PROGRESS[i])
+        }));
     }
 
     let mut last_progress = [0; CONCURRENCY];
@@ -40,7 +42,13 @@ fn test_race() {
 
         // Normally, the progress for each thread should advance within a long time period, say 1 sec here.
         // Otherwise, it indicates that there is an infinite loop.
-        assert!(!new_progress.iter().zip(last_progress.iter()).any(|(&new, &old)| new == old && new != TARGET), "Progress did not increase during the last second");
+        assert!(
+            !new_progress
+                .iter()
+                .zip(last_progress.iter())
+                .any(|(&new, &old)| new == old && new != TARGET),
+            "Progress did not increase during the last second"
+        );
         last_progress.copy_from_slice(&new_progress[..]);
     }
 

--- a/crates/tests/win32/tests/win32.rs
+++ b/crates/tests/win32/tests/win32.rs
@@ -2,7 +2,11 @@ use windows::{
     core::*,
     Win32::Foundation::{CloseHandle, BOOL, HANDLE, HWND, RECT},
     Win32::Gaming::HasExpandedResources,
-    Win32::Graphics::{Direct2D::CLSID_D2D1Shadow, Direct3D11::D3DDisassemble11Trace, Direct3D12::D3D12_DEFAULT_BLEND_FACTOR_ALPHA, Dxgi::Common::*, Dxgi::*, Hlsl::D3DCOMPILER_DLL},
+    Win32::Graphics::{
+        Direct2D::CLSID_D2D1Shadow, Direct3D11::D3DDisassemble11Trace,
+        Direct3D12::D3D12_DEFAULT_BLEND_FACTOR_ALPHA, Dxgi::Common::*, Dxgi::*,
+        Hlsl::D3DCOMPILER_DLL,
+    },
     Win32::Networking::Ldap::ldapsearch,
     Win32::Security::Authorization::*,
     Win32::System::Com::StructuredStorage::*,
@@ -36,7 +40,12 @@ fn unsigned_enum32() {
 
 #[test]
 fn rect() {
-    let rect = RECT { left: 1, top: 2, right: 3, bottom: 4 };
+    let rect = RECT {
+        left: 1,
+        top: 2,
+        right: 3,
+        bottom: 4,
+    };
 
     assert!(rect.left == 1);
     assert!(rect.top == 2);
@@ -45,7 +54,15 @@ fn rect() {
 
     let clone = rect.clone();
 
-    assert!(clone == RECT { left: 1, top: 2, right: 3, bottom: 4 });
+    assert!(
+        clone
+            == RECT {
+                left: 1,
+                top: 2,
+                right: 3,
+                bottom: 4
+            }
+    );
 }
 
 #[test]
@@ -53,7 +70,10 @@ fn dxgi_mode_desc() {
     let _ = DXGI_MODE_DESC {
         Width: 1,
         Height: 2,
-        RefreshRate: DXGI_RATIONAL { Numerator: 3, Denominator: 5 },
+        RefreshRate: DXGI_RATIONAL {
+            Numerator: 3,
+            Denominator: 5,
+        },
         Format: DXGI_FORMAT_R32_TYPELESS,
         ScanlineOrdering: DXGI_MODE_SCANLINE_ORDER_PROGRESSIVE,
         Scaling: DXGI_MODE_SCALING_CENTERED,
@@ -126,11 +146,23 @@ fn com() -> windows::core::Result<()> {
         let values = vec![1, 20, 300, 4000];
 
         let mut copied = 0;
-        stream.Write(values.as_ptr() as _, (values.len() * core::mem::size_of::<i32>()) as u32, &mut copied).ok()?;
+        stream
+            .Write(
+                values.as_ptr() as _,
+                (values.len() * core::mem::size_of::<i32>()) as u32,
+                &mut copied,
+            )
+            .ok()?;
         assert!(copied == (values.len() * core::mem::size_of::<i32>()) as u32);
 
         let mut copied = 0;
-        stream.Write(&UIAnimationTransitionLibrary as *const _ as _, core::mem::size_of::<windows::core::GUID>() as u32, &mut copied).ok()?;
+        stream
+            .Write(
+                &UIAnimationTransitionLibrary as *const _ as _,
+                core::mem::size_of::<windows::core::GUID>() as u32,
+                &mut copied,
+            )
+            .ok()?;
         assert!(copied == core::mem::size_of::<windows::core::GUID>() as u32);
 
         let position = stream.Seek(0, STREAM_SEEK_SET)?;
@@ -138,13 +170,25 @@ fn com() -> windows::core::Result<()> {
 
         let mut values = vec![0, 0, 0, 0];
         let mut copied = 0;
-        stream.Read(values.as_mut_ptr() as _, (values.len() * core::mem::size_of::<i32>()) as u32, &mut copied).ok()?;
+        stream
+            .Read(
+                values.as_mut_ptr() as _,
+                (values.len() * core::mem::size_of::<i32>()) as u32,
+                &mut copied,
+            )
+            .ok()?;
         assert!(copied == (values.len() * core::mem::size_of::<i32>()) as u32);
         assert!(values == vec![1, 20, 300, 4000]);
 
         let mut value: windows::core::GUID = windows::core::GUID::default();
         let mut copied = 0;
-        stream.Read(&mut value as *mut _ as _, core::mem::size_of::<windows::core::GUID>() as u32, &mut copied).ok()?;
+        stream
+            .Read(
+                &mut value as *mut _ as _,
+                core::mem::size_of::<windows::core::GUID>() as u32,
+                &mut copied,
+            )
+            .ok()?;
         assert!(copied == core::mem::size_of::<windows::core::GUID>() as u32);
         assert!(value == UIAnimationTransitionLibrary);
     }
@@ -170,7 +214,13 @@ fn com_inheritance() {
         assert!(factory.GetCreationFlags() == 0);
 
         // IDXGIFactory7 (default)
-        assert!(factory.RegisterAdaptersChangedEvent(HANDLE(0)).unwrap_err().code() == DXGI_ERROR_INVALID_CALL);
+        assert!(
+            factory
+                .RegisterAdaptersChangedEvent(HANDLE(0))
+                .unwrap_err()
+                .code()
+                == DXGI_ERROR_INVALID_CALL
+        );
     }
 }
 
@@ -180,12 +230,28 @@ fn onecore_imports() -> windows::core::Result<()> {
     unsafe {
         HasExpandedResources()?;
 
-        let uri = CreateUri(PCWSTR(windows::core::HSTRING::from("http://kennykerr.ca").as_wide().as_ptr()), Default::default(), 0)?;
+        let uri = CreateUri(
+            PCWSTR(
+                windows::core::HSTRING::from("http://kennykerr.ca")
+                    .as_wide()
+                    .as_ptr(),
+            ),
+            Default::default(),
+            0,
+        )?;
 
         let port = uri.GetPort()?;
         assert!(port == 80);
 
-        let result = MiniDumpWriteDump(None, 0, None, MiniDumpNormal, core::ptr::null_mut(), core::ptr::null_mut(), core::ptr::null_mut());
+        let result = MiniDumpWriteDump(
+            None,
+            0,
+            None,
+            MiniDumpNormal,
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+        );
         assert!(!result.as_bool());
 
         assert!(D3DDisassemble11Trace(core::ptr::null_mut(), 0, None, 0, 0, 0).is_err());
@@ -212,7 +278,14 @@ fn callback() {
         assert!(BOOL(789) == a.unwrap()(HWND(123), PCSTR("hello a\0".as_ptr()), HANDLE(456)));
 
         let a: PROPENUMPROCW = Some(callback_w);
-        assert!(BOOL(789) == a.unwrap()(HWND(123), PCWSTR(windows::core::HSTRING::from("hello w\0").as_wide().as_ptr()), HANDLE(456)));
+        assert!(
+            BOOL(789)
+                == a.unwrap()(
+                    HWND(123),
+                    PCWSTR(windows::core::HSTRING::from("hello w\0").as_wide().as_ptr()),
+                    HANDLE(456)
+                )
+        );
     }
 }
 
@@ -232,7 +305,8 @@ extern "system" fn callback_a(param0: HWND, param1: PCSTR, param2: HANDLE) -> BO
             end = end.add(1);
         }
 
-        let s = String::from_utf8_lossy(core::slice::from_raw_parts(param1.0 as *const u8, len)).into_owned();
+        let s = String::from_utf8_lossy(core::slice::from_raw_parts(param1.0 as *const u8, len))
+            .into_owned();
         assert!(s == "hello a");
         BOOL(789)
     }

--- a/crates/tests/win32/tests/winsock.rs
+++ b/crates/tests/win32/tests/winsock.rs
@@ -1,7 +1,9 @@
 use windows::Win32::Networking::WinSock::*;
 
 const IPV4_ADDR: std::net::Ipv4Addr = std::net::Ipv4Addr::new(1, 2, 3, 4);
-const IPV6_ADDR: std::net::Ipv6Addr = std::net::Ipv6Addr::new(0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xaabb, 0xccdd, 0xeeff);
+const IPV6_ADDR: std::net::Ipv6Addr = std::net::Ipv6Addr::new(
+    0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xaabb, 0xccdd, 0xeeff,
+);
 const PORT_HOST_BYTE_ORDER: u16 = 0x1234_u16;
 const PORT_NETWORK_BYTE_ORDER: u16 = PORT_HOST_BYTE_ORDER.to_be();
 const FLOWINFO_HOST_BYTE_ORDER: u32 = 0x12345678_u32;
@@ -14,7 +16,10 @@ fn in_addr() {
         unsafe {
             let mut chars = [0; 24];
             inet_ntop(AF_INET.0 as _, in_addr as *const IN_ADDR as _, &mut chars);
-            std::ffi::CStr::from_ptr(chars.as_ptr() as *const _).to_str().unwrap().to_owned()
+            std::ffi::CStr::from_ptr(chars.as_ptr() as *const _)
+                .to_str()
+                .unwrap()
+                .to_owned()
         }
     }
 
@@ -53,12 +58,20 @@ fn sockaddr_in() {
 
     // These fields should be network byte order
     assert_eq!(sockaddr_in.sin_port, PORT_NETWORK_BYTE_ORDER);
-    assert_eq!(unsafe { sockaddr_in.sin_addr.S_un.S_addr }, u32::from(IPV4_ADDR).to_be());
+    assert_eq!(
+        unsafe { sockaddr_in.sin_addr.S_un.S_addr },
+        u32::from(IPV4_ADDR).to_be()
+    );
 }
 
 #[test]
 fn sockaddr_in6() {
-    let socket_addr_v6 = std::net::SocketAddrV6::new(IPV6_ADDR, PORT_HOST_BYTE_ORDER, FLOWINFO_HOST_BYTE_ORDER, SCOPE_ID);
+    let socket_addr_v6 = std::net::SocketAddrV6::new(
+        IPV6_ADDR,
+        PORT_HOST_BYTE_ORDER,
+        FLOWINFO_HOST_BYTE_ORDER,
+        SCOPE_ID,
+    );
     let sockaddr_in6: SOCKADDR_IN6 = socket_addr_v6.into();
 
     // These fields should be host byte order
@@ -67,7 +80,10 @@ fn sockaddr_in6() {
 
     // These fields should be network byte order
     assert_eq!(sockaddr_in6.sin6_flowinfo, FLOWINFO_NETWORK_BYTE_ORDER);
-    assert_eq!(unsafe { sockaddr_in6.sin6_addr.u.Byte }, socket_addr_v6.ip().octets());
+    assert_eq!(
+        unsafe { sockaddr_in6.sin6_addr.u.Byte },
+        socket_addr_v6.ip().octets()
+    );
 
     // This bitfield has no endianness
     assert_eq!(unsafe { sockaddr_in6.Anonymous.sin6_scope_id }, SCOPE_ID);
@@ -83,13 +99,24 @@ fn sockaddr_inet4() {
     assert_eq!(unsafe { sockaddr_inet.Ipv4.sin_family }, AF_INET.0 as u16);
 
     // These fields should be network byte order
-    assert_eq!(unsafe { sockaddr_inet.Ipv4.sin_port }, PORT_NETWORK_BYTE_ORDER);
-    assert_eq!(unsafe { sockaddr_inet.Ipv4.sin_addr.S_un.S_addr }, u32::from(IPV4_ADDR).to_be());
+    assert_eq!(
+        unsafe { sockaddr_inet.Ipv4.sin_port },
+        PORT_NETWORK_BYTE_ORDER
+    );
+    assert_eq!(
+        unsafe { sockaddr_inet.Ipv4.sin_addr.S_un.S_addr },
+        u32::from(IPV4_ADDR).to_be()
+    );
 }
 
 #[test]
 fn sockaddr_inet6() {
-    let socket_addr_v6 = std::net::SocketAddrV6::new(IPV6_ADDR, PORT_HOST_BYTE_ORDER, FLOWINFO_HOST_BYTE_ORDER, SCOPE_ID);
+    let socket_addr_v6 = std::net::SocketAddrV6::new(
+        IPV6_ADDR,
+        PORT_HOST_BYTE_ORDER,
+        FLOWINFO_HOST_BYTE_ORDER,
+        SCOPE_ID,
+    );
     let sockaddr_inet: SOCKADDR_INET = socket_addr_v6.into();
 
     // These fields should be host byte order
@@ -97,10 +124,22 @@ fn sockaddr_inet6() {
     assert_eq!(unsafe { sockaddr_inet.Ipv6.sin6_family }, AF_INET6.0 as u16);
 
     // These fields should be network byte order
-    assert_eq!(unsafe { sockaddr_inet.Ipv6.sin6_port }, PORT_NETWORK_BYTE_ORDER);
-    assert_eq!(unsafe { sockaddr_inet.Ipv6.sin6_flowinfo }, FLOWINFO_NETWORK_BYTE_ORDER);
-    assert_eq!(unsafe { sockaddr_inet.Ipv6.sin6_addr.u.Byte }, socket_addr_v6.ip().octets());
+    assert_eq!(
+        unsafe { sockaddr_inet.Ipv6.sin6_port },
+        PORT_NETWORK_BYTE_ORDER
+    );
+    assert_eq!(
+        unsafe { sockaddr_inet.Ipv6.sin6_flowinfo },
+        FLOWINFO_NETWORK_BYTE_ORDER
+    );
+    assert_eq!(
+        unsafe { sockaddr_inet.Ipv6.sin6_addr.u.Byte },
+        socket_addr_v6.ip().octets()
+    );
 
     // This bitfield has no endianness
-    assert_eq!(unsafe { sockaddr_inet.Ipv6.Anonymous.sin6_scope_id }, SCOPE_ID);
+    assert_eq!(
+        unsafe { sockaddr_inet.Ipv6.Anonymous.sin6_scope_id },
+        SCOPE_ID
+    );
 }

--- a/crates/tests/win32_arrays/tests/fixed.rs
+++ b/crates/tests/win32_arrays/tests/fixed.rs
@@ -1,4 +1,6 @@
-use windows::{Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::UI::Input::KeyboardAndMouse::*};
+use windows::{
+    Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::UI::Input::KeyboardAndMouse::*,
+};
 
 #[test]
 fn keyboard_state() {

--- a/crates/tests/win32_arrays/tests/multi_byte.rs
+++ b/crates/tests/win32_arrays/tests/multi_byte.rs
@@ -10,7 +10,15 @@ fn test() {
 
         let mut c: [u8; 5] = [0xFF; 5];
         // TODO: workaround for https://github.com/microsoft/win32metadata/issues/820
-        let len = WideCharToMultiByte(CP_UTF8, Default::default(), &b, PSTR(c.as_mut_ptr()), c.len() as _, None, std::ptr::null_mut());
+        let len = WideCharToMultiByte(
+            CP_UTF8,
+            Default::default(),
+            &b,
+            PSTR(c.as_mut_ptr()),
+            c.len() as _,
+            None,
+            std::ptr::null_mut(),
+        );
         assert_eq!(len, 5);
 
         assert_eq!(&c, b"hello");

--- a/crates/tests/win32_arrays/tests/shared_size.rs
+++ b/crates/tests/win32_arrays/tests/shared_size.rs
@@ -9,7 +9,18 @@ fn test() -> Result<()> {
         // TODO: workaround for https://github.com/microsoft/win32metadata/issues/817
         assert!(0 != SetICMMode(dc, ICM_ON as _));
 
-        let input = [RGBTRIPLE { rgbtBlue: 1, rgbtGreen: 2, rgbtRed: 3 }, RGBTRIPLE { rgbtBlue: 4, rgbtGreen: 5, rgbtRed: 6 }];
+        let input = [
+            RGBTRIPLE {
+                rgbtBlue: 1,
+                rgbtGreen: 2,
+                rgbtRed: 3,
+            },
+            RGBTRIPLE {
+                rgbtBlue: 4,
+                rgbtGreen: 5,
+                rgbtRed: 6,
+            },
+        ];
 
         assert_eq!(results[0], 255);
         assert_eq!(results[1], 255);

--- a/crates/tests/win32_arrays/tests/xmllite.rs
+++ b/crates/tests/win32_arrays/tests/xmllite.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Win32::Data::Xml::XmlLite::*, Win32::System::Com::StructuredStorage::*, Win32::System::Com::*};
+use windows::{
+    core::*, Win32::Data::Xml::XmlLite::*, Win32::System::Com::StructuredStorage::*,
+    Win32::System::Com::*,
+};
 
 #[test]
 fn test() -> Result<()> {
@@ -12,7 +15,12 @@ fn test() -> Result<()> {
 
         writer.WriteStartDocument(XmlStandalone_Omit)?;
         writer.WriteStartElement(None, "html", None)?;
-        writer.WriteElementString(None, "head", None, "The quick brown fox jumps over the lazy dog")?;
+        writer.WriteElementString(
+            None,
+            "head",
+            None,
+            "The quick brown fox jumps over the lazy dog",
+        )?;
         writer.WriteStartElement(None, "body", None)?;
         writer.WriteChars(&[])?;
         writer.WriteChars(&[0x52, 0x75, 0x73, 0x74])?;
@@ -38,13 +46,19 @@ fn test() -> Result<()> {
         reader.Read(&mut node_type).ok()?;
         assert_eq!(node_type, XmlNodeType_Element);
         reader.GetLocalName(&mut name, &mut name_len)?;
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)), "html");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            "html"
+        );
 
         let mut node_type = XmlNodeType_None;
         reader.Read(&mut node_type).ok()?;
         assert_eq!(node_type, XmlNodeType_Element);
         reader.GetLocalName(&mut name, &mut name_len)?;
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)), "head");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            "head"
+        );
 
         let mut node_type = XmlNodeType_None;
         reader.Read(&mut node_type).ok()?;
@@ -62,7 +76,10 @@ fn test() -> Result<()> {
         }
 
         assert_eq!(read_count, 5);
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(message.as_ptr(), message.len())), "The quick brown fox jumps over the lazy dog");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(message.as_ptr(), message.len())),
+            "The quick brown fox jumps over the lazy dog"
+        );
 
         let mut node_type = XmlNodeType_None;
         reader.Read(&mut node_type).ok()?;
@@ -78,7 +95,10 @@ fn test() -> Result<()> {
 
         reader.ReadValueChunk(&mut chunk, &mut chars_read).ok()?;
         assert_eq!(chars_read, 4);
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(chunk.as_ptr(), chars_read as _)), "Rust");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(chunk.as_ptr(), chars_read as _)),
+            "Rust"
+        );
 
         Ok(())
     }
@@ -96,7 +116,10 @@ fn lite() -> Result<()> {
 
         writer.WriteStartElement(HSTRING::from("html").as_wide())?;
         writer.WriteAttributeString(HSTRING::from("no-value").as_wide(), &[])?;
-        writer.WriteAttributeString(HSTRING::from("with-value").as_wide(), HSTRING::from("value").as_wide())?;
+        writer.WriteAttributeString(
+            HSTRING::from("with-value").as_wide(),
+            HSTRING::from("value").as_wide(),
+        )?;
         writer.WriteEndElement(HSTRING::from("html").as_wide())?;
         writer.Flush()?;
 
@@ -115,24 +138,39 @@ fn lite() -> Result<()> {
         reader.Read(&mut node_type).ok()?;
         assert_eq!(node_type, XmlNodeType_Element);
         reader.GetLocalName(&mut name, &mut name_len)?;
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)), "html");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            "html"
+        );
 
         assert_eq!(reader.GetAttributeCount()?, 2);
         reader.MoveToFirstAttribute().ok()?;
 
         reader.GetLocalName(&mut name, &mut name_len)?;
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)), "no-value");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            "no-value"
+        );
 
         reader.GetValue(&mut name, &mut name_len)?;
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)), "");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            ""
+        );
 
         reader.MoveToNextAttribute().ok()?;
 
         reader.GetLocalName(&mut name, &mut name_len)?;
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)), "with-value");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            "with-value"
+        );
 
         reader.GetValue(&mut name, &mut name_len)?;
-        assert_eq!(String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)), "value");
+        assert_eq!(
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            "value"
+        );
 
         Ok(())
     }

--- a/crates/tests/winrt/tests/boxing.rs
+++ b/crates/tests/winrt/tests/boxing.rs
@@ -96,7 +96,8 @@ fn explicit_boxing() -> windows::core::Result<()> {
     assert!(!array.is_empty());
     assert!(array.len() == 3);
 
-    let object = PropertyValue::CreateStringArray(&["Hello".into(), "Rust".into(), "WinRT".into()])?;
+    let object =
+        PropertyValue::CreateStringArray(&["Hello".into(), "Rust".into(), "WinRT".into()])?;
     let pv: IPropertyValue = object.cast()?;
     let mut array = windows::core::Array::new();
     assert!(array.is_empty());

--- a/crates/tests/winrt/tests/collisions.rs
+++ b/crates/tests/winrt/tests/collisions.rs
@@ -1,6 +1,8 @@
 use windows::{
     ApplicationModel::Email::EmailAttachment,
-    Devices::WiFiDirect::{WiFiDirectConnectionParameters, WiFiDirectDevice, WiFiDirectDeviceSelectorType},
+    Devices::WiFiDirect::{
+        WiFiDirectConnectionParameters, WiFiDirectDevice, WiFiDirectDeviceSelectorType,
+    },
     Storage::Streams::{InMemoryRandomAccessStream, RandomAccessStreamReference},
 };
 

--- a/crates/tests/winrt/tests/composition.rs
+++ b/crates/tests/winrt/tests/composition.rs
@@ -1,13 +1,20 @@
 use windows::{
     System::DispatcherQueueController,
-    Win32::System::WinRT::{CreateDispatcherQueueController, DispatcherQueueOptions, DQTAT_COM_NONE, DQTYPE_THREAD_CURRENT},
+    Win32::System::WinRT::{
+        CreateDispatcherQueueController, DispatcherQueueOptions, DQTAT_COM_NONE,
+        DQTYPE_THREAD_CURRENT,
+    },
 };
 
 fn create_dispatcher() -> DispatcherQueueController {
     // We need a DispatcherQueue on our thread to properly create a Compositor. Note that since
     // we aren't pumping messages, the Compositor won't commit. This is fine for the test for now.
 
-    let options = DispatcherQueueOptions { dwSize: core::mem::size_of::<DispatcherQueueOptions>() as u32, threadType: DQTYPE_THREAD_CURRENT, apartmentType: DQTAT_COM_NONE };
+    let options = DispatcherQueueOptions {
+        dwSize: core::mem::size_of::<DispatcherQueueOptions>() as u32,
+        threadType: DQTYPE_THREAD_CURRENT,
+        apartmentType: DQTAT_COM_NONE,
+    };
 
     unsafe { CreateDispatcherQueueController(options).unwrap() }
 }
@@ -64,7 +71,14 @@ fn composition() -> windows::core::Result<()> {
     let visual = compositor.CreateSpriteVisual()?;
     let red = Colors::Red()?;
 
-    assert!(red == Color { A: 255, R: 255, G: 0, B: 0 });
+    assert!(
+        red == Color {
+            A: 255,
+            R: 255,
+            G: 0,
+            B: 0
+        }
+    );
 
     // Visual.set_brush expects a CompositionBrush but CreateColorBrushWithColor returns a
     // CompositionColorBrush that logically derives from CompositionBrush.
@@ -76,22 +90,45 @@ fn composition() -> windows::core::Result<()> {
     let brush: CompositionColorBrush = visual.Brush()?.cast()?;
     assert!(brush.Color()? == red);
 
-    visual.SetOffset(Vector3 { X: 1.0, Y: 2.0, Z: 3.0 })?;
+    visual.SetOffset(Vector3 {
+        X: 1.0,
+        Y: 2.0,
+        Z: 3.0,
+    })?;
 
-    assert!(visual.Offset()? == Vector3 { X: 1.0, Y: 2.0, Z: 3.0 });
+    assert!(
+        visual.Offset()?
+            == Vector3 {
+                X: 1.0,
+                Y: 2.0,
+                Z: 3.0
+            }
+    );
 
     let children = visual.Children()?;
 
     let child = compositor.CreateSpriteVisual()?;
-    child.SetOffset(Vector3 { X: 1.0, Y: 0.0, Z: 0.0 })?;
+    child.SetOffset(Vector3 {
+        X: 1.0,
+        Y: 0.0,
+        Z: 0.0,
+    })?;
     children.InsertAtBottom(child)?;
 
     let child = compositor.CreateSpriteVisual()?;
-    child.SetOffset(Vector3 { X: 2.0, Y: 0.0, Z: 0.0 })?;
+    child.SetOffset(Vector3 {
+        X: 2.0,
+        Y: 0.0,
+        Z: 0.0,
+    })?;
     children.InsertAtBottom(child)?;
 
     let child = compositor.CreateSpriteVisual()?;
-    child.SetOffset(Vector3 { X: 3.0, Y: 0.0, Z: 0.0 })?;
+    child.SetOffset(Vector3 {
+        X: 3.0,
+        Y: 0.0,
+        Z: 0.0,
+    })?;
     children.InsertAtBottom(child)?;
 
     assert!(children.Count()? == 3);
@@ -99,17 +136,38 @@ fn composition() -> windows::core::Result<()> {
     let iterator = children.First()?;
     assert!(iterator.HasCurrent()?);
 
-    assert!(iterator.Current()?.Offset()? == Vector3 { X: 3.0, Y: 0.0, Z: 0.0 });
+    assert!(
+        iterator.Current()?.Offset()?
+            == Vector3 {
+                X: 3.0,
+                Y: 0.0,
+                Z: 0.0
+            }
+    );
 
     assert!(iterator.MoveNext()?);
     assert!(iterator.HasCurrent()?);
 
-    assert!(iterator.Current()?.Offset()? == Vector3 { X: 2.0, Y: 0.0, Z: 0.0 });
+    assert!(
+        iterator.Current()?.Offset()?
+            == Vector3 {
+                X: 2.0,
+                Y: 0.0,
+                Z: 0.0
+            }
+    );
 
     assert!(iterator.MoveNext()?);
     assert!(iterator.HasCurrent()?);
 
-    assert!(iterator.Current()?.Offset()? == Vector3 { X: 1.0, Y: 0.0, Z: 0.0 });
+    assert!(
+        iterator.Current()?.Offset()?
+            == Vector3 {
+                X: 1.0,
+                Y: 0.0,
+                Z: 0.0
+            }
+    );
 
     assert!(!(iterator.MoveNext()?));
     assert!(!(iterator.HasCurrent()?));

--- a/crates/tests/winrt/tests/delegates.rs
+++ b/crates/tests/winrt/tests/delegates.rs
@@ -1,7 +1,9 @@
 use core::convert::*;
 
 use windows::{
-    Foundation::Collections::{CollectionChange, IObservableMap, MapChangedEventHandler, PropertySet},
+    Foundation::Collections::{
+        CollectionChange, IObservableMap, MapChangedEventHandler, PropertySet,
+    },
     Foundation::{AsyncActionCompletedHandler, AsyncStatus, TypedEventHandler, Uri},
 };
 
@@ -11,7 +13,10 @@ use windows::core::Interface;
 fn non_generic() -> windows::core::Result<()> {
     type Handler = AsyncActionCompletedHandler;
 
-    assert_eq!(Handler::IID, windows::core::GUID::from("A4ED5C81-76C9-40BD-8BE6-B1D90FB20AE7"));
+    assert_eq!(
+        Handler::IID,
+        windows::core::GUID::from("A4ED5C81-76C9-40BD-8BE6-B1D90FB20AE7")
+    );
 
     let (tx, rx) = std::sync::mpsc::channel();
 
@@ -35,7 +40,10 @@ fn non_generic() -> windows::core::Result<()> {
 fn generic() -> windows::core::Result<()> {
     type Handler = TypedEventHandler<Uri, i32>;
 
-    assert_eq!(Handler::IID, windows::core::GUID::from("DAE18EA9-FCF3-5ACF-BCDD-8C354CBA6D23"));
+    assert_eq!(
+        Handler::IID,
+        windows::core::GUID::from("DAE18EA9-FCF3-5ACF-BCDD-8C354CBA6D23")
+    );
 
     let uri = Uri::CreateUri("http://kennykerr.ca")?;
     let (tx, rx) = std::sync::mpsc::channel();
@@ -64,11 +72,15 @@ fn event() -> windows::core::Result<()> {
     let set_clone = set.clone();
     // TODO: Should be able to elide the delegate construction and simply say:
     // set.MapChanged(|sender, args| {...})?;
-    set.MapChanged(MapChangedEventHandler::<windows::core::HSTRING, windows::core::IInspectable>::new(move |_, args| {
+    set.MapChanged(MapChangedEventHandler::<
+        windows::core::HSTRING,
+        windows::core::IInspectable,
+    >::new(move |_, args| {
         let args = args.as_ref().unwrap();
         tx.send(true).unwrap();
         let set = set_clone.clone();
-        let _: IObservableMap<windows::core::HSTRING, windows::core::IInspectable> = set.try_into().unwrap();
+        let _: IObservableMap<windows::core::HSTRING, windows::core::IInspectable> =
+            set.try_into().unwrap();
         assert!(args.Key()? == "A");
         assert!(args.CollectionChange()? == CollectionChange::ItemInserted);
         Ok(())

--- a/crates/tests/winrt/tests/enum.rs
+++ b/crates/tests/winrt/tests/enum.rs
@@ -29,9 +29,15 @@ fn unsigned_enum() {
     days |= AppointmentDaysOfWeek::Tuesday;
     days |= AppointmentDaysOfWeek::Wednesday;
 
-    assert!(days == AppointmentDaysOfWeek::Monday | AppointmentDaysOfWeek::Tuesday | AppointmentDaysOfWeek::Wednesday);
+    assert!(
+        days == AppointmentDaysOfWeek::Monday
+            | AppointmentDaysOfWeek::Tuesday
+            | AppointmentDaysOfWeek::Wednesday
+    );
 
-    days &= AppointmentDaysOfWeek::Monday | AppointmentDaysOfWeek::Wednesday | AppointmentDaysOfWeek::Friday;
+    days &= AppointmentDaysOfWeek::Monday
+        | AppointmentDaysOfWeek::Wednesday
+        | AppointmentDaysOfWeek::Friday;
 
     assert!(days == AppointmentDaysOfWeek::Monday | AppointmentDaysOfWeek::Wednesday);
     days &= AppointmentDaysOfWeek::Wednesday;

--- a/crates/tests/winrt/tests/error.rs
+++ b/crates/tests/winrt/tests/error.rs
@@ -14,7 +14,8 @@ fn from_hresult() {
 
 #[test]
 fn originate() {
-    let error = windows::core::Error::new(windows::core::HRESULT(-2147467260), "test originate".into());
+    let error =
+        windows::core::Error::new(windows::core::HRESULT(-2147467260), "test originate".into());
 
     assert_eq!(error.code(), windows::core::HRESULT(-2147467260));
     assert_eq!(error.message(), "test originate");
@@ -41,7 +42,10 @@ fn bad_uri() {
 #[test]
 fn convertible() {
     fn windows_error() -> windows::core::Result<()> {
-        Err(windows::core::Error::new(E_NOINTERFACE, "test message".into()))
+        Err(windows::core::Error::new(
+            E_NOINTERFACE,
+            "test message".into(),
+        ))
     }
 
     fn convertible_error() -> core::result::Result<(), Box<dyn std::error::Error>> {
@@ -52,5 +56,8 @@ fn convertible() {
     let result = convertible_error();
     let format = format!("{:?}", result);
 
-    assert_eq!(format, "Err(Error { code: 0x80004002, message: test message })");
+    assert_eq!(
+        format,
+        "Err(Error { code: 0x80004002, message: test message })"
+    );
 }

--- a/crates/tests/winrt/tests/generic_guids.rs
+++ b/crates/tests/winrt/tests/generic_guids.rs
@@ -10,87 +10,198 @@ fn generic_guids() -> windows::core::Result<()> {
     //
     // Generated Windows.Foundation GUIDs
     //
-    assert_eq!(IAsyncActionWithProgress::<A>::IID, windows::core::GUID::from("DD725452-2DA3-5103-9C7D-22EE9BB14AD3"));
+    assert_eq!(
+        IAsyncActionWithProgress::<A>::IID,
+        windows::core::GUID::from("DD725452-2DA3-5103-9C7D-22EE9BB14AD3")
+    );
 
-    assert_eq!(IAsyncOperationWithProgress::<A, B>::IID, windows::core::GUID::from("94645425-B9E5-5B91-B509-8DA4DF6A8916"));
+    assert_eq!(
+        IAsyncOperationWithProgress::<A, B>::IID,
+        windows::core::GUID::from("94645425-B9E5-5B91-B509-8DA4DF6A8916")
+    );
 
-    assert_eq!(IAsyncOperation::<A>::IID, windows::core::GUID::from("2BD35EE6-72D9-5C5D-9827-05EBB81487AB"));
+    assert_eq!(
+        IAsyncOperation::<A>::IID,
+        windows::core::GUID::from("2BD35EE6-72D9-5C5D-9827-05EBB81487AB")
+    );
 
-    assert_eq!(IReferenceArray::<A>::IID, windows::core::GUID::from("4A33FE03-E8B9-5346-A124-5449913ECA57"));
+    assert_eq!(
+        IReferenceArray::<A>::IID,
+        windows::core::GUID::from("4A33FE03-E8B9-5346-A124-5449913ECA57")
+    );
 
-    assert_eq!(IReference::<A>::IID, windows::core::GUID::from("F9E4006C-6E8C-56DF-811C-61F9990EBFB0"));
+    assert_eq!(
+        IReference::<A>::IID,
+        windows::core::GUID::from("F9E4006C-6E8C-56DF-811C-61F9990EBFB0")
+    );
 
-    assert_eq!(AsyncActionProgressHandler::<A>::IID, windows::core::GUID::from("C261D8D0-71BA-5F38-A239-872342253A18"));
+    assert_eq!(
+        AsyncActionProgressHandler::<A>::IID,
+        windows::core::GUID::from("C261D8D0-71BA-5F38-A239-872342253A18")
+    );
 
-    assert_eq!(AsyncActionWithProgressCompletedHandler::<A>::IID, windows::core::GUID::from("9A0D211C-0374-5D23-9E15-EAA3570FAE63"));
+    assert_eq!(
+        AsyncActionWithProgressCompletedHandler::<A>::IID,
+        windows::core::GUID::from("9A0D211C-0374-5D23-9E15-EAA3570FAE63")
+    );
 
-    assert_eq!(AsyncOperationCompletedHandler::<A>::IID, windows::core::GUID::from("9D534225-231F-55E7-A6D0-6C938E2D9160"));
+    assert_eq!(
+        AsyncOperationCompletedHandler::<A>::IID,
+        windows::core::GUID::from("9D534225-231F-55E7-A6D0-6C938E2D9160")
+    );
 
-    assert_eq!(AsyncOperationProgressHandler::<A, B>::IID, windows::core::GUID::from("264F1E0C-ABE4-590B-9D37-E1CC118ECC75"));
+    assert_eq!(
+        AsyncOperationProgressHandler::<A, B>::IID,
+        windows::core::GUID::from("264F1E0C-ABE4-590B-9D37-E1CC118ECC75")
+    );
 
-    assert_eq!(AsyncOperationWithProgressCompletedHandler::<A, B>::IID, windows::core::GUID::from("C2D078D8-AC47-55AB-83E8-123B2BE5BC5A"));
+    assert_eq!(
+        AsyncOperationWithProgressCompletedHandler::<A, B>::IID,
+        windows::core::GUID::from("C2D078D8-AC47-55AB-83E8-123B2BE5BC5A")
+    );
 
-    assert_eq!(EventHandler::<A>::IID, windows::core::GUID::from("FA0B7D80-7EFA-52DF-9B69-0574CE57ADA4"));
+    assert_eq!(
+        EventHandler::<A>::IID,
+        windows::core::GUID::from("FA0B7D80-7EFA-52DF-9B69-0574CE57ADA4")
+    );
 
-    assert_eq!(TypedEventHandler::<A, B>::IID, windows::core::GUID::from("EDB31843-B4CF-56EB-925A-D4D0CE97A08D"));
+    assert_eq!(
+        TypedEventHandler::<A, B>::IID,
+        windows::core::GUID::from("EDB31843-B4CF-56EB-925A-D4D0CE97A08D")
+    );
 
     //
     // Generated Windows.Foundation.Collections GUIDs
     //
 
-    assert_eq!(IIterable::<A>::IID, windows::core::GUID::from("96565EB9-A692-59C8-BCB5-647CDE4E6C4D"));
+    assert_eq!(
+        IIterable::<A>::IID,
+        windows::core::GUID::from("96565EB9-A692-59C8-BCB5-647CDE4E6C4D")
+    );
 
-    assert_eq!(IIterator::<A>::IID, windows::core::GUID::from("3C9B1E27-8357-590B-8828-6E917F172390"));
+    assert_eq!(
+        IIterator::<A>::IID,
+        windows::core::GUID::from("3C9B1E27-8357-590B-8828-6E917F172390")
+    );
 
-    assert_eq!(IKeyValuePair::<A, B>::IID, windows::core::GUID::from("89336CD9-8B66-50A7-9759-EB88CCB2E1FE"));
+    assert_eq!(
+        IKeyValuePair::<A, B>::IID,
+        windows::core::GUID::from("89336CD9-8B66-50A7-9759-EB88CCB2E1FE")
+    );
 
-    assert_eq!(IMapChangedEventArgs::<A>::IID, windows::core::GUID::from("E1AA5138-12BD-51A1-8558-698DFD070ABE"));
+    assert_eq!(
+        IMapChangedEventArgs::<A>::IID,
+        windows::core::GUID::from("E1AA5138-12BD-51A1-8558-698DFD070ABE")
+    );
 
-    assert_eq!(IMapView::<A, B>::IID, windows::core::GUID::from("B78F0653-FA89-59CF-BA95-726938AAE666"));
+    assert_eq!(
+        IMapView::<A, B>::IID,
+        windows::core::GUID::from("B78F0653-FA89-59CF-BA95-726938AAE666")
+    );
 
-    assert_eq!(IMap::<A, B>::IID, windows::core::GUID::from("9962CD50-09D5-5C46-B1E1-3C679C1C8FAE"));
+    assert_eq!(
+        IMap::<A, B>::IID,
+        windows::core::GUID::from("9962CD50-09D5-5C46-B1E1-3C679C1C8FAE")
+    );
 
-    assert_eq!(IObservableMap::<A, B>::IID, windows::core::GUID::from("75F99E2A-137E-537E-A5B1-0B5A6245FC02"));
+    assert_eq!(
+        IObservableMap::<A, B>::IID,
+        windows::core::GUID::from("75F99E2A-137E-537E-A5B1-0B5A6245FC02")
+    );
 
-    assert_eq!(IObservableVector::<A>::IID, windows::core::GUID::from("D24C289F-2341-5128-AAA1-292DD0DC1950"));
+    assert_eq!(
+        IObservableVector::<A>::IID,
+        windows::core::GUID::from("D24C289F-2341-5128-AAA1-292DD0DC1950")
+    );
 
-    assert_eq!(IVectorView::<A>::IID, windows::core::GUID::from("5F07498B-8E14-556E-9D2E-2E98D5615DA9"));
+    assert_eq!(
+        IVectorView::<A>::IID,
+        windows::core::GUID::from("5F07498B-8E14-556E-9D2E-2E98D5615DA9")
+    );
 
-    assert_eq!(IVector::<A>::IID, windows::core::GUID::from("0E3F106F-A266-50A1-8043-C90FCF3844F6"));
+    assert_eq!(
+        IVector::<A>::IID,
+        windows::core::GUID::from("0E3F106F-A266-50A1-8043-C90FCF3844F6")
+    );
 
-    assert_eq!(MapChangedEventHandler::<A, B>::IID, windows::core::GUID::from("19046F0B-CF81-5DEC-BBB2-7CC250DA8B8B"));
+    assert_eq!(
+        MapChangedEventHandler::<A, B>::IID,
+        windows::core::GUID::from("19046F0B-CF81-5DEC-BBB2-7CC250DA8B8B")
+    );
 
-    assert_eq!(VectorChangedEventHandler::<A>::IID, windows::core::GUID::from("A1E9ACD7-E4DF-5A79-AEFA-DE07934AB0FB"));
+    assert_eq!(
+        VectorChangedEventHandler::<A>::IID,
+        windows::core::GUID::from("A1E9ACD7-E4DF-5A79-AEFA-DE07934AB0FB")
+    );
 
     //
     // Generated primitive GUIDs
     //
 
-    assert_eq!(IReference::<bool>::IID, windows::core::GUID::from("3C00FD60-2950-5939-A21A-2D12C5A01B8A"));
+    assert_eq!(
+        IReference::<bool>::IID,
+        windows::core::GUID::from("3C00FD60-2950-5939-A21A-2D12C5A01B8A")
+    );
 
-    assert_eq!(IReference::<i8>::IID, windows::core::GUID::from("95500129-FBF6-5AFC-89DF-70642D741990"));
+    assert_eq!(
+        IReference::<i8>::IID,
+        windows::core::GUID::from("95500129-FBF6-5AFC-89DF-70642D741990")
+    );
 
-    assert_eq!(IReference::<i16>::IID, windows::core::GUID::from("6EC9E41B-6709-5647-9918-A1270110FC4E"));
+    assert_eq!(
+        IReference::<i16>::IID,
+        windows::core::GUID::from("6EC9E41B-6709-5647-9918-A1270110FC4E")
+    );
 
-    assert_eq!(IReference::<i32>::IID, windows::core::GUID::from("548CEFBD-BC8A-5FA0-8DF2-957440FC8BF4"));
+    assert_eq!(
+        IReference::<i32>::IID,
+        windows::core::GUID::from("548CEFBD-BC8A-5FA0-8DF2-957440FC8BF4")
+    );
 
-    assert_eq!(IReference::<i64>::IID, windows::core::GUID::from("4DDA9E24-E69F-5C6A-A0A6-93427365AF2A"));
+    assert_eq!(
+        IReference::<i64>::IID,
+        windows::core::GUID::from("4DDA9E24-E69F-5C6A-A0A6-93427365AF2A")
+    );
 
-    assert_eq!(IReference::<u8>::IID, windows::core::GUID::from("e5198cc8-2873-55f5-b0a1-84ff9e4aad62"));
+    assert_eq!(
+        IReference::<u8>::IID,
+        windows::core::GUID::from("e5198cc8-2873-55f5-b0a1-84ff9e4aad62")
+    );
 
-    assert_eq!(IReference::<u16>::IID, windows::core::GUID::from("5AB7D2C3-6B62-5E71-A4B6-2D49C4F238FD"));
+    assert_eq!(
+        IReference::<u16>::IID,
+        windows::core::GUID::from("5AB7D2C3-6B62-5E71-A4B6-2D49C4F238FD")
+    );
 
-    assert_eq!(IReference::<u32>::IID, windows::core::GUID::from("513ef3af-e784-5325-a91e-97c2b8111cf3"));
+    assert_eq!(
+        IReference::<u32>::IID,
+        windows::core::GUID::from("513ef3af-e784-5325-a91e-97c2b8111cf3")
+    );
 
-    assert_eq!(IReference::<u64>::IID, windows::core::GUID::from("6755e376-53bb-568b-a11d-17239868309e"));
+    assert_eq!(
+        IReference::<u64>::IID,
+        windows::core::GUID::from("6755e376-53bb-568b-a11d-17239868309e")
+    );
 
-    assert_eq!(IReference::<f32>::IID, windows::core::GUID::from("719CC2BA-3E76-5DEF-9F1A-38D85A145EA8"));
+    assert_eq!(
+        IReference::<f32>::IID,
+        windows::core::GUID::from("719CC2BA-3E76-5DEF-9F1A-38D85A145EA8")
+    );
 
-    assert_eq!(IReference::<f64>::IID, windows::core::GUID::from("2F2D6C29-5473-5F3E-92E7-96572BB990E2"));
+    assert_eq!(
+        IReference::<f64>::IID,
+        windows::core::GUID::from("2F2D6C29-5473-5F3E-92E7-96572BB990E2")
+    );
 
-    assert_eq!(IReference::<windows::core::GUID>::IID, windows::core::GUID::from("7D50F649-632C-51F9-849A-EE49428933EA"));
+    assert_eq!(
+        IReference::<windows::core::GUID>::IID,
+        windows::core::GUID::from("7D50F649-632C-51F9-849A-EE49428933EA")
+    );
 
-    assert_eq!(IReference::<windows::core::HSTRING>::IID, windows::core::GUID::from("FD416DFB-2A07-52EB-AAE3-DFCE14116C05"));
+    assert_eq!(
+        IReference::<windows::core::HSTRING>::IID,
+        windows::core::GUID::from("FD416DFB-2A07-52EB-AAE3-DFCE14116C05")
+    );
 
     // TODO: structs and enums
 

--- a/crates/tests/winrt/tests/guid.rs
+++ b/crates/tests/winrt/tests/guid.rs
@@ -16,7 +16,12 @@ fn guid_helper() -> windows::core::Result<()> {
 fn guid_from_string() {
     let a = GUID::from("CFF52E04-CCA6-4614-A17E-754910C84A99");
 
-    let b = GUID::from_values(0xCFF52E04, 0xCCA6, 0x4614, [0xA1, 0x7E, 0x75, 0x49, 0x10, 0xC8, 0x4A, 0x99]);
+    let b = GUID::from_values(
+        0xCFF52E04,
+        0xCCA6,
+        0x4614,
+        [0xA1, 0x7E, 0x75, 0x49, 0x10, 0xC8, 0x4A, 0x99],
+    );
 
     assert!(a == b);
 }

--- a/crates/tests/winrt/tests/implement.rs
+++ b/crates/tests/winrt/tests/implement.rs
@@ -6,7 +6,10 @@ use windows::{core::*, Foundation::*};
 fn implement() -> Result<()> {
     let (sender, receiver) = std::sync::mpsc::channel();
     {
-        let t = Thing { value: "hello".to_string(), sender };
+        let t = Thing {
+            value: "hello".to_string(),
+            sender,
+        };
 
         let s: IStringable = t.into();
         assert_eq!(s.ToString()?, "hello");
@@ -19,7 +22,10 @@ fn implement() -> Result<()> {
 
     let (sender, receiver) = std::sync::mpsc::channel();
     {
-        let t = Thing { value: "world".to_string(), sender };
+        let t = Thing {
+            value: "world".to_string(),
+            sender,
+        };
 
         let c: IClosable = t.into();
         c.Close()?;
@@ -32,7 +38,10 @@ fn implement() -> Result<()> {
 
     let (sender, receiver) = std::sync::mpsc::channel();
     {
-        let t = Thing { value: "object".to_string(), sender };
+        let t = Thing {
+            value: "object".to_string(),
+            sender,
+        };
 
         let s: IStringable = t.into();
         assert!(s.ToString()? == "object");

--- a/crates/tests/winrt/tests/implement_escape.rs
+++ b/crates/tests/winrt/tests/implement_escape.rs
@@ -12,11 +12,18 @@ impl UI::Xaml::Data::ICustomPropertyProvider_Impl for BookShu {
         panic!();
     }
 
-    fn GetCustomProperty(&self, _name: &::windows::core::HSTRING) -> ::windows::core::Result<UI::Xaml::Data::ICustomProperty> {
+    fn GetCustomProperty(
+        &self,
+        _name: &::windows::core::HSTRING,
+    ) -> ::windows::core::Result<UI::Xaml::Data::ICustomProperty> {
         panic!();
     }
 
-    fn GetIndexedProperty(&self, _name: &::windows::core::HSTRING, _type: &UI::Xaml::Interop::TypeName) -> ::windows::core::Result<UI::Xaml::Data::ICustomProperty> {
+    fn GetIndexedProperty(
+        &self,
+        _name: &::windows::core::HSTRING,
+        _type: &UI::Xaml::Interop::TypeName,
+    ) -> ::windows::core::Result<UI::Xaml::Data::ICustomProperty> {
         panic!();
     }
 

--- a/crates/tests/winrt/tests/interface.rs
+++ b/crates/tests/winrt/tests/interface.rs
@@ -3,7 +3,10 @@ use windows::Foundation::IStringable;
 
 #[test]
 fn interface() -> windows::core::Result<()> {
-    assert_eq!(IStringable::IID, windows::core::GUID::from("96369F54-8EB6-48F0-ABCE-C1B211E627C3"));
+    assert_eq!(
+        IStringable::IID,
+        windows::core::GUID::from("96369F54-8EB6-48F0-ABCE-C1B211E627C3")
+    );
 
     // TODO: Find an example where the default constructor is not exclusive.
     Ok(())

--- a/crates/tests/winrt/tests/numerics.rs
+++ b/crates/tests/winrt/tests/numerics.rs
@@ -74,124 +74,320 @@ fn vector2_mul() {
 
 #[test]
 fn vector3_add() {
-    let value1 = Vector3 { X: 5.0, Y: 50.0, Z: 18.0 };
-    let value2 = Vector3 { X: 15.0, Y: 25.0, Z: 3.0 };
-    let expected = Vector3 { X: 20.0, Y: 75.0, Z: 21.0 };
+    let value1 = Vector3 {
+        X: 5.0,
+        Y: 50.0,
+        Z: 18.0,
+    };
+    let value2 = Vector3 {
+        X: 15.0,
+        Y: 25.0,
+        Z: 3.0,
+    };
+    let expected = Vector3 {
+        X: 20.0,
+        Y: 75.0,
+        Z: 21.0,
+    };
 
     test_with_same_type!(value1, value2, +, expected);
 }
 
 #[test]
 fn vector3_sub() {
-    let value1 = Vector3 { X: 5.0, Y: 50.0, Z: 18.0 };
-    let value2 = Vector3 { X: 15.0, Y: 20.0, Z: 3.0 };
-    let expected = Vector3 { X: -10.0, Y: 30.0, Z: 15.0 };
+    let value1 = Vector3 {
+        X: 5.0,
+        Y: 50.0,
+        Z: 18.0,
+    };
+    let value2 = Vector3 {
+        X: 15.0,
+        Y: 20.0,
+        Z: 3.0,
+    };
+    let expected = Vector3 {
+        X: -10.0,
+        Y: 30.0,
+        Z: 15.0,
+    };
 
     test_with_same_type!(value1, value2, -, expected);
 }
 
 #[test]
 fn vector3_div() {
-    let value1 = Vector3 { X: 10.0, Y: 50.0, Z: 100.0 };
-    let value2 = Vector3 { X: 20.0, Y: 25.0, Z: 100.0 };
-    let expected = Vector3 { X: 0.5, Y: 2.0, Z: 1.0 };
+    let value1 = Vector3 {
+        X: 10.0,
+        Y: 50.0,
+        Z: 100.0,
+    };
+    let value2 = Vector3 {
+        X: 20.0,
+        Y: 25.0,
+        Z: 100.0,
+    };
+    let expected = Vector3 {
+        X: 0.5,
+        Y: 2.0,
+        Z: 1.0,
+    };
 
     test_with_same_type!(value1, value2, /, expected);
 
     let value2 = 2.0;
-    let expected = Vector3 { X: 5.0, Y: 25.0, Z: 50.0 };
+    let expected = Vector3 {
+        X: 5.0,
+        Y: 25.0,
+        Z: 50.0,
+    };
 
     test_with_scalar!(value1, value2, /, expected);
 }
 
 #[test]
 fn vector3_mul() {
-    let value1 = Vector3 { X: 5.0, Y: 50.0, Z: 18.0 };
-    let value2 = Vector3 { X: 15.0, Y: 25.0, Z: 3.0 };
-    let expected = Vector3 { X: 75.0, Y: 1250.0, Z: 54.0 };
+    let value1 = Vector3 {
+        X: 5.0,
+        Y: 50.0,
+        Z: 18.0,
+    };
+    let value2 = Vector3 {
+        X: 15.0,
+        Y: 25.0,
+        Z: 3.0,
+    };
+    let expected = Vector3 {
+        X: 75.0,
+        Y: 1250.0,
+        Z: 54.0,
+    };
 
     test_with_same_type!(value1, value2, *, expected);
 
     let value2 = 2.5;
-    let expected = Vector3 { X: 12.5, Y: 125.0, Z: 45.0 };
+    let expected = Vector3 {
+        X: 12.5,
+        Y: 125.0,
+        Z: 45.0,
+    };
 
     test_with_scalar!(value1, value2, *, expected);
 }
 
 #[test]
 fn vector4_add() {
-    let value1 = Vector4 { X: 5.0, Y: 50.0, Z: 18.0, W: 63.0 };
-    let value2 = Vector4 { X: 15.0, Y: 25.0, Z: 3.0, W: 7.0 };
-    let expected = Vector4 { X: 20.0, Y: 75.0, Z: 21.0, W: 70.0 };
+    let value1 = Vector4 {
+        X: 5.0,
+        Y: 50.0,
+        Z: 18.0,
+        W: 63.0,
+    };
+    let value2 = Vector4 {
+        X: 15.0,
+        Y: 25.0,
+        Z: 3.0,
+        W: 7.0,
+    };
+    let expected = Vector4 {
+        X: 20.0,
+        Y: 75.0,
+        Z: 21.0,
+        W: 70.0,
+    };
 
     test_with_same_type!(value1, value2, +, expected);
 }
 
 #[test]
 fn vector4_sub() {
-    let value1 = Vector4 { X: 5.0, Y: 50.0, Z: 18.0, W: 63.0 };
-    let value2 = Vector4 { X: 15.0, Y: 20.0, Z: 3.0, W: 7.0 };
-    let expected = Vector4 { X: -10.0, Y: 30.0, Z: 15.0, W: 56.0 };
+    let value1 = Vector4 {
+        X: 5.0,
+        Y: 50.0,
+        Z: 18.0,
+        W: 63.0,
+    };
+    let value2 = Vector4 {
+        X: 15.0,
+        Y: 20.0,
+        Z: 3.0,
+        W: 7.0,
+    };
+    let expected = Vector4 {
+        X: -10.0,
+        Y: 30.0,
+        Z: 15.0,
+        W: 56.0,
+    };
 
     test_with_same_type!(value1, value2, -, expected);
 }
 
 #[test]
 fn vector4_div() {
-    let value1 = Vector4 { X: 10.0, Y: 50.0, Z: 100.0, W: 1.0 };
-    let value2 = Vector4 { X: 20.0, Y: 25.0, Z: 100.0, W: 10.0 };
-    let expected = Vector4 { X: 0.5, Y: 2.0, Z: 1.0, W: 0.1 };
+    let value1 = Vector4 {
+        X: 10.0,
+        Y: 50.0,
+        Z: 100.0,
+        W: 1.0,
+    };
+    let value2 = Vector4 {
+        X: 20.0,
+        Y: 25.0,
+        Z: 100.0,
+        W: 10.0,
+    };
+    let expected = Vector4 {
+        X: 0.5,
+        Y: 2.0,
+        Z: 1.0,
+        W: 0.1,
+    };
 
     test_with_same_type!(value1, value2, /, expected);
 
     let value2 = 2.0;
-    let expected = Vector4 { X: 5.0, Y: 25.0, Z: 50.0, W: 0.5 };
+    let expected = Vector4 {
+        X: 5.0,
+        Y: 25.0,
+        Z: 50.0,
+        W: 0.5,
+    };
 
     test_with_scalar!(value1, value2, /, expected);
 }
 
 #[test]
 fn vector4_mul() {
-    let value1 = Vector4 { X: 5.0, Y: 50.0, Z: 18.0, W: 2.5 };
-    let value2 = Vector4 { X: 15.0, Y: 25.0, Z: 3.0, W: 10.0 };
-    let expected = Vector4 { X: 75.0, Y: 1250.0, Z: 54.0, W: 25.0 };
+    let value1 = Vector4 {
+        X: 5.0,
+        Y: 50.0,
+        Z: 18.0,
+        W: 2.5,
+    };
+    let value2 = Vector4 {
+        X: 15.0,
+        Y: 25.0,
+        Z: 3.0,
+        W: 10.0,
+    };
+    let expected = Vector4 {
+        X: 75.0,
+        Y: 1250.0,
+        Z: 54.0,
+        W: 25.0,
+    };
 
     test_with_same_type!(value1, value2, *, expected);
 
     let value2 = 2.5;
-    let expected = Vector4 { X: 12.5, Y: 125.0, Z: 45.0, W: 6.25 };
+    let expected = Vector4 {
+        X: 12.5,
+        Y: 125.0,
+        Z: 45.0,
+        W: 6.25,
+    };
 
     test_with_scalar!(value1, value2, *, expected);
 }
 
 #[test]
 fn matrix3x2_add() {
-    let value1 = Matrix3x2 { M11: 16.0, M12: 15.0, M21: 14.0, M22: 13.0, M31: 12.0, M32: 11.0 };
-    let value2 = Matrix3x2 { M11: 10.0, M12: 9.0, M21: 8.0, M22: 7.0, M31: 6.0, M32: 5.0 };
-    let expected = Matrix3x2 { M11: 26.0, M12: 24.0, M21: 22.0, M22: 20.0, M31: 18.0, M32: 16.0 };
+    let value1 = Matrix3x2 {
+        M11: 16.0,
+        M12: 15.0,
+        M21: 14.0,
+        M22: 13.0,
+        M31: 12.0,
+        M32: 11.0,
+    };
+    let value2 = Matrix3x2 {
+        M11: 10.0,
+        M12: 9.0,
+        M21: 8.0,
+        M22: 7.0,
+        M31: 6.0,
+        M32: 5.0,
+    };
+    let expected = Matrix3x2 {
+        M11: 26.0,
+        M12: 24.0,
+        M21: 22.0,
+        M22: 20.0,
+        M31: 18.0,
+        M32: 16.0,
+    };
 
     test_with_same_type!(value1, value2, +, expected);
 }
 
 #[test]
 fn matrix3x2_sub() {
-    let value1 = Matrix3x2 { M11: 16.0, M12: 15.0, M21: 14.0, M22: 13.0, M31: 12.0, M32: 11.0 };
-    let value2 = Matrix3x2 { M11: 32.0, M12: 5.0, M21: 14.0, M22: 8.0, M31: 6.0, M32: 2.0 };
-    let expected = Matrix3x2 { M11: -16.0, M12: 10.0, M21: 0.0, M22: 5.0, M31: 6.0, M32: 9.0 };
+    let value1 = Matrix3x2 {
+        M11: 16.0,
+        M12: 15.0,
+        M21: 14.0,
+        M22: 13.0,
+        M31: 12.0,
+        M32: 11.0,
+    };
+    let value2 = Matrix3x2 {
+        M11: 32.0,
+        M12: 5.0,
+        M21: 14.0,
+        M22: 8.0,
+        M31: 6.0,
+        M32: 2.0,
+    };
+    let expected = Matrix3x2 {
+        M11: -16.0,
+        M12: 10.0,
+        M21: 0.0,
+        M22: 5.0,
+        M31: 6.0,
+        M32: 9.0,
+    };
 
     test_with_same_type!(value1, value2, -, expected);
 }
 
 #[test]
 fn matrix3x2_mul() {
-    let value1 = Matrix3x2 { M11: 16.0, M12: 15.0, M21: 14.0, M22: 13.0, M31: 12.0, M32: 11.0 };
-    let value2 = Matrix3x2 { M11: 32.0, M12: 5.0, M21: 14.0, M22: 8.0, M31: 6.0, M32: 2.0 };
-    let expected = Matrix3x2 { M11: 722.0, M12: 200.0, M21: 630.0, M22: 174.0, M31: 544.0, M32: 150.0 };
+    let value1 = Matrix3x2 {
+        M11: 16.0,
+        M12: 15.0,
+        M21: 14.0,
+        M22: 13.0,
+        M31: 12.0,
+        M32: 11.0,
+    };
+    let value2 = Matrix3x2 {
+        M11: 32.0,
+        M12: 5.0,
+        M21: 14.0,
+        M22: 8.0,
+        M31: 6.0,
+        M32: 2.0,
+    };
+    let expected = Matrix3x2 {
+        M11: 722.0,
+        M12: 200.0,
+        M21: 630.0,
+        M22: 174.0,
+        M31: 544.0,
+        M32: 150.0,
+    };
 
     test_with_same_type!(value1, value2, *, expected);
 
     let value2 = 2.0;
-    let expected = Matrix3x2 { M11: 32.0, M12: 30.0, M21: 28.0, M22: 26.0, M31: 24.0, M32: 22.0 };
+    let expected = Matrix3x2 {
+        M11: 32.0,
+        M12: 30.0,
+        M21: 28.0,
+        M22: 26.0,
+        M31: 24.0,
+        M32: 22.0,
+    };
 
     test_with_scalar!(value1, value2, *, expected);
 }

--- a/crates/tools/bindings/src/main.rs
+++ b/crates/tools/bindings/src/main.rs
@@ -62,7 +62,10 @@ fn main() -> std::io::Result<()> {
         "Windows.Win32.System.WinRT.IWeakReferenceSource",
     ];
 
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap()];
+    let files = vec![
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(),
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(),
+    ];
     let reader = &metadata::reader::Reader::new(&files);
 
     let gen = &mut bindgen::Gen::new(reader);

--- a/crates/tools/msvc/src/main.rs
+++ b/crates/tools/msvc/src/main.rs
@@ -17,19 +17,34 @@ fn main() {
         return;
     };
 
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
+    let files = vec![
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(),
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(),
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd")
+            .unwrap(),
+    ];
     let reader = &metadata::reader::Reader::new(&files);
 
     let mut libraries = BTreeMap::<String, BTreeMap<String, usize>>::new();
-    let root = reader.tree("Windows.Win32", &[]).expect("`Windows` namespace not found");
+    let root = reader
+        .tree("Windows.Win32", &[])
+        .expect("`Windows` namespace not found");
     for tree in root.flatten() {
-        if let Some(apis) = reader.get(metadata::reader::TypeName::new(tree.namespace, "Apis")).next() {
+        if let Some(apis) = reader
+            .get(metadata::reader::TypeName::new(tree.namespace, "Apis"))
+            .next()
+        {
             for method in reader.type_def_methods(apis) {
-                let impl_map = reader.method_def_impl_map(method).expect("ImplMap not found");
+                let impl_map = reader
+                    .method_def_impl_map(method)
+                    .expect("ImplMap not found");
                 let scope = reader.impl_map_scope(impl_map);
                 let library = reader.module_ref_name(scope).to_lowercase();
                 let params = reader.method_def_size(method);
-                libraries.entry(library).or_default().insert(reader.method_def_name(method).to_string(), params);
+                libraries
+                    .entry(library)
+                    .or_default()
+                    .insert(reader.method_def_name(method).to_string(), params);
             }
         }
     }

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -8,12 +8,21 @@ fn main() {
     let _ = std::fs::remove_dir_all(&output);
     output.pop();
 
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
+    let files = vec![
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(),
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(),
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd")
+            .unwrap(),
+    ];
     let reader = &metadata::reader::Reader::new(&files);
-    let root = reader.tree("Windows", &EXCLUDE_NAMESPACES).expect("`Windows` namespace not found");
+    let root = reader
+        .tree("Windows", &EXCLUDE_NAMESPACES)
+        .expect("`Windows` namespace not found");
 
     let trees = root.flatten();
-    trees.par_iter().for_each(|tree| gen_tree(reader, &output, tree));
+    trees
+        .par_iter()
+        .for_each(|tree| gen_tree(reader, &output, tree));
 
     output.pop();
     output.push("Cargo.toml");
@@ -83,9 +92,11 @@ deprecated = []
         if let Some(pos) = feature.rfind('_') {
             let dependency = &feature[..pos];
 
-            file.write_all(format!("{} = [\"{}\"]\n", feature, dependency).as_bytes()).unwrap();
+            file.write_all(format!("{} = [\"{}\"]\n", feature, dependency).as_bytes())
+                .unwrap();
         } else {
-            file.write_all(format!("{} = []\n", feature).as_bytes()).unwrap();
+            file.write_all(format!("{} = []\n", feature).as_bytes())
+                .unwrap();
         }
     }
 
@@ -93,7 +104,11 @@ deprecated = []
     std::fs::copy(".github/license-apache", "crates/libs/sys/license-apache").unwrap();
 }
 
-fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &metadata::reader::Tree) {
+fn gen_tree(
+    reader: &metadata::reader::Reader,
+    output: &std::path::Path,
+    tree: &metadata::reader::Tree,
+) {
     let mut path = std::path::PathBuf::from(output);
     path.push(tree.namespace.replace('.', "/"));
     std::fs::create_dir_all(&path).unwrap();
@@ -106,7 +121,12 @@ fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &
     gen.doc = true;
     let mut tokens = bindgen::namespace(&gen, tree);
 
-    let mut child = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn().expect("Failed to spawn `rustfmt`");
+    let mut child = std::process::Command::new("rustfmt")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("Failed to spawn `rustfmt`");
     let mut stdin = child.stdin.take().expect("Failed to open stdin");
     stdin.write_all(tokens.as_bytes()).unwrap();
     drop(stdin);

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -8,12 +8,21 @@ fn main() {
     let _ = std::fs::remove_dir_all(&output);
     output.pop();
 
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
+    let files = vec![
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(),
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(),
+        metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd")
+            .unwrap(),
+    ];
     let reader = &metadata::reader::Reader::new(&files);
-    let root = reader.tree("Windows", &EXCLUDE_NAMESPACES).expect("`Windows` namespace not found");
+    let root = reader
+        .tree("Windows", &EXCLUDE_NAMESPACES)
+        .expect("`Windows` namespace not found");
 
     let trees = root.flatten();
-    trees.par_iter().for_each(|tree| gen_tree(reader, &output, tree));
+    trees
+        .par_iter()
+        .for_each(|tree| gen_tree(reader, &output, tree));
 
     output.pop();
     output.push("Cargo.toml");
@@ -90,17 +99,27 @@ interface = ["windows-interface"]
         if let Some(pos) = feature.rfind('_') {
             let dependency = &feature[..pos];
 
-            file.write_all(format!("{} = [\"{}\"]\n", feature, dependency).as_bytes()).unwrap();
+            file.write_all(format!("{} = [\"{}\"]\n", feature, dependency).as_bytes())
+                .unwrap();
         } else {
-            file.write_all(format!("{} = []\n", feature).as_bytes()).unwrap();
+            file.write_all(format!("{} = []\n", feature).as_bytes())
+                .unwrap();
         }
     }
 
     std::fs::copy(".github/license-mit", "crates/libs/windows/license-mit").unwrap();
-    std::fs::copy(".github/license-apache", "crates/libs/windows/license-apache").unwrap();
+    std::fs::copy(
+        ".github/license-apache",
+        "crates/libs/windows/license-apache",
+    )
+    .unwrap();
 }
 
-fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &metadata::reader::Tree) {
+fn gen_tree(
+    reader: &metadata::reader::Reader,
+    output: &std::path::Path,
+    tree: &metadata::reader::Tree,
+) {
     println!("{}", tree.namespace);
     let mut path = std::path::PathBuf::from(output);
     path.push(tree.namespace.replace('.', "/"));
@@ -122,7 +141,12 @@ fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &
 }
 
 fn fmt_tokens(namespace: &str, tokens: &mut String) {
-    let mut child = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn().expect("Failed to spawn `rustfmt`");
+    let mut child = std::process::Command::new("rustfmt")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("Failed to spawn `rustfmt`");
     let mut stdin = child.stdin.take().expect("Failed to open stdin");
     stdin.write_all(tokens.as_bytes()).unwrap();
     drop(stdin);

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -96,13 +96,23 @@ jobs:
     let (first, last) = crates.split_at(crates.len() / 2);
 
     for name in first {
-        write!(&mut yml, "\n        cargo test --target ${{{{ matrix.target }}}} -p {} &&", name).unwrap();
+        write!(
+            &mut yml,
+            "\n        cargo test --target ${{{{ matrix.target }}}} -p {} &&",
+            name
+        )
+        .unwrap();
     }
 
     write!(&mut yml, "\n        cargo clean &&").unwrap();
 
     for name in last {
-        write!(&mut yml, "\n        cargo test --target ${{{{ matrix.target }}}} -p {} &&", name).unwrap();
+        write!(
+            &mut yml,
+            "\n        cargo test --target ${{{{ matrix.target }}}} -p {} &&",
+            name
+        )
+        .unwrap();
     }
 
     yml.truncate(yml.len() - 2);


### PR DESCRIPTION
The repo's `rustfmt.toml` applies a `max_width` of 800 to reduce the overall size of the `windows` and `windows-sys` crates, but this can be annoying for readability when it comes to the rest of the repo. Here I'm just applying it more selectively to the lib crates. We can apply it further to only the `windows` and `windows-sys` crates but I thought I'd start here first to avoid merge hell for Ryan and I. 😊

This should make the samples far more readable. 