### PR TITLE
Replace unsafe `strlen` usage in metadata library with safe Rust

### DIFF
--- a/crates/libs/metadata/src/imp.rs
+++ b/crates/libs/metadata/src/imp.rs
@@ -13,10 +13,6 @@ pub struct METADATA_HEADER {
 
 pub const METADATA_SIGNATURE: u32 = 0x424A_5342;
 
-extern "C" {
-    pub fn strlen(cs: *const u8) -> usize;
-}
-
 /// A coded index (see codes.rs) is a table index that may refer to different tables. The size of the column in memory
 /// must therefore be large enough to hold an index for a row in the largest possible table. This function determines
 /// this size for the given winmd file.

--- a/crates/libs/metadata/src/reader/file.rs
+++ b/crates/libs/metadata/src/reader/file.rs
@@ -333,13 +333,21 @@ impl File {
         }
     }
 
+    /// Returns the string from the `#Strings` stream as referenced by
+    /// the (table, row, column) triple.
+    ///
+    /// # Panics
+    ///
+    /// * When any element of the (table, row, column) triple is invalid.
+    /// * When the offset in the string table is out of bounds.
+    /// * When no null terminator can be found in the string table.
+    /// * When the null-terminated string is not valid utf-8.
     pub fn str(&self, row: usize, table: usize, column: usize) -> &str {
         let offset = self.strings + self.usize(row, table, column);
 
-        unsafe {
-            let len = strlen(self.bytes.as_ptr().add(offset));
-            std::str::from_utf8_unchecked(&self.bytes[offset..offset + len])
-        }
+        let bytes = &self.bytes[offset..];
+        let nul_pos = bytes.iter().position(|&c| c == 0).expect("expected null-terminated C-string");
+        std::str::from_utf8(&bytes[..nul_pos]).expect("expected valid utf-8 C-string")
     }
 
     pub fn blob(&self, row: usize, table: usize, column: usize) -> &[u8] {


### PR DESCRIPTION
Removes the `unsafe` usage of C strlen and unchecked utf8 decoding
from `File::str`, replacing it with safe (but panicing) Rust code.
This also documents the method at the same time.

This pulls in the `memchr` crate, and uses almost the same code as the nightly-only `CStr::from_bytes_until_nul`.

Not sure this subcrate by itself has any tests? So I’m not 100% confident of this change due to the lack of tests?