### PR TITLE
Remove orphaned "alloc" feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -85,7 +85,6 @@ body:
         [dependencies.windows]
         version = "0.38.0"
         features = [
-            "alloc",
             "Win32_Foundation",
             "Win32_UI_WindowsAndMessaging",
         ]

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -52,7 +52,6 @@ windows-interface = { path = "../interface",  version = "0.38.0", optional = tru
 [features]
 default = []
 deprecated = []
-alloc = []
 implement = ["windows-implement"]
 interface = ["windows-interface"]
 AI = []

--- a/crates/samples/com_uri/Cargo.toml
+++ b/crates/samples/com_uri/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_System_Com",
 ]

--- a/crates/samples/consent/Cargo.toml
+++ b/crates/samples/consent/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Foundation",
     "Security_Credentials_UI",
     "Win32_Foundation",

--- a/crates/samples/core_app/Cargo.toml
+++ b/crates/samples/core_app/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "implement",
     "ApplicationModel_Core",
     "UI_Core",

--- a/crates/samples/create_window/Cargo.toml
+++ b/crates/samples/create_window/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",

--- a/crates/samples/data_protection/Cargo.toml
+++ b/crates/samples/data_protection/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Foundation",
     "Storage_Streams",
     "Security_Cryptography_DataProtection",

--- a/crates/samples/direct3d12/Cargo.toml
+++ b/crates/samples/direct3d12/Cargo.toml
@@ -9,7 +9,6 @@ array-init = "2.0.0"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_Graphics_Direct3D_Fxc",
     "Win32_Graphics_Direct3D12",

--- a/crates/samples/message_box/Cargo.toml
+++ b/crates/samples/message_box/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
 ]

--- a/crates/samples/ocr/Cargo.toml
+++ b/crates/samples/ocr/Cargo.toml
@@ -9,7 +9,6 @@ futures = "0.3.5"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Media_Ocr", 
     "Graphics_Imaging", 
     "Storage_Streams", 

--- a/crates/samples/overlapped/Cargo.toml
+++ b/crates/samples/overlapped/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Storage_FileSystem",

--- a/crates/samples/rss/Cargo.toml
+++ b/crates/samples/rss/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Foundation_Collections",
     "Web_Syndication",
 ]

--- a/crates/samples/spellchecker/Cargo.toml
+++ b/crates/samples/spellchecker/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_System_Com",
     "Win32_Foundation",
     "Win32_Globalization",

--- a/crates/samples/uiautomation/Cargo.toml
+++ b/crates/samples/uiautomation/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_System_Com",
     "Win32_UI_Accessibility",

--- a/crates/samples/xml/Cargo.toml
+++ b/crates/samples/xml/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Data_Xml_Dom",
 ]

--- a/crates/tests/bstr/Cargo.toml
+++ b/crates/tests/bstr/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
 ]

--- a/crates/tests/component_client/Cargo.toml
+++ b/crates/tests/component_client/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
 ]
 

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_System_WinRT",
 ]

--- a/crates/tests/helpers/Cargo.toml
+++ b/crates/tests/helpers/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_Globalization",
 ]

--- a/crates/tests/implement/Cargo.toml
+++ b/crates/tests/implement/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "implement",
     "ApplicationModel_Activation",
     "Foundation_Collections",

--- a/crates/tests/interface/Cargo.toml
+++ b/crates/tests/interface/Cargo.toml
@@ -11,5 +11,4 @@ features = [
     "Win32_System_Com",
     "interface",
     "implement",
-    "alloc"
 ]

--- a/crates/tests/interop/Cargo.toml
+++ b/crates/tests/interop/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Foundation_Collections",
     "Win32_System_Com",
     "Win32_System_WinRT",

--- a/crates/tests/mshtml/Cargo.toml
+++ b/crates/tests/mshtml/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Web_MsHtml",
     "Win32_Foundation",
     "Win32_System_Com",

--- a/crates/tests/ntstatus/Cargo.toml
+++ b/crates/tests/ntstatus/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_Security_Cryptography",   
 ]

--- a/crates/tests/string_param/Cargo.toml
+++ b/crates/tests/string_param/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
 ]

--- a/crates/tests/vector/Cargo.toml
+++ b/crates/tests/vector/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "implement",
     "Foundation_Collections",
     "Win32_Foundation",

--- a/crates/tests/weak/Cargo.toml
+++ b/crates/tests/weak/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Foundation",
 ]

--- a/crates/tests/win32_arrays/Cargo.toml
+++ b/crates/tests/win32_arrays/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "Win32_Foundation",
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Gdi",

--- a/crates/tests/winrt/Cargo.toml
+++ b/crates/tests/winrt/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "alloc",
     "implement",
     "AI_MachineLearning",
     "Foundation_Collections",

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -77,7 +77,6 @@ windows-interface = { path = "../interface",  version = "0.38.0", optional = tru
 [features]
 default = []
 deprecated = []
-alloc = []
 implement = ["windows-implement"]
 interface = ["windows-interface"]
 "#

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -17,7 +17,6 @@ Start by adding the following to your Cargo.toml file:
 [dependencies.windows]
 version = "0.38.0"
 features = [
-    "alloc",
     "Data_Xml_Dom",
     "Win32_Foundation",
     "Win32_Security",


### PR DESCRIPTION
Cleaning up a few things after #1811 - this just removes the "alloc" feature that is no longer does anything. 