### PR TITLE
Simpler `Option` deref for `PCWSTR` and `PCSTR`

### DIFF
--- a/crates/libs/windows/src/core/pcstr.rs
+++ b/crates/libs/windows/src/core/pcstr.rs
@@ -46,6 +46,6 @@ unsafe impl Abi for PCSTR {
 // with some Windows APIs.
 impl From<Option<PCSTR>> for PCSTR {
     fn from(from: Option<PCSTR>) -> Self {
-        from.unwrap_or_else(|| Self::default())
+        from.unwrap_or_default()
     }
 }

--- a/crates/libs/windows/src/core/pcwstr.rs
+++ b/crates/libs/windows/src/core/pcwstr.rs
@@ -44,6 +44,6 @@ impl From<&HSTRING> for PCWSTR {
 // with some Windows APIs.
 impl From<Option<PCWSTR>> for PCWSTR {
     fn from(from: Option<PCWSTR>) -> Self {
-        from.unwrap_or_else(|| Self::default())
+        from.unwrap_or_default()
     }
 }


### PR DESCRIPTION
_Originally posted by @rylev in https://github.com/microsoft/windows-rs/pull/1894#discussion_r919289749_