### PR TITLE
Add `tool_lib` crate to hold some of the common support for the `windows-rs` tools

### DIFF
--- a/crates/tools/bindings/src/main.rs
+++ b/crates/tools/bindings/src/main.rs
@@ -79,12 +79,7 @@ fn main() -> std::io::Result<()> {
         tokens += &bindgen::define(gen, name);
     }
 
-    let path = std::path::Path::new("crates/libs/windows/src/core/bindings.rs");
-    std::fs::write(&path, tokens)?;
-
-    let mut cmd = ::std::process::Command::new("rustfmt");
-    cmd.arg(&path);
-    cmd.output()?;
-
+    lib::rustfmt("bindings.rs", &mut tokens);
+    std::fs::write("crates/libs/windows/src/core/bindings.rs", tokens)?;
     Ok(())
 }

--- a/crates/tools/gnu/Cargo.toml
+++ b/crates/tools/gnu/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata" }
+lib = { package = "tool_lib", path = "../lib" }

--- a/crates/tools/gnu/src/main.rs
+++ b/crates/tools/gnu/src/main.rs
@@ -25,23 +25,7 @@ fn main() {
 
     println!("Platform: {}", platform);
 
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
-    let reader = &metadata::reader::Reader::new(&files);
-
-    let mut libraries = BTreeMap::<String, BTreeMap<String, usize>>::new();
-    let root = reader.tree("Windows.Win32", &[]).expect("`Windows` namespace not found");
-    for tree in root.flatten() {
-        if let Some(apis) = reader.get(metadata::reader::TypeName::new(tree.namespace, "Apis")).next() {
-            for method in reader.type_def_methods(apis) {
-                let impl_map = reader.method_def_impl_map(method).expect("ImplMap not found");
-                let scope = reader.impl_map_scope(impl_map);
-                let library = reader.module_ref_name(scope).to_lowercase();
-                let params = reader.method_def_size(method);
-                libraries.entry(library).or_default().insert(reader.method_def_name(method).to_string(), params);
-            }
-        }
-    }
-
+    let libraries = lib::libraries();
     let output = std::path::PathBuf::from(format!("crates/targets/{}/lib", platform));
     let _ = std::fs::remove_dir_all(&output);
     std::fs::create_dir_all(&output).unwrap();

--- a/crates/tools/lib/Cargo.toml
+++ b/crates/tools/lib/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
-name = "tool_bindings"
+name = "tool_lib"
 version = "0.0.0"
 edition = "2018"
 publish = false
 
 [dependencies]
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen" }
-lib = { package = "tool_lib", path = "../lib" }

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -1,0 +1,39 @@
+use std::collections::*;
+use std::io::*;
+
+/// Formats the token string.
+pub fn rustfmt(name: &str, tokens: &mut String) {
+    let mut child = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn().expect("Failed to spawn `rustfmt`");
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+    stdin.write_all(tokens.as_bytes()).unwrap();
+    drop(stdin);
+    let output = child.wait_with_output().unwrap();
+
+    if output.status.success() {
+        *tokens = String::from_utf8(output.stdout).expect("Failed to parse UTF-8");
+    } else {
+        println!("rustfmt failed: `{}`", name);
+    }
+}
+
+/// Returns the libraries and their function and stack sizes used by the gnu and msvc tools to build the umbrella libs.
+pub fn libraries() -> BTreeMap<String, BTreeMap<String, usize>> {
+    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
+    let reader = &metadata::reader::Reader::new(&files);
+    let mut libraries = BTreeMap::<String, BTreeMap<String, usize>>::new();
+    let root = reader.tree("Windows.Win32", &[]).expect("`Windows` namespace not found");
+
+    for tree in root.flatten() {
+        if let Some(apis) = reader.get(metadata::reader::TypeName::new(tree.namespace, "Apis")).next() {
+            for method in reader.type_def_methods(apis) {
+                let impl_map = reader.method_def_impl_map(method).expect("ImplMap not found");
+                let scope = reader.impl_map_scope(impl_map);
+                let library = reader.module_ref_name(scope).to_lowercase();
+                let params = reader.method_def_size(method);
+                libraries.entry(library).or_default().insert(reader.method_def_name(method).to_string(), params);
+            }
+        }
+    }
+
+    libraries
+}

--- a/crates/tools/msvc/Cargo.toml
+++ b/crates/tools/msvc/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata" }
+lib = { package = "tool_lib", path = "../lib" }

--- a/crates/tools/msvc/src/main.rs
+++ b/crates/tools/msvc/src/main.rs
@@ -17,23 +17,7 @@ fn main() {
         return;
     };
 
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
-    let reader = &metadata::reader::Reader::new(&files);
-
-    let mut libraries = BTreeMap::<String, BTreeMap<String, usize>>::new();
-    let root = reader.tree("Windows.Win32", &[]).expect("`Windows` namespace not found");
-    for tree in root.flatten() {
-        if let Some(apis) = reader.get(metadata::reader::TypeName::new(tree.namespace, "Apis")).next() {
-            for method in reader.type_def_methods(apis) {
-                let impl_map = reader.method_def_impl_map(method).expect("ImplMap not found");
-                let scope = reader.impl_map_scope(impl_map);
-                let library = reader.module_ref_name(scope).to_lowercase();
-                let params = reader.method_def_size(method);
-                libraries.entry(library).or_default().insert(reader.method_def_name(method).to_string(), params);
-            }
-        }
-    }
-
+    let libraries = lib::libraries();
     let output = std::path::PathBuf::from(format!("crates/targets/{}/lib", platform));
     let _ = std::fs::remove_dir_all(&output);
     std::fs::create_dir_all(&output).unwrap();

--- a/crates/tools/sys/Cargo.toml
+++ b/crates/tools/sys/Cargo.toml
@@ -7,4 +7,5 @@ publish = false
 [dependencies]
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }
 bindgen = { package = "windows-bindgen", path = "../../libs/bindgen" }
