### PR TITLE
Add samples readme

### DIFF
--- a/crates/samples/readme.md
+++ b/crates/samples/readme.md
@@ -1,0 +1,6 @@
+The samples in the repo compile with the latest, usually pre-release, version of the `windows` or `windows-sys` crate. 
+To find the samples for a particular release you can use a specific release tag. For example:
+
+https://github.com/microsoft/windows-rs/tree/0.39.0
+
+That will give you the samples that compile with version 0.39 of the windows crate.


### PR DESCRIPTION
This adds a brief explanation for how to find the correct samples for a given release of the `windows` and `windows-sys` crates. 

Fixes: #1977
