### PR TITLE
Remove workaround for `GUID` constants

### DIFF
--- a/crates/libs/bindgen/src/structs.rs
+++ b/crates/libs/bindgen/src/structs.rs
@@ -22,11 +22,7 @@ fn gen_struct_with_name(gen: &Gen, def: TypeDef, struct_name: &str, cfg: &Cfg) -
     let name = to_ident(struct_name);
 
     if gen.reader.type_def_fields(def).next().is_none() {
-        if let Some(guid) = gen.reader.type_def_guid(def) {
-            let value = gen.guid(&guid);
-            let guid = gen.type_name(&Type::GUID);
-            return quote! { pub const #name: #guid = #value; };
-        } else if name.as_str().ends_with("Vtbl") {
+        if name.as_str().ends_with("Vtbl") {
             // This just omits some useless struct declarations like `IDDVideoPortContainerVtbl`
             return quote! {};
         } else {


### PR DESCRIPTION
Now that https://github.com/microsoft/win32metadata/pull/1204 has been fixed, we no longer need this workaround to harmonize `GUID` constants.