### PR TITLE
Disable all (implicit) uses of `OsStr(ing)Ext` in `HSTRING` and `PCWSTR` for WSL/Linux support

### DIFF
--- a/crates/libs/windows/src/core/hstring.rs
+++ b/crates/libs/windows/src/core/hstring.rs
@@ -49,6 +49,7 @@ impl HSTRING {
     }
 
     /// Get the contents of this `HSTRING` as a OsString.
+    #[cfg(windows)]
     pub fn to_os_string(&self) -> std::ffi::OsString {
         std::os::windows::ffi::OsStringExt::from_wide(self.as_wide())
     }
@@ -168,18 +169,21 @@ impl core::convert::From<&alloc::string::String> for HSTRING {
     }
 }
 
+#[cfg(windows)]
 impl core::convert::From<&std::ffi::OsStr> for HSTRING {
     fn from(value: &std::ffi::OsStr) -> Self {
         unsafe { Self::from_wide_iter(std::os::windows::ffi::OsStrExt::encode_wide(value), value.len() as u32) }
     }
 }
 
+#[cfg(windows)]
 impl core::convert::From<std::ffi::OsString> for HSTRING {
     fn from(value: std::ffi::OsString) -> Self {
         value.as_os_str().into()
     }
 }
 
+#[cfg(windows)]
 impl core::convert::From<&std::ffi::OsString> for HSTRING {
     fn from(value: &std::ffi::OsString) -> Self {
         value.as_os_str().into()
@@ -264,72 +268,84 @@ impl PartialEq<&HSTRING> for alloc::string::String {
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<std::ffi::OsString> for HSTRING {
     fn eq(&self, other: &std::ffi::OsString) -> bool {
         *self == **other
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<std::ffi::OsString> for &HSTRING {
     fn eq(&self, other: &std::ffi::OsString) -> bool {
         **self == **other
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<&std::ffi::OsString> for HSTRING {
     fn eq(&self, other: &&std::ffi::OsString) -> bool {
         *self == ***other
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<std::ffi::OsStr> for HSTRING {
     fn eq(&self, other: &std::ffi::OsStr) -> bool {
         self.as_wide().iter().copied().eq(std::os::windows::ffi::OsStrExt::encode_wide(other))
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<std::ffi::OsStr> for &HSTRING {
     fn eq(&self, other: &std::ffi::OsStr) -> bool {
         **self == *other
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<&std::ffi::OsStr> for HSTRING {
     fn eq(&self, other: &&std::ffi::OsStr) -> bool {
         *self == **other
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<HSTRING> for std::ffi::OsStr {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == *self
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<HSTRING> for &std::ffi::OsStr {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == **self
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<&HSTRING> for std::ffi::OsStr {
     fn eq(&self, other: &&HSTRING) -> bool {
         **other == *self
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<HSTRING> for std::ffi::OsString {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == **self
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<HSTRING> for &std::ffi::OsString {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == ***self
     }
 }
 
+#[cfg(windows)]
 impl PartialEq<&HSTRING> for std::ffi::OsString {
     fn eq(&self, other: &&HSTRING) -> bool {
         **other == **self
@@ -352,12 +368,14 @@ impl core::convert::TryFrom<HSTRING> for alloc::string::String {
     }
 }
 
+#[cfg(windows)]
 impl<'a> core::convert::From<&'a HSTRING> for std::ffi::OsString {
     fn from(hstring: &HSTRING) -> Self {
         hstring.to_os_string()
     }
 }
 
+#[cfg(windows)]
 impl core::convert::From<HSTRING> for std::ffi::OsString {
     fn from(hstring: HSTRING) -> Self {
         Self::from(&hstring)
@@ -378,14 +396,14 @@ impl<'a> IntoParam<'a, HSTRING> for alloc::string::String {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(windows, feature = "alloc"))]
 impl<'a> IntoParam<'a, HSTRING> for &std::ffi::OsStr {
     fn into_param(self) -> Param<'a, HSTRING> {
         Param::Owned(self.into())
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(windows, feature = "alloc"))]
 impl<'a> IntoParam<'a, HSTRING> for std::ffi::OsString {
     fn into_param(self) -> Param<'a, HSTRING> {
         Param::Owned(self.into())

--- a/crates/libs/windows/src/core/pcwstr.rs
+++ b/crates/libs/windows/src/core/pcwstr.rs
@@ -58,14 +58,14 @@ impl<'a> IntoParam<'a, PCWSTR> for alloc::string::String {
         IntoParam::into_param(self.as_str())
     }
 }
-#[cfg(feature = "alloc")]
+#[cfg(all(windows, feature = "alloc"))]
 impl<'a> IntoParam<'a, PCWSTR> for &::std::ffi::OsStr {
     fn into_param(self) -> Param<'a, PCWSTR> {
         use ::std::os::windows::ffi::OsStrExt;
         Param::Boxed(PCWSTR(alloc_from_iter(self.encode_wide().chain(core::iter::once(0)), self.len() + 1)))
     }
 }
-#[cfg(feature = "alloc")]
+#[cfg(all(windows, feature = "alloc"))]
 impl<'a> IntoParam<'a, PCWSTR> for ::std::ffi::OsString {
     fn into_param(self) -> Param<'a, PCWSTR> {
         IntoParam::into_param(self.as_os_str())


### PR DESCRIPTION
Fixes #1860

On non-Windows targets - such as Linux and WSL - the `std::os::windows::ffi::OsStrExt` and `std::os::windows::ffi::OsStringExt` extension traits are not available.

To support compiling and running _on_ such non-Windows targets (not just cross-compiling _from_ them, for a Windows target) anything using these traits has to be guarded in the same way using a `#[cfg(windows)]`.

If needed fallbacks can be implemented manually, but that likely requires a bit more thought since wide-strings on these platforms typically have [32-bit `wchar_t` sizes, with Windows' 16-bit being the exception].

[32-bit `wchar_t` sizes, with Windows' 16-bit being the exception]: https://en.cppreference.com/w/cpp/language/types#Character%20types:~:text=wchar_t,a%20distinct%20type
