### PR TITLE
Add support for `x86_64-pc-windows-gnullvm` target

### DIFF
--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -42,6 +42,9 @@ windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.38.0" }
 [target.x86_64-pc-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 
+[target.x86_64-pc-windows-gnullvm.dependencies]
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
+
 [target.x86_64-uwp-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -42,6 +42,9 @@ windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.38.0" }
 [target.x86_64-pc-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 
+[target.x86_64-pc-windows-gnullvm.dependencies]
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
+
 [target.x86_64-uwp-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 

--- a/crates/targets/x86_64_gnu/build.rs
+++ b/crates/targets/x86_64_gnu/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     let target = std::env::var("TARGET").unwrap();
-    if target != "x86_64-pc-windows-gnu" && target != "x86_64-uwp-windows-gnu" {
+    if target != "x86_64-pc-windows-gnu" && target != "x86_64-uwp-windows-gnu" && target != "x86_64-uwp-windows-gnullvm" {
         return;
     }
 

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -65,6 +65,9 @@ windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.38.0" }
 [target.x86_64-pc-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 
+[target.x86_64-pc-windows-gnullvm.dependencies]
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
+
 [target.x86_64-uwp-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -65,6 +65,9 @@ windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.38.0" }
 [target.x86_64-pc-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 
+[target.x86_64-pc-windows-gnullvm.dependencies]
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
+
 [target.x86_64-uwp-windows-gnu.dependencies]
 windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.38.0" }
 


### PR DESCRIPTION
This is Tier 3 target but lack of `windows-rs` support is one of the blockers for testing it in real world. Given the changes here are minimal I think there should be no problem with them.