### PR TITLE
Update min rust version for `windows-sys` to 1.49

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     name: Check windows-sys
     strategy:
       matrix:
-        rust: [1.46.0, stable, nightly]
+        rust: [1.49.0, stable, nightly]
         runs-on:
           - windows-2019
           - ubuntu-latest

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "../../../docs/readme.md"
-rust-version = "1.46"
+rust-version = "1.49"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -48,7 +48,7 @@ license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "../../../docs/readme.md"
-rust-version = "1.46"
+rust-version = "1.49"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -187,7 +187,7 @@ jobs:
     name: Check windows-sys
     strategy:
       matrix:
-        rust: [1.46.0, stable, nightly]
+        rust: [1.49.0, stable, nightly]
         runs-on:
           - windows-2019
           - ubuntu-latest


### PR DESCRIPTION
This update just bumps the minimum supported Rust version for the `windows-sys` crate from 1.46 to 1.49 to pick up some Cargo fixes needed to simplify the build, like the issue encountered in #1980. I chose 1.49 as that version has already been picked as the min version for the prominent `parking_lot` crate that depends on the `windows-sys` crate so should be broadly adopted. 