### PR TITLE
Remove unused `bindgen` options

### DIFF
--- a/crates/libs/bindgen/src/classes.rs
+++ b/crates/libs/bindgen/src/classes.rs
@@ -32,10 +32,6 @@ fn gen_class(gen: &Gen, def: TypeDef) -> TokenStream {
 
     for interface in &interfaces {
         if let Type::TypeDef((def, generics)) = &interface.ty {
-            if gen.min_xaml && interface.kind == InterfaceKind::Base && gen.namespace.starts_with("Windows.UI.Xaml") && !gen.reader.type_def_namespace(*def).starts_with("Windows.Foundation") {
-                continue;
-            }
-
             let mut virtual_names = MethodNames::new();
 
             for method in gen.reader.type_def_methods(*def) {

--- a/crates/libs/bindgen/src/enums.rs
+++ b/crates/libs/bindgen/src/enums.rs
@@ -10,7 +10,7 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
     let doc = gen.cfg_doc(&cfg);
     let features = gen.cfg_features(&cfg);
 
-    let mut fields: Vec<(TokenStream, TokenStream)> = gen
+    let fields: Vec<(TokenStream, TokenStream)> = gen
         .reader
         .type_def_fields(def)
         .filter_map(|field| {
@@ -25,10 +25,6 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
             }
         })
         .collect();
-
-    if gen.min_enum && fields.len() > 100 {
-        fields.clear();
-    }
 
     let eq = if gen.sys {
         quote! {}

--- a/crates/libs/bindgen/src/interfaces.rs
+++ b/crates/libs/bindgen/src/interfaces.rs
@@ -85,12 +85,10 @@ fn gen_methods(gen: &Gen, def: TypeDef, generics: &[Type], interfaces: &[Interfa
         for method in gen.reader.type_def_methods(def) {
             methods.combine(&winrt_methods::gen(gen, def, generics, InterfaceKind::Default, method, method_names, virtual_names));
         }
-        if !gen.min_inherit {
-            for interface in interfaces {
-                if let Type::TypeDef((def, generics)) = &interface.ty {
-                    for method in gen.reader.type_def_methods(*def) {
-                        methods.combine(&winrt_methods::gen(gen, *def, generics, InterfaceKind::None, method, method_names, virtual_names));
-                    }
+        for interface in interfaces {
+            if let Type::TypeDef((def, generics)) = &interface.ty {
+                for method in gen.reader.type_def_methods(*def) {
+                    methods.combine(&winrt_methods::gen(gen, *def, generics, InterfaceKind::None, method, method_names, virtual_names));
                 }
             }
         }

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -130,7 +130,6 @@ fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &
     gen.namespace = tree.namespace;
     gen.cfg = true;
     gen.doc = true;
-    gen.min_xaml = true;
     let mut tokens = bindgen::namespace(&gen, tree);
     tokens.push_str(r#"#[cfg(feature = "implement")] ::core::include!("impl.rs");"#);
     lib::format(tree.namespace, &mut tokens, rustfmt);


### PR DESCRIPTION
These options were used by the internal bindings as well as Xaml code generation and are no longer needed. 