### PR TITLE
Declare `rust-version` for `windows-interface` crate

### DIFF
--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Microsoft"]
 license = "MIT OR Apache-2.0"
 description = "The interface macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
+rust-version = "1.61"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
Both `windows-interface` and `windows-implement` crates require Rust 1.61 - the `rust-version` was just missing from the `windows-interface` crate.