### PR TITLE
Update the faq to call out `no_std` support

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -7,6 +7,7 @@
 | Reason | `windows` | `windows-sys`|
 | --- | --- | --- |
 | Fast compile times are one of your top concerns | | ✅ |
+| You need `no_std` support | | ✅ |
 | You need COM or WinRT support | ✅ | |
 | You would prefer to use APIs that feel idiomatic to Rust | ✅ | |
 


### PR DESCRIPTION
Clarifies that the `windows-sys` crate offers no_std support. 

Related: #1989