### PR TITLE
Used std::ptr::null() instead of None in readme

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     assert!(root.InnerText()? == "hello world");
 
     unsafe {
-        let event = CreateEventW(None, true, false, None)?;
+        let event = CreateEventW(std::ptr::null(), true, false, None)?;
         SetEvent(event).ok()?;
         WaitForSingleObject(event, 0);
         CloseHandle(event).ok()?;


### PR DESCRIPTION
The current example in the readme produces a mismatched type error in which CreateEventW is expecting either a *const SECURITY_ATTRIBUTES or null. The error is corrected by replacing None in the example with std::ptr::null().