### PR TITLE
Implement `Debug` for `AgileReference`

### DIFF
--- a/crates/libs/windows/src/core/agile_reference.rs
+++ b/crates/libs/windows/src/core/agile_reference.rs
@@ -22,3 +22,9 @@ impl<T: Interface> AgileReference<T> {
 
 unsafe impl<T: Interface> Send for AgileReference<T> {}
 unsafe impl<T: Interface> Sync for AgileReference<T> {}
+
+impl<T> std::fmt::Debug for AgileReference<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AgileReference({:?})", <&IAgileReference as Into<&IUnknown>>::into(&self.0))
+    }
+}

--- a/crates/tests/agile_reference/tests/tests.rs
+++ b/crates/tests/agile_reference/tests/tests.rs
@@ -1,8 +1,9 @@
-use windows::core::{AgileReference, Result};
+use windows::core::{w, AgileReference, Result};
+use windows::Foundation::Uri;
 use windows::Media::Control::GlobalSystemMediaTransportControlsSessionManager;
 
 #[test]
-fn test() -> Result<()> {
+fn agile_send() -> Result<()> {
     let manager = GlobalSystemMediaTransportControlsSessionManager::RequestAsync()?.get()?;
     let reference = AgileReference::new(&manager)?;
 
@@ -13,4 +14,12 @@ fn test() -> Result<()> {
         Ok(())
     });
     handle.join().unwrap()
+}
+
+#[test]
+fn agile_debug() -> Result<()> {
+    let uri = Uri::CreateUri(w!("http://kennykerr.ca"))?;
+    let reference = AgileReference::new(&uri)?;
+    assert!(format!("{:?}", reference).starts_with("AgileReference(IUnknown(0x"));
+    Ok(())
 }

--- a/crates/tests/agile_reference/tests/tests.rs
+++ b/crates/tests/agile_reference/tests/tests.rs
@@ -19,6 +19,8 @@ fn agile_send() -> Result<()> {
 #[test]
 fn agile_debug() -> Result<()> {
     let uri = Uri::CreateUri(w!("http://kennykerr.ca"))?;
+    assert!(format!("{:?}", uri).starts_with("Uri(IUnknown(0x"));
+
     let reference = AgileReference::new(&uri)?;
     assert!(format!("{:?}", reference).starts_with("AgileReference(IUnknown(0x"));
     Ok(())


### PR DESCRIPTION
This just provides a basic `Debug` implementation that ensures the formatting is similar to that of other `IUnknown` based values.

Fixes: #1982
