### PR TITLE
ci: Replace `diff --exit-code` with `status --porcelain` to catch untracked files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       run: cargo run -p tool_${{ matrix.generator }}
     - name: Compare
       shell: bash
-      run: git diff --exit-code || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; exit 1)
+      run: test -z "$(git status --porcelain)" || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; git diff; exit 1)
 
   cargo_sys:
     name: Check windows-sys

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -182,7 +182,7 @@ jobs:
       run: cargo run -p tool_${{ matrix.generator }}
     - name: Compare
       shell: bash
-      run: git diff --exit-code || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; exit 1)
+      run: test -z "$(git status --porcelain)" || (echo '::error::Generated `tool_${{ matrix.generator }}` are out-of-date. Please run `cargo run -p tool_${{ matrix.generator }}`'; git diff; exit 1)
 
   cargo_sys:
     name: Check windows-sys


### PR DESCRIPTION
I commited this line to the repo quite some time, but discovered over time that it has one fatal flaw: `git diff` only considers _tracked_ files.  In the event that the command-at-test generates new files that weren't checked in by accident (and aren't explicitly in `.gitignore`), `git status --porcelain` will return a non-empty string and allow the test to fail appropriately.

Note that it is typically unlikely for this to happen, as e.g. a single missing Rust file generally results in a compilation failure, assuming a `mod` has likely been added in a file that was tracked already.  But better to be safe than sorry nevertheless.
