### PR TITLE
Remove unused binding

### DIFF
--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -1363,17 +1363,6 @@ unsafe impl ::windows::core::Abi for HINSTANCE {
 }
 pub const S_OK: ::windows::core::HRESULT = ::windows::core::HRESULT(0i32);
 #[inline]
-pub unsafe fn SysAllocStringByteLen<'a, P0>(psz: P0, len: u32) -> BSTR
-where
-    P0: ::std::convert::Into<::windows::core::PCSTR>,
-{
-    #[cfg_attr(windows, link(name = "windows"))]
-    extern "system" {
-        fn SysAllocStringByteLen(psz: ::windows::core::PCSTR, len: u32) -> BSTR;
-    }
-    SysAllocStringByteLen(psz.into(), len)
-}
-#[inline]
 pub unsafe fn SysAllocStringLen(strin: ::core::option::Option<&[u16]>) -> BSTR {
     #[cfg_attr(windows, link(name = "windows"))]
     extern "system" {

--- a/crates/tools/bindings/src/main.rs
+++ b/crates/tools/bindings/src/main.rs
@@ -25,7 +25,6 @@ fn main() -> std::io::Result<()> {
         "Windows.Win32.Foundation.HANDLE",
         "Windows.Win32.Foundation.HINSTANCE",
         "Windows.Win32.Foundation.S_OK",
-        "Windows.Win32.Foundation.SysAllocStringByteLen",
         "Windows.Win32.Foundation.SysAllocStringLen",
         "Windows.Win32.Foundation.SysFreeString",
         "Windows.Win32.Foundation.SysStringLen",


### PR DESCRIPTION
The `SysAllocStringByteLen` function is no longer used by the `windows` crate implementation. 