### PR TITLE
Basic field metadata encoding

### DIFF
--- a/crates/libs/metadata/src/flags.rs
+++ b/crates/libs/metadata/src/flags.rs
@@ -17,8 +17,18 @@ pub struct PInvokeAttributes(pub usize);
 pub struct TypeAttributes(pub usize);
 
 impl FieldAttributes {
+    pub fn public(&self) -> bool {
+        self.0 & 0x6 != 0
+    }
+    pub fn set_public(&mut self) {
+        self.0 |= 0x6;
+    }
+
     pub fn literal(&self) -> bool {
         self.0 & 0x40 != 0
+    }
+    pub fn set_literal(&mut self) {
+        self.0 |= 0x40;
     }
 }
 

--- a/crates/libs/metadata/src/writer/tables/field.rs
+++ b/crates/libs/metadata/src/writer/tables/field.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[derive(Default)]
 pub struct Field {
+    pub flags: FieldAttributes,
     pub name: String,
     pub ty: Type,
     pub constant: Option<Value>,

--- a/crates/libs/metadata/src/writer/tables/mod.rs
+++ b/crates/libs/metadata/src/writer/tables/mod.rs
@@ -105,7 +105,7 @@ impl Tables {
         }
 
         for field in &self.field {
-            buffer.write(&0u16); // Flags
+            buffer.write(&(field.flags.0 as u16));
             buffer.write(&strings.insert(&field.name));
             buffer.write(&blobs.insert(&field.ty.to_field_sig()));
         }

--- a/crates/tests/metadata/tests/writer.rs
+++ b/crates/tests/metadata/tests/writer.rs
@@ -22,7 +22,10 @@ fn writer() {
         def.flags.set_public();
         def.flags.set_winrt();
         def.extends = Some(TypeRef::system_value_type());
-        def.field_list.push(Field::new("Height"));
+        let mut field = Field::new("X");
+        field.ty = Type::F32;
+        field.flags.set_public();
+        def.field_list.push(field);
         tables.type_def.push(def);
 
         let mut def = TypeDef::new(TypeName::new("TestWindows.Foundation", "AsyncStatus"));
@@ -37,7 +40,7 @@ fn writer() {
     {
         use metadata::reader::*;
 
-        let files = vec![File::new(temp_file.to_str().unwrap()).unwrap()];
+        let files = vec![File::new(temp_file.to_str().unwrap()).unwrap(), File::new("../../libs/metadata/default/Windows.winmd").unwrap()];
         let reader = &Reader::new(&files);
         let def = reader.get(TypeName::new("TestWindows.Foundation", "IStringable")).next().unwrap();
         assert_eq!(reader.type_def_kind(def), TypeKind::Interface);
@@ -55,7 +58,8 @@ fn writer() {
         assert!(reader.type_def_flags(def).winrt());
 
         let field = reader.type_def_fields(def).next().unwrap();
-        assert_eq!(reader.field_name(field), "Height");
+        assert_eq!(reader.field_name(field), "X");
+        assert!(reader.field_type(field, None) == Type::F32);
 
         let def = reader.get(TypeName::new("TestWindows.Foundation", "AsyncStatus")).next().unwrap();
         assert_eq!(reader.type_def_kind(def), TypeKind::Enum);

--- a/crates/tests/metadata/tests/writer.rs
+++ b/crates/tests/metadata/tests/writer.rs
@@ -26,6 +26,18 @@ fn writer() {
         field.ty = Type::F32;
         field.flags.set_public();
         def.field_list.push(field);
+        let mut field = Field::new("Y");
+        field.ty = Type::F32;
+        field.flags.set_public();
+        def.field_list.push(field);
+        let mut field = Field::new("Width");
+        field.ty = Type::F32;
+        field.flags.set_public();
+        def.field_list.push(field);
+        let mut field = Field::new("Height");
+        field.ty = Type::F32;
+        field.flags.set_public();
+        def.field_list.push(field);
         tables.type_def.push(def);
 
         let mut def = TypeDef::new(TypeName::new("TestWindows.Foundation", "AsyncStatus"));
@@ -57,9 +69,23 @@ fn writer() {
         assert_eq!(reader.type_def_kind(def), TypeKind::Struct);
         assert!(reader.type_def_flags(def).winrt());
 
-        let field = reader.type_def_fields(def).next().unwrap();
+        let mut fields = reader.type_def_fields(def);
+        let field = fields.next().unwrap();
         assert_eq!(reader.field_name(field), "X");
         assert!(reader.field_type(field, None) == Type::F32);
+        assert!(reader.field_flags(field).public());
+        let field = fields.next().unwrap();
+        assert_eq!(reader.field_name(field), "Y");
+        assert!(reader.field_type(field, None) == Type::F32);
+        assert!(reader.field_flags(field).public());
+        let field = fields.next().unwrap();
+        assert_eq!(reader.field_name(field), "Width");
+        assert!(reader.field_type(field, None) == Type::F32);
+        assert!(reader.field_flags(field).public());
+        let field = fields.next().unwrap();
+        assert_eq!(reader.field_name(field), "Height");
+        assert!(reader.field_type(field, None) == Type::F32);
+        assert!(reader.field_flags(field).public());
 
         let def = reader.get(TypeName::new("TestWindows.Foundation", "AsyncStatus")).next().unwrap();
         assert_eq!(reader.type_def_kind(def), TypeKind::Enum);


### PR DESCRIPTION
Continuing on with the ECMA-335 writer support, this update just allows primitive fields to be properly encoded. 