### PR TITLE
Fix new Rust-1.62 lints

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -303,7 +303,7 @@ impl<'a> Gen<'a> {
 
             let mut features = cfg_features(cfg, self.namespace);
             if self.windows_extern {
-                features = features.into_iter().filter(|f| !f.starts_with("Windows.")).collect();
+                features.retain(|f| !f.starts_with("Windows."));
             }
             for features in features {
                 write!(tokens, r#", `\"{}\"`"#, to_feature(features)).unwrap();
@@ -330,7 +330,7 @@ impl<'a> Gen<'a> {
 
             let mut features = cfg_features(cfg, self.namespace);
             if self.windows_extern {
-                features = features.into_iter().filter(|f| !f.starts_with("Windows.")).collect();
+                features.retain(|f| !f.starts_with("Windows."));
             }
 
             let features = match features.len() {
@@ -355,7 +355,7 @@ impl<'a> Gen<'a> {
             quote! {}
         } else {
             if self.windows_extern {
-                features = features.into_iter().filter(|f| !f.starts_with("Windows.")).collect();
+                features.retain(|f| !f.starts_with("Windows."));
             }
             match features.len() {
                 0 => quote! {},

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -278,7 +278,7 @@ impl ImplementAttributes {
                 }
 
                 namespace.push_str(&input.ident.to_string());
-                self.walk_implement(&*input.tree, namespace)?;
+                self.walk_implement(&input.tree, namespace)?;
             }
             UseTree2::Name(_) => {
                 self.implement.push(tree.to_element_type(namespace)?);


### PR DESCRIPTION
Some new lints are appearing in Rust 1.62: fix them to make the CI and our eyes happy again :partying_face: 