### PR TITLE
yml: Clean up formatting and indetation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report
-title: 'Bug:'
+title: "Bug:"
 labels: [bug]
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,13 +1,13 @@
 name: Feature request
 description: Suggest an improvement to windows-rs
-title: 'Feature request:'
-labels: ['enhancement']
+title: "Feature request:"
+labels: ["enhancement"]
 assignees: []
 body:
   - type: markdown
     attributes:
       value: >
-        Thank you for submitting a feature request! 
+        Thank you for submitting a feature request!
   - type: textarea
     attributes:
       label: Motivation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,24 +10,23 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  
   cargo_fmt:
     name: Check cargo formatting
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Run cargo fmt
-      run: cargo fmt --all -- --check
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
 
   cargo_doc:
     name: Check cargo docs
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Run cargo doc
-      run: cargo doc --no-deps -p windows
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run cargo doc
+        run: cargo doc --no-deps -p windows
 
   generation:
     name: Check generation of `tool_${{ matrix.generator }}`
@@ -36,13 +35,13 @@ jobs:
       matrix:
         generator: [bindings, windows, sys, yml]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Run tool_${{ matrix.generator }}
-      run: cargo run -p tool_${{ matrix.generator }}
-    - name: Compare
-      shell: bash
-      run: git diff --exit-code || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; exit 1)
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tool_${{ matrix.generator }}
+        run: cargo run -p tool_${{ matrix.generator }}
+      - name: Compare
+        shell: bash
+        run: git diff --exit-code || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; exit 1)
 
   cargo_sys:
     name: Check windows-sys
@@ -51,12 +50,12 @@ jobs:
       matrix:
         rust: [1.46.0, stable, nightly]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-    - name: Run cargo check
-      run: cargo check -p windows-sys --all-features
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - name: Run cargo check
+        run: cargo check -p windows-sys --all-features
 
   cargo_windows:
     name: Check windows
@@ -65,119 +64,119 @@ jobs:
       matrix:
         rust: [1.59.0, stable, nightly]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-    - name: Run cargo check
