### PR TITLE
Remove unnecessary parentheses

### DIFF
--- a/crates/libs/metadata/src/reader/codes.rs
+++ b/crates/libs/metadata/src/reader/codes.rs
@@ -33,7 +33,7 @@ pub enum HasAttribute {
 impl HasAttribute {
     pub fn encode(&self) -> usize {
         (match self {
-            Self::MethodDef(row) => ((row.0.row + 1) << 5),
+            Self::MethodDef(row) => (row.0.row + 1) << 5,
             Self::Field(row) => ((row.0.row + 1) << 5) | 1,
             Self::TypeRef(row) => ((row.0.row + 1) << 5) | 2,
             Self::TypeDef(row) => ((row.0.row + 1) << 5) | 3,
@@ -54,7 +54,7 @@ pub enum HasConstant {
 impl HasConstant {
     pub fn encode(&self) -> usize {
         (match self {
-            Self::Field(row) => ((row.0.row + 1) << 2),
+            Self::Field(row) => (row.0.row + 1) << 2,
         }) as _
     }
 }
@@ -116,7 +116,7 @@ pub enum TypeOrMethodDef {
 impl TypeOrMethodDef {
     pub fn encode(&self) -> usize {
         (match self {
-            Self::TypeDef(value) => ((value.0.row + 1) << 1),
+            Self::TypeDef(value) => (value.0.row + 1) << 1,
         }) as _
     }
 }

--- a/crates/libs/metadata/src/writer/codes.rs
+++ b/crates/libs/metadata/src/writer/codes.rs
@@ -11,7 +11,7 @@ pub enum ResolutionScope {
 impl ResolutionScope {
     pub fn encode(&self) -> usize {
         match self {
-            Self::Module(row) => ((row + 1) << 2),
+            Self::Module(row) => (row + 1) << 2,
             Self::ModuleRef(row) => ((row + 1) << 2) + 1,
             Self::AssemblyRef(row) => ((row + 1) << 2) + 2,
             Self::TypeRef(row) => ((row + 1) << 2) + 3,
@@ -38,7 +38,7 @@ pub enum TypeDefOrRef {
 impl TypeDefOrRef {
     pub fn encode(&self) -> usize {
         match self {
-            Self::TypeDef(row) => ((row + 1) << 2),
+            Self::TypeDef(row) => (row + 1) << 2,
             Self::TypeRef(row) => ((row + 1) << 2) + 1,
             Self::TypeSpec(row) => ((row + 1) << 2) + 2,
             _ => 0,
@@ -64,7 +64,7 @@ pub enum HasConstant {
 impl HasConstant {
     pub fn encode(&self) -> usize {
         match self {
-            Self::Field(row) => ((row + 1) << 2),
+            Self::Field(row) => (row + 1) << 2,
             Self::Param(row) => ((row + 1) << 2) + 1,
             Self::Property(row) => ((row + 1) << 2) + 2,
             _ => 0,


### PR DESCRIPTION
Satisfies clippy errors now appearing in build runs (e.g. https://github.com/microsoft/windows-rs/runs/7684977188).