+lib = { package = "tool_lib", path = "../lib" }
 rayon = "1.5.1"

--- a/crates/tools/windows/Cargo.toml
+++ b/crates/tools/windows/Cargo.toml
@@ -7,4 +7,5 @@ publish = false
 [dependencies]
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }
 bindgen = { package = "windows-bindgen", path = "../../libs/bindgen" }
+lib = { package = "tool_lib", path = "../lib" }
 rayon = "1.5.1"

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -113,24 +113,10 @@ fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &
     gen.min_xaml = true;
     let mut tokens = bindgen::namespace(&gen, tree);
     tokens.push_str(r#"#[cfg(feature = "implement")] ::core::include!("impl.rs");"#);
-    fmt_tokens(tree.namespace, &mut tokens);
+    lib::rustfmt(tree.namespace, &mut tokens);
     std::fs::write(path.join("mod.rs"), tokens).unwrap();
 
     let mut tokens = bindgen::namespace_impl(&gen, tree);
-    fmt_tokens(tree.namespace, &mut tokens);
+    lib::rustfmt(tree.namespace, &mut tokens);
     std::fs::write(path.join("impl.rs"), tokens).unwrap();
-}
-
-fn fmt_tokens(namespace: &str, tokens: &mut String) {
-    let mut child = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn().expect("Failed to spawn `rustfmt`");
-    let mut stdin = child.stdin.take().expect("Failed to open stdin");
-    stdin.write_all(tokens.as_bytes()).unwrap();
-    drop(stdin);
-    let output = child.wait_with_output().unwrap();
-
-    if output.status.success() {
-        *tokens = String::from_utf8(output.stdout).expect("Failed to parse UTF-8");
-    } else {
-        println!("** {} - rustfmt failed", namespace);
-    }
 }


### PR DESCRIPTION
This just avoids a bunch of duplicate code across the various internal tools. 