### PR TITLE
Adding documentation for factory

### DIFF
--- a/crates/libs/windows/src/core/factory_cache.rs
+++ b/crates/libs/windows/src/core/factory_cache.rs
@@ -47,7 +47,8 @@ impl<C: RuntimeName, I: Interface> FactoryCache<C, I> {
 // This is safe because `FactoryCache` only holds agile factory pointers, which are safe to cache and share between threads.
 unsafe impl<C, I> ::core::marker::Sync for FactoryCache<C, I> {}
 
-/// Attempts to load the factory interface for the given WinRT class
+/// Attempts to load the factory object for the given WinRT class. 
+/// This can be used to access COM interfaces implemented on a Windows Runtime class factory. 
 pub fn factory<C: RuntimeName, I: Interface>() -> Result<I> {
     let mut factory: Option<I> = None;
     let name = HSTRING::from(C::NAME);

--- a/crates/libs/windows/src/core/factory_cache.rs
+++ b/crates/libs/windows/src/core/factory_cache.rs
@@ -47,8 +47,8 @@ impl<C: RuntimeName, I: Interface> FactoryCache<C, I> {
 // This is safe because `FactoryCache` only holds agile factory pointers, which are safe to cache and share between threads.
 unsafe impl<C, I> ::core::marker::Sync for FactoryCache<C, I> {}
 
-/// Attempts to load the factory object for the given WinRT class. 
-/// This can be used to access COM interfaces implemented on a Windows Runtime class factory. 
+/// Attempts to load the factory object for the given WinRT class.
+/// This can be used to access COM interfaces implemented on a Windows Runtime class factory.
 pub fn factory<C: RuntimeName, I: Interface>() -> Result<I> {
     let mut factory: Option<I> = None;
     let name = HSTRING::from(C::NAME);

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -38,7 +38,6 @@ pub use compose::*;
 pub(crate) use delay_load::*;
 pub use error::*;
 pub use event::*;
-#[doc(hidden)]
 pub use factory_cache::*;
 #[doc(hidden)]
 pub use generic_factory::*;


### PR DESCRIPTION
This pull request updates the factory function to be included in the documentation set, since it's useful for accessing WinRT interop interfaces implemented on activation factory objects.

Fixes #1733 