-      run: cargo check -p windows --features Foundation,Win32_Foundation,Win32_Graphics_Direct2D
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - name: Run cargo check
+        run: cargo check -p windows --features Foundation,Win32_Foundation,Win32_Graphics_Direct2D
 
   cargo_clippy:
     name: Check clippy
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
-    - name: Install clippy
-      run: rustup component add clippy      
-    - name: Configure environment
-      shell: pwsh
-      run: |
-        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-        ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
-          | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
-        (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
-        (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
-        "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
-          >> $env:GITHUB_ENV
-    - name: Run cargo clippy
-      run: |
-        cargo clippy -p windows-bindgen &&
-        cargo clippy -p windows-implement &&
-        cargo clippy -p windows-interface &&
-        cargo clippy -p windows-metadata &&
-        cargo clippy -p windows-sys &&
-        cargo clippy -p windows-tokens &&
-        cargo clippy -p windows &&
-        cargo clippy -p sample_com_uri &&
-        cargo clippy -p sample_consent &&
-        cargo clippy -p sample_core_app &&
-        cargo clippy -p sample_create_window &&
-        cargo clippy -p sample_create_window_sys &&
-        cargo clippy -p sample_data_protection &&
-        cargo clippy -p sample_direct2d &&
-        cargo clippy -p sample_direct3d12 &&
-        cargo clippy -p sample_enum_windows &&
-        cargo clippy -p sample_enum_windows_sys &&
-        cargo clippy -p sample_kernel_event &&
-        cargo clippy -p sample_memory_buffer &&
-        cargo clippy -p sample_message_box &&
-        cargo clippy -p sample_ocr &&
-        cargo clippy -p sample_overlapped &&
-        cargo clippy -p sample_rss &&
-        cargo clippy -p sample_simple &&
-        cargo clippy -p sample_spellchecker &&
-        cargo clippy -p sample_uiautomation &&
-        cargo clippy -p sample_xml &&
-        cargo clippy -p windows_aarch64_msvc &&
-        cargo clippy -p windows_i686_gnu &&
-        cargo clippy -p windows_i686_msvc &&
-        cargo clippy -p windows_x86_64_gnu &&
-        cargo clippy -p windows_x86_64_msvc &&
-        cargo clippy -p test_agile &&
-        cargo clippy -p test_agile_reference &&
-        cargo clippy -p test_alternate_success_code &&
-        cargo clippy -p test_arch &&
-        cargo clippy -p test_arch_feature &&
-        cargo clippy -p test_bstr &&
-        cargo clippy -p test_cfg_generic &&
-        cargo clippy -p test_class_factory &&
-        cargo clippy -p test_component &&
-        cargo clippy -p test_component_client &&
-        cargo clippy -p test_const_fields &&
-        cargo clippy -p test_core &&
-        cargo clippy -p test_data_object &&
-        cargo clippy -p test_debug &&
-        cargo clippy -p test_deprecated &&
-        cargo clippy -p test_dispatch &&
-        cargo clippy -p test_does_not_return &&
-        cargo clippy -p test_drop_target &&
-        cargo clippy -p test_enums &&
-        cargo clippy -p test_error &&
-        cargo clippy -p test_event &&
-        cargo clippy -p test_handles &&
-        cargo clippy -p test_helpers &&
-        cargo clippy -p test_identity &&
-        cargo clippy -p test_implement &&
-        cargo clippy -p test_interface &&
-        cargo clippy -p test_interop &&
-        cargo clippy -p test_lib &&
-        cargo clippy -p test_map &&
-        cargo clippy -p test_matrix3x2 &&
-        cargo clippy -p test_metadata &&
-        cargo clippy -p test_mshtml &&
-        cargo clippy -p test_not_dll &&
-        cargo clippy -p test_no_use &&
-        cargo clippy -p test_ntstatus &&
-        cargo clippy -p test_properties &&
-        cargo clippy -p test_query_signature &&
-        cargo clippy -p test_return_struct &&
-        cargo clippy -p test_string_param &&
-        cargo clippy -p test_structs &&
-        cargo clippy -p test_sys &&
-        cargo clippy -p test_unions &&
-        cargo clippy -p test_vector &&
-        cargo clippy -p test_weak &&
-        cargo clippy -p test_weak_ref &&
-        cargo clippy -p test_win32 &&
-        cargo clippy -p test_win32_arrays &&
-        cargo clippy -p test_winrt &&
-        cargo clippy -p tool_bindings &&
-        cargo clippy -p tool_gnu &&
-        cargo clippy -p tool_ilrs &&
-        cargo clippy -p tool_msvc &&
-        cargo clippy -p tool_sys &&
-        cargo clippy -p tool_windows &&
-        cargo clippy -p tool_yml 
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Configure environment
+        shell: pwsh
+        run: |
+          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
+          ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
+          (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
+          (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
+          "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
+            >> $env:GITHUB_ENV
+      - name: Run cargo clippy
+        run: |
+          cargo clippy -p windows-bindgen &&
+          cargo clippy -p windows-implement &&
+          cargo clippy -p windows-interface &&
+          cargo clippy -p windows-metadata &&
+          cargo clippy -p windows-sys &&
+          cargo clippy -p windows-tokens &&
+          cargo clippy -p windows &&
+          cargo clippy -p sample_com_uri &&
+          cargo clippy -p sample_consent &&
+          cargo clippy -p sample_core_app &&
+          cargo clippy -p sample_create_window &&
+          cargo clippy -p sample_create_window_sys &&
+          cargo clippy -p sample_data_protection &&
+          cargo clippy -p sample_direct2d &&
+          cargo clippy -p sample_direct3d12 &&
+          cargo clippy -p sample_enum_windows &&
+          cargo clippy -p sample_enum_windows_sys &&
+          cargo clippy -p sample_kernel_event &&
+          cargo clippy -p sample_memory_buffer &&
+          cargo clippy -p sample_message_box &&
+          cargo clippy -p sample_ocr &&
+          cargo clippy -p sample_overlapped &&
+          cargo clippy -p sample_rss &&
+          cargo clippy -p sample_simple &&
+          cargo clippy -p sample_spellchecker &&
+          cargo clippy -p sample_uiautomation &&
+          cargo clippy -p sample_xml &&
+          cargo clippy -p windows_aarch64_msvc &&
+          cargo clippy -p windows_i686_gnu &&
+          cargo clippy -p windows_i686_msvc &&
+          cargo clippy -p windows_x86_64_gnu &&
+          cargo clippy -p windows_x86_64_msvc &&
+          cargo clippy -p test_agile &&
+          cargo clippy -p test_agile_reference &&
+          cargo clippy -p test_alternate_success_code &&
+          cargo clippy -p test_arch &&
+          cargo clippy -p test_arch_feature &&
+          cargo clippy -p test_bstr &&
+          cargo clippy -p test_cfg_generic &&
+          cargo clippy -p test_class_factory &&
+          cargo clippy -p test_component &&
+          cargo clippy -p test_component_client &&
+          cargo clippy -p test_const_fields &&
+          cargo clippy -p test_core &&
+          cargo clippy -p test_data_object &&
+          cargo clippy -p test_debug &&
+          cargo clippy -p test_deprecated &&
+          cargo clippy -p test_dispatch &&
+          cargo clippy -p test_does_not_return &&
+          cargo clippy -p test_drop_target &&
+          cargo clippy -p test_enums &&
+          cargo clippy -p test_error &&
+          cargo clippy -p test_event &&
+          cargo clippy -p test_handles &&
+          cargo clippy -p test_helpers &&
+          cargo clippy -p test_identity &&
+          cargo clippy -p test_implement &&
+          cargo clippy -p test_interface &&
+          cargo clippy -p test_interop &&
+          cargo clippy -p test_lib &&
+          cargo clippy -p test_map &&
+          cargo clippy -p test_matrix3x2 &&
+          cargo clippy -p test_metadata &&
+          cargo clippy -p test_mshtml &&
+          cargo clippy -p test_not_dll &&
+          cargo clippy -p test_no_use &&
+          cargo clippy -p test_ntstatus &&
+          cargo clippy -p test_properties &&
+          cargo clippy -p test_query_signature &&
+          cargo clippy -p test_return_struct &&
+          cargo clippy -p test_string_param &&
+          cargo clippy -p test_structs &&
+          cargo clippy -p test_sys &&
+          cargo clippy -p test_unions &&
+          cargo clippy -p test_vector &&
+          cargo clippy -p test_weak &&
+          cargo clippy -p test_weak_ref &&
+          cargo clippy -p test_win32 &&
+          cargo clippy -p test_win32_arrays &&
+          cargo clippy -p test_winrt &&
+          cargo clippy -p tool_bindings &&
+          cargo clippy -p tool_gnu &&
+          cargo clippy -p tool_ilrs &&
+          cargo clippy -p tool_msvc &&
+          cargo clippy -p tool_sys &&
+          cargo clippy -p tool_windows &&
+          cargo clippy -p tool_yml

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -31,24 +31,24 @@ jobs:
     runs-on: ${{ matrix.image }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Add toolchain target
-      run: rustup target add ${{ matrix.target }}
+      - name: Add toolchain target
+        run: rustup target add ${{ matrix.target }}
 
-    - name: Install gcc-mingw-w64-x86-64
-      run: sudo apt-get install -y gcc-mingw-w64-x86-64
-      if: startsWith(matrix.image, 'ubuntu-') && matrix.target == 'x86_64-pc-windows-gnu'
+      - name: Install gcc-mingw-w64-x86-64
+        run: sudo apt-get install -y gcc-mingw-w64-x86-64
+        if: startsWith(matrix.image, 'ubuntu-') && matrix.target == 'x86_64-pc-windows-gnu'
 
-    - name: Install mingw-w64
-      run: brew install mingw-w64
-      if: startsWith(matrix.image, 'macos-') && matrix.target == 'x86_64-pc-windows-gnu'
+      - name: Install mingw-w64
+        run: brew install mingw-w64
+        if: startsWith(matrix.image, 'macos-') && matrix.target == 'x86_64-pc-windows-gnu'
 
-    - name: Test
-      shell: pwsh
-      run: |
-        cargo test --no-run --target ${{ matrix.target }} -p test_win32
-        if (-Not (Resolve-Path "target/*/debug/deps/test_win32-*.exe" | Test-Path)) {
-          throw "Failed to find test_win32 executable."
-        }
+      - name: Test
+        shell: pwsh
+        run: |
+          cargo test --no-run --target ${{ matrix.target }} -p test_win32
+          if (-Not (Resolve-Path "target/*/debug/deps/test_win32-*.exe" | Test-Path)) {
+            throw "Failed to find test_win32 executable."
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,179 +17,178 @@ jobs:
     strategy:
       matrix:
         include:
-        - version: stable
-          target: x86_64-pc-windows-msvc
-        - version: nightly
-          target: i686-pc-windows-msvc
-        - version: nightly
-          target: x86_64-pc-windows-gnu
-        - version: stable
-          target: i686-pc-windows-gnu
+          - version: stable
+            target: x86_64-pc-windows-msvc
+          - version: nightly
+            target: i686-pc-windows-msvc
+          - version: nightly
+            target: x86_64-pc-windows-gnu
+          - version: stable
+            target: i686-pc-windows-gnu
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
-    - name: Add toolchain target
-      run: rustup target add ${{ matrix.target }}
-    - name: Install clippy
-      run: rustup component add clippy      
-    - name: Configure Cargo for GNU toolchain
-      shell: pwsh
-      run: |
-        Add-Content $env:USERPROFILE\.cargo\config @"
-            [target.x86_64-pc-windows-gnu]
-            linker = `"C:\\msys64\\mingw64\\bin\\x86_64-w64-mingw32-gcc.exe`"
-            ar = `"C:\\msys64\\mingw64\\bin\\ar.exe`"
-            [target.i686-pc-windows-gnu]
-            linker = `"C:\\msys64\\mingw32\\bin\\i686-w64-mingw32-gcc.exe`"
-            ar = `"C:\\msys64\\mingw32\\bin\\ar.exe`"
-        "@
-      if: contains(matrix.target, 'windows-gnu')
-    - name: Configure environment
-      shell: pwsh
-      run: |
-        switch -Wildcard ("${{ matrix.target }}")
-        {
-          "i686-pc-windows-gnu"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
+      - name: Add toolchain target
+        run: rustup target add ${{ matrix.target }}
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Configure Cargo for GNU toolchain
+        shell: pwsh
+        run: |
+          Add-Content $env:USERPROFILE\.cargo\config @"
+              [target.x86_64-pc-windows-gnu]
+              linker = `"C:\\msys64\\mingw64\\bin\\x86_64-w64-mingw32-gcc.exe`"
+              ar = `"C:\\msys64\\mingw64\\bin\\ar.exe`"
+              [target.i686-pc-windows-gnu]
+              linker = `"C:\\msys64\\mingw32\\bin\\i686-w64-mingw32-gcc.exe`"
+              ar = `"C:\\msys64\\mingw32\\bin\\ar.exe`"
+          "@
+        if: contains(matrix.target, 'windows-gnu')
+      - name: Configure environment
+        shell: pwsh
+        run: |
+          switch -Wildcard ("${{ matrix.target }}")
           {
-            "C:\msys64\mingw32\bin" >> $env:GITHUB_PATH
+            "i686-pc-windows-gnu"
+            {
+              "C:\msys64\mingw32\bin" >> $env:GITHUB_PATH
+            }
+            "x86_64-pc-windows-gnu"
+            {
+              "C:\msys64\mingw64\bin" >> $env:GITHUB_PATH
+            }
+            "i686*"
+            {
+              "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
+              ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx86\x86")
+                | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
+            }
+            "x86_64*"
+            {
+              "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
+              ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+                | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
+            }
+            "*"
+            {
+              (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
+              (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
+              "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
+                >> $env:GITHUB_ENV
+            }
           }
-          "x86_64-pc-windows-gnu"
-          {
-            "C:\msys64\mingw64\bin" >> $env:GITHUB_PATH
-          }
-          "i686*"
-          {
-            "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx86\x86")
-              | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
-          }
-          "x86_64*"
-          {
-            "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
-              | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
-          }
-          "*"
-          {
-            (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
-            (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
-            "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
-              >> $env:GITHUB_ENV
-          }
-        }
-    - name: Test
-      run: >
-        cargo test --target ${{ matrix.target }} -p windows-bindgen &&
-        cargo test --target ${{ matrix.target }} -p windows-implement &&
-        cargo test --target ${{ matrix.target }} -p windows-interface &&
-        cargo test --target ${{ matrix.target }} -p windows-metadata &&
-        cargo test --target ${{ matrix.target }} -p windows-sys &&
-        cargo test --target ${{ matrix.target }} -p windows-tokens &&
-        cargo test --target ${{ matrix.target }} -p windows &&
-        cargo test --target ${{ matrix.target }} -p sample_com_uri &&
-        cargo test --target ${{ matrix.target }} -p sample_consent &&
-        cargo test --target ${{ matrix.target }} -p sample_core_app &&
-        cargo test --target ${{ matrix.target }} -p sample_create_window &&
-        cargo test --target ${{ matrix.target }} -p sample_create_window_sys &&
-        cargo test --target ${{ matrix.target }} -p sample_data_protection &&
-        cargo test --target ${{ matrix.target }} -p sample_direct2d &&
-        cargo test --target ${{ matrix.target }} -p sample_direct3d12 &&
-        cargo test --target ${{ matrix.target }} -p sample_enum_windows &&
-        cargo test --target ${{ matrix.target }} -p sample_enum_windows_sys &&
-        cargo test --target ${{ matrix.target }} -p sample_kernel_event &&
-        cargo test --target ${{ matrix.target }} -p sample_memory_buffer &&
-        cargo test --target ${{ matrix.target }} -p sample_message_box &&
-        cargo test --target ${{ matrix.target }} -p sample_ocr &&
-        cargo test --target ${{ matrix.target }} -p sample_overlapped &&
-        cargo test --target ${{ matrix.target }} -p sample_rss &&
-        cargo test --target ${{ matrix.target }} -p sample_simple &&
-        cargo test --target ${{ matrix.target }} -p sample_spellchecker &&
-        cargo test --target ${{ matrix.target }} -p sample_uiautomation &&
-        cargo test --target ${{ matrix.target }} -p sample_xml &&
-        cargo test --target ${{ matrix.target }} -p windows_aarch64_msvc &&
-        cargo test --target ${{ matrix.target }} -p windows_i686_gnu &&
-        cargo test --target ${{ matrix.target }} -p windows_i686_msvc &&
-        cargo test --target ${{ matrix.target }} -p windows_x86_64_gnu &&
-        cargo test --target ${{ matrix.target }} -p windows_x86_64_msvc &&
-        cargo test --target ${{ matrix.target }} -p test_agile &&
-        cargo test --target ${{ matrix.target }} -p test_agile_reference &&
-        cargo test --target ${{ matrix.target }} -p test_alternate_success_code &&
-        cargo test --target ${{ matrix.target }} -p test_arch &&
-        cargo test --target ${{ matrix.target }} -p test_arch_feature &&
-        cargo test --target ${{ matrix.target }} -p test_bstr &&
-        cargo test --target ${{ matrix.target }} -p test_cfg_generic &&
-        cargo test --target ${{ matrix.target }} -p test_class_factory &&
-        cargo test --target ${{ matrix.target }} -p test_component &&
-        cargo test --target ${{ matrix.target }} -p test_component_client &&
-        cargo test --target ${{ matrix.target }} -p test_const_fields &&
-        cargo clean &&
-        cargo test --target ${{ matrix.target }} -p test_core &&
-        cargo test --target ${{ matrix.target }} -p test_data_object &&
-        cargo test --target ${{ matrix.target }} -p test_debug &&
-        cargo test --target ${{ matrix.target }} -p test_deprecated &&
-        cargo test --target ${{ matrix.target }} -p test_dispatch &&
-        cargo test --target ${{ matrix.target }} -p test_does_not_return &&
-        cargo test --target ${{ matrix.target }} -p test_drop_target &&
-        cargo test --target ${{ matrix.target }} -p test_enums &&
-        cargo test --target ${{ matrix.target }} -p test_error &&
-        cargo test --target ${{ matrix.target }} -p test_event &&
-        cargo test --target ${{ matrix.target }} -p test_handles &&
-        cargo test --target ${{ matrix.target }} -p test_helpers &&
-        cargo test --target ${{ matrix.target }} -p test_identity &&
-        cargo test --target ${{ matrix.target }} -p test_implement &&
-        cargo test --target ${{ matrix.target }} -p test_interface &&
-        cargo test --target ${{ matrix.target }} -p test_interop &&
-        cargo test --target ${{ matrix.target }} -p test_lib &&
-        cargo test --target ${{ matrix.target }} -p test_map &&
-        cargo test --target ${{ matrix.target }} -p test_matrix3x2 &&
-        cargo test --target ${{ matrix.target }} -p test_metadata &&
-        cargo test --target ${{ matrix.target }} -p test_mshtml &&
-        cargo test --target ${{ matrix.target }} -p test_not_dll &&
-        cargo test --target ${{ matrix.target }} -p test_no_use &&
-        cargo test --target ${{ matrix.target }} -p test_ntstatus &&
-        cargo test --target ${{ matrix.target }} -p test_properties &&
-        cargo test --target ${{ matrix.target }} -p test_query_signature &&
-        cargo test --target ${{ matrix.target }} -p test_return_struct &&
-        cargo test --target ${{ matrix.target }} -p test_string_param &&
-        cargo test --target ${{ matrix.target }} -p test_structs &&
-        cargo test --target ${{ matrix.target }} -p test_sys &&
-        cargo test --target ${{ matrix.target }} -p test_unions &&
-        cargo test --target ${{ matrix.target }} -p test_vector &&
-        cargo test --target ${{ matrix.target }} -p test_weak &&
-        cargo test --target ${{ matrix.target }} -p test_weak_ref &&
-        cargo test --target ${{ matrix.target }} -p test_win32 &&
-        cargo test --target ${{ matrix.target }} -p test_win32_arrays &&
-        cargo test --target ${{ matrix.target }} -p test_winrt &&
-        cargo test --target ${{ matrix.target }} -p tool_bindings &&
-        cargo test --target ${{ matrix.target }} -p tool_gnu &&
-        cargo test --target ${{ matrix.target }} -p tool_ilrs &&
-        cargo test --target ${{ matrix.target }} -p tool_msvc &&
-        cargo test --target ${{ matrix.target }} -p tool_sys &&
-        cargo test --target ${{ matrix.target }} -p tool_windows &&
-        cargo test --target ${{ matrix.target }} -p tool_yml 
+      - name: Test
+        run: >
+          cargo test --target ${{ matrix.target }} -p windows-bindgen &&
+          cargo test --target ${{ matrix.target }} -p windows-implement &&
+          cargo test --target ${{ matrix.target }} -p windows-interface &&
+          cargo test --target ${{ matrix.target }} -p windows-metadata &&
+          cargo test --target ${{ matrix.target }} -p windows-sys &&
+          cargo test --target ${{ matrix.target }} -p windows-tokens &&
+          cargo test --target ${{ matrix.target }} -p windows &&
+          cargo test --target ${{ matrix.target }} -p sample_com_uri &&
+          cargo test --target ${{ matrix.target }} -p sample_consent &&
+          cargo test --target ${{ matrix.target }} -p sample_core_app &&
+          cargo test --target ${{ matrix.target }} -p sample_create_window &&
+          cargo test --target ${{ matrix.target }} -p sample_create_window_sys &&
+          cargo test --target ${{ matrix.target }} -p sample_data_protection &&
+          cargo test --target ${{ matrix.target }} -p sample_direct2d &&
+          cargo test --target ${{ matrix.target }} -p sample_direct3d12 &&
+          cargo test --target ${{ matrix.target }} -p sample_enum_windows &&
+          cargo test --target ${{ matrix.target }} -p sample_enum_windows_sys &&
+          cargo test --target ${{ matrix.target }} -p sample_kernel_event &&
+          cargo test --target ${{ matrix.target }} -p sample_memory_buffer &&
+          cargo test --target ${{ matrix.target }} -p sample_message_box &&
+          cargo test --target ${{ matrix.target }} -p sample_ocr &&
+          cargo test --target ${{ matrix.target }} -p sample_overlapped &&
+          cargo test --target ${{ matrix.target }} -p sample_rss &&
+          cargo test --target ${{ matrix.target }} -p sample_simple &&
+          cargo test --target ${{ matrix.target }} -p sample_spellchecker &&
+          cargo test --target ${{ matrix.target }} -p sample_uiautomation &&
+          cargo test --target ${{ matrix.target }} -p sample_xml &&
+          cargo test --target ${{ matrix.target }} -p windows_aarch64_msvc &&
+          cargo test --target ${{ matrix.target }} -p windows_i686_gnu &&
+          cargo test --target ${{ matrix.target }} -p windows_i686_msvc &&
+          cargo test --target ${{ matrix.target }} -p windows_x86_64_gnu &&
+          cargo test --target ${{ matrix.target }} -p windows_x86_64_msvc &&
+          cargo test --target ${{ matrix.target }} -p test_agile &&
+          cargo test --target ${{ matrix.target }} -p test_agile_reference &&
+          cargo test --target ${{ matrix.target }} -p test_alternate_success_code &&
+          cargo test --target ${{ matrix.target }} -p test_arch &&
+          cargo test --target ${{ matrix.target }} -p test_arch_feature &&
+          cargo test --target ${{ matrix.target }} -p test_bstr &&
+          cargo test --target ${{ matrix.target }} -p test_cfg_generic &&
+          cargo test --target ${{ matrix.target }} -p test_class_factory &&
+          cargo test --target ${{ matrix.target }} -p test_component &&
+          cargo test --target ${{ matrix.target }} -p test_component_client &&
+          cargo test --target ${{ matrix.target }} -p test_const_fields &&
+          cargo clean &&
+          cargo test --target ${{ matrix.target }} -p test_core &&
+          cargo test --target ${{ matrix.target }} -p test_data_object &&
+          cargo test --target ${{ matrix.target }} -p test_debug &&
+          cargo test --target ${{ matrix.target }} -p test_deprecated &&
+          cargo test --target ${{ matrix.target }} -p test_dispatch &&
+          cargo test --target ${{ matrix.target }} -p test_does_not_return &&
+          cargo test --target ${{ matrix.target }} -p test_drop_target &&
+          cargo test --target ${{ matrix.target }} -p test_enums &&
+          cargo test --target ${{ matrix.target }} -p test_error &&
+          cargo test --target ${{ matrix.target }} -p test_event &&
+          cargo test --target ${{ matrix.target }} -p test_handles &&
+          cargo test --target ${{ matrix.target }} -p test_helpers &&
+          cargo test --target ${{ matrix.target }} -p test_identity &&
+          cargo test --target ${{ matrix.target }} -p test_implement &&
+          cargo test --target ${{ matrix.target }} -p test_interface &&
+          cargo test --target ${{ matrix.target }} -p test_interop &&
+          cargo test --target ${{ matrix.target }} -p test_lib &&
+          cargo test --target ${{ matrix.target }} -p test_map &&
+          cargo test --target ${{ matrix.target }} -p test_matrix3x2 &&
+          cargo test --target ${{ matrix.target }} -p test_metadata &&
+          cargo test --target ${{ matrix.target }} -p test_mshtml &&
+          cargo test --target ${{ matrix.target }} -p test_not_dll &&
+          cargo test --target ${{ matrix.target }} -p test_no_use &&
+          cargo test --target ${{ matrix.target }} -p test_ntstatus &&
+          cargo test --target ${{ matrix.target }} -p test_properties &&
+          cargo test --target ${{ matrix.target }} -p test_query_signature &&
+          cargo test --target ${{ matrix.target }} -p test_return_struct &&
+          cargo test --target ${{ matrix.target }} -p test_string_param &&
+          cargo test --target ${{ matrix.target }} -p test_structs &&
+          cargo test --target ${{ matrix.target }} -p test_sys &&
+          cargo test --target ${{ matrix.target }} -p test_unions &&
+          cargo test --target ${{ matrix.target }} -p test_vector &&
+          cargo test --target ${{ matrix.target }} -p test_weak &&
+          cargo test --target ${{ matrix.target }} -p test_weak_ref &&
+          cargo test --target ${{ matrix.target }} -p test_win32 &&
+          cargo test --target ${{ matrix.target }} -p test_win32_arrays &&
+          cargo test --target ${{ matrix.target }} -p test_winrt &&
+          cargo test --target ${{ matrix.target }} -p tool_bindings &&
+          cargo test --target ${{ matrix.target }} -p tool_gnu &&
+          cargo test --target ${{ matrix.target }} -p tool_ilrs &&
+          cargo test --target ${{ matrix.target }} -p tool_msvc &&
+          cargo test --target ${{ matrix.target }} -p tool_sys &&
+          cargo test --target ${{ matrix.target }} -p tool_windows &&
+          cargo test --target ${{ matrix.target }} -p tool_yml
 
-    - name: Check import libs
-      shell: pwsh
-      run: |
-        $VisualStudioRoot = & vswhere -latest -property installationPath -format value
-        $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
-          Select -ExpandProperty Path -First 1
-        $Tests = @(
-          [Tuple]::Create("aarch64_msvc","AA64"),
-          [Tuple]::Create("x86_64_msvc","8664"),
-          [Tuple]::Create("i686_msvc","14C")
-        )
-        foreach($Test in $Tests) {
-          $Target = $Test.Item1
-          $Magic = $Test.Item2
-          $Output = [string](& $DumpbinPath /headers crates/targets/$Target/lib/windows.lib)
-          if($Output -match "Machine\s*: $Magic" -ne $True) {
-            Write-Error "Import lib check failed for $Target ($Magic)."
-            Exit 1
+      - name: Check import libs
+        shell: pwsh
+        run: |
+          $VisualStudioRoot = & vswhere -latest -property installationPath -format value
+          $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
+            Select -ExpandProperty Path -First 1
+          $Tests = @(
+            [Tuple]::Create("aarch64_msvc","AA64"),
+            [Tuple]::Create("x86_64_msvc","8664"),
+            [Tuple]::Create("i686_msvc","14C")
+          )
+          foreach($Test in $Tests) {
+            $Target = $Test.Item1
+            $Magic = $Test.Item2
+            $Output = [string](& $DumpbinPath /headers crates/targets/$Target/lib/windows.lib)
+            if($Output -match "Machine\s*: $Magic" -ne $True) {
+              Write-Error "Import lib check failed for $Target ($Magic)."
+              Exit 1
+            }
           }
-        }
-      if: matrix.version == 'stable' && matrix.target == 'x86_64-pc-windows-msvc'
-    
+        if: matrix.version == 'stable' && matrix.target == 'x86_64-pc-windows-msvc'

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -25,113 +25,113 @@ jobs:
     strategy:
       matrix:
         include:
-        - version: stable
-          target: x86_64-pc-windows-msvc
-        - version: nightly
-          target: i686-pc-windows-msvc
-        - version: nightly
-          target: x86_64-pc-windows-gnu
-        - version: stable
-          target: i686-pc-windows-gnu
+          - version: stable
+            target: x86_64-pc-windows-msvc
+          - version: nightly
+            target: i686-pc-windows-msvc
+          - version: nightly
+            target: x86_64-pc-windows-gnu
+          - version: stable
+            target: i686-pc-windows-gnu
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
-    - name: Add toolchain target
-      run: rustup target add ${{ matrix.target }}
-    - name: Install clippy
-      run: rustup component add clippy      
-    - name: Configure Cargo for GNU toolchain
-      shell: pwsh
-      run: |
-        Add-Content $env:USERPROFILE\.cargo\config @"
-            [target.x86_64-pc-windows-gnu]
-            linker = `"C:\\msys64\\mingw64\\bin\\x86_64-w64-mingw32-gcc.exe`"
-            ar = `"C:\\msys64\\mingw64\\bin\\ar.exe`"
-            [target.i686-pc-windows-gnu]
-            linker = `"C:\\msys64\\mingw32\\bin\\i686-w64-mingw32-gcc.exe`"
-            ar = `"C:\\msys64\\mingw32\\bin\\ar.exe`"
-        "@
-      if: contains(matrix.target, 'windows-gnu')
-    - name: Configure environment
-      shell: pwsh
-      run: |
-        switch -Wildcard ("${{ matrix.target }}")
-        {
-          "i686-pc-windows-gnu"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
+      - name: Add toolchain target
+        run: rustup target add ${{ matrix.target }}
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Configure Cargo for GNU toolchain
+        shell: pwsh
+        run: |
+          Add-Content $env:USERPROFILE\.cargo\config @"
+              [target.x86_64-pc-windows-gnu]
+              linker = `"C:\\msys64\\mingw64\\bin\\x86_64-w64-mingw32-gcc.exe`"
+              ar = `"C:\\msys64\\mingw64\\bin\\ar.exe`"
+              [target.i686-pc-windows-gnu]
+              linker = `"C:\\msys64\\mingw32\\bin\\i686-w64-mingw32-gcc.exe`"
+              ar = `"C:\\msys64\\mingw32\\bin\\ar.exe`"
+          "@
+        if: contains(matrix.target, 'windows-gnu')
+      - name: Configure environment
+        shell: pwsh
+        run: |
+          switch -Wildcard ("${{ matrix.target }}")
           {
-            "C:\msys64\mingw32\bin" >> $env:GITHUB_PATH
+            "i686-pc-windows-gnu"
+            {
+              "C:\msys64\mingw32\bin" >> $env:GITHUB_PATH
+            }
+            "x86_64-pc-windows-gnu"
+            {
+              "C:\msys64\mingw64\bin" >> $env:GITHUB_PATH
+            }
+            "i686*"
+            {
+              "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
+              ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx86\x86")
+                | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
+            }
+            "x86_64*"
+            {
+              "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
+              ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+                | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
+            }
+            "*"
+            {
+              (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
+              (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
+              "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
+                >> $env:GITHUB_ENV
+            }
           }
-          "x86_64-pc-windows-gnu"
-          {
-            "C:\msys64\mingw64\bin" >> $env:GITHUB_PATH
-          }
-          "i686*"
-          {
-            "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx86\x86")
-              | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
-          }
-          "x86_64*"
-          {
-            "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
-              | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
-          }
-          "*"
-          {
-            (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
-            (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
-            "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
-              >> $env:GITHUB_ENV
-          }
-        }
-    - name: Test
-      run: >"#
+      - name: Test
+        run: >"#
         .to_string();
 
     let crates = crates();
     let (first, last) = crates.split_at(crates.len() / 2);
 
     for name in first {
-        write!(&mut yml, "\n        cargo test --target ${{{{ matrix.target }}}} -p {} &&", name).unwrap();
+        write!(&mut yml, "\n          cargo test --target ${{{{ matrix.target }}}} -p {} &&", name).unwrap();
     }
 
-    write!(&mut yml, "\n        cargo clean &&").unwrap();
+    write!(&mut yml, "\n          cargo clean &&").unwrap();
 
     for name in last {
-        write!(&mut yml, "\n        cargo test --target ${{{{ matrix.target }}}} -p {} &&", name).unwrap();
+        write!(&mut yml, "\n          cargo test --target ${{{{ matrix.target }}}} -p {} &&", name).unwrap();
     }
 
-    yml.truncate(yml.len() - 2);
+    yml.truncate(yml.len() - 3);
 
     yml.push_str(
         r#"
 
-    - name: Check import libs
-      shell: pwsh
-      run: |
-        $VisualStudioRoot = & vswhere -latest -property installationPath -format value
-        $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
-          Select -ExpandProperty Path -First 1
-        $Tests = @(
-          [Tuple]::Create("aarch64_msvc","AA64"),
-          [Tuple]::Create("x86_64_msvc","8664"),
-          [Tuple]::Create("i686_msvc","14C")
-        )
-        foreach($Test in $Tests) {
-          $Target = $Test.Item1
-          $Magic = $Test.Item2
-          $Output = [string](& $DumpbinPath /headers crates/targets/$Target/lib/windows.lib)
-          if($Output -match "Machine\s*: $Magic" -ne $True) {
-            Write-Error "Import lib check failed for $Target ($Magic)."
-            Exit 1
+      - name: Check import libs
+        shell: pwsh
+        run: |
+          $VisualStudioRoot = & vswhere -latest -property installationPath -format value
+          $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
+            Select -ExpandProperty Path -First 1
+          $Tests = @(
+            [Tuple]::Create("aarch64_msvc","AA64"),
+            [Tuple]::Create("x86_64_msvc","8664"),
+            [Tuple]::Create("i686_msvc","14C")
+          )
+          foreach($Test in $Tests) {
+            $Target = $Test.Item1
+            $Magic = $Test.Item2
+            $Output = [string](& $DumpbinPath /headers crates/targets/$Target/lib/windows.lib)
+            if($Output -match "Machine\s*: $Magic" -ne $True) {
+              Write-Error "Import lib check failed for $Target ($Magic)."
+              Exit 1
+            }
           }
-        }
-      if: matrix.version == 'stable' && matrix.target == 'x86_64-pc-windows-msvc'
-    "#,
+        if: matrix.version == 'stable' && matrix.target == 'x86_64-pc-windows-msvc'
+"#,
     );
 
     std::fs::write(".github/workflows/test.yml", yml.as_bytes()).unwrap();
@@ -150,24 +150,23 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  
   cargo_fmt:
     name: Check cargo formatting
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Run cargo fmt
-      run: cargo fmt --all -- --check
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
 
   cargo_doc:
     name: Check cargo docs
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Run cargo doc
-      run: cargo doc --no-deps -p windows
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run cargo doc
+        run: cargo doc --no-deps -p windows
 
   generation:
     name: Check generation of `tool_${{ matrix.generator }}`
@@ -176,13 +175,13 @@ jobs:
       matrix:
         generator: [bindings, windows, sys, yml]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Run tool_${{ matrix.generator }}
-      run: cargo run -p tool_${{ matrix.generator }}
-    - name: Compare
-      shell: bash
-      run: git diff --exit-code || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; exit 1)
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tool_${{ matrix.generator }}
+        run: cargo run -p tool_${{ matrix.generator }}
+      - name: Compare
+        shell: bash
+        run: git diff --exit-code || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; exit 1)
 
   cargo_sys:
     name: Check windows-sys
@@ -191,12 +190,12 @@ jobs:
       matrix:
         rust: [1.46.0, stable, nightly]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-    - name: Run cargo check
-      run: cargo check -p windows-sys --all-features
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - name: Run cargo check
+        run: cargo check -p windows-sys --all-features
 
   cargo_windows:
     name: Check windows
@@ -205,42 +204,43 @@ jobs:
       matrix:
         rust: [1.59.0, stable, nightly]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-    - name: Run cargo check
-      run: cargo check -p windows --features Foundation,Win32_Foundation,Win32_Graphics_Direct2D
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - name: Run cargo check
+        run: cargo check -p windows --features Foundation,Win32_Foundation,Win32_Graphics_Direct2D
 
   cargo_clippy:
     name: Check clippy
     runs-on: windows-2019
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Update toolchain
-      run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
-    - name: Install clippy
-      run: rustup component add clippy      
-    - name: Configure environment
-      shell: pwsh
-      run: |
-        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-        ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
-          | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
-        (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
-        (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
-        "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
-          >> $env:GITHUB_ENV
-    - name: Run cargo clippy
-      run: |"#
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update toolchain
+        run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Configure environment
+        shell: pwsh
+        run: |
+          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
+          ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
+          (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
+          (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
+          "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
+            >> $env:GITHUB_ENV
+      - name: Run cargo clippy
+        run: |"#
         .to_string();
 
     for name in crates() {
-        write!(&mut yml, "\n        cargo clippy -p {} &&", name).unwrap();
+        write!(&mut yml, "\n          cargo clippy -p {} &&", name).unwrap();
     }
 
-    yml.truncate(yml.len() - 2);
+    yml.truncate(yml.len() - 3);
+    yml.push('\n');
 
     std::fs::write(".github/workflows/build.yml", yml.as_bytes()).unwrap();
 }


### PR DESCRIPTION
YAML arrays should have one extra indent level on top of their parent, before starting the line with `-`.  In addition the YAML formatter seems to prefer double quotes over single quotes, and is used this way in all but three places.  Finally, trim some trailing whitespace and make sure all files have a single trailing newline.
