### PR TITLE
Adds `unsafe` helpers to cast from C++ or raw `IUnknown` pointers to Rust `IUnknown` values

### DIFF
--- a/crates/libs/windows/src/core/interface.rs
+++ b/crates/libs/windows/src/core/interface.rs
@@ -48,6 +48,26 @@ pub unsafe trait Interface: Sized {
         raw
     }
 
+    /// Creates an `Interface` by taking ownership of the `raw` COM interface pointer.
+    ///
+    /// # Safety
+    ///
+    /// The `raw` pointer must be owned by the caller and represent a valid COM interface pointer. In other words,
+    /// it must point to a vtable beginning with the `IUnknown` function pointers and match the vtable of `Interface`.
+    unsafe fn from_raw(raw: *mut core::ffi::c_void) -> Self {
+        std::mem::transmute_copy(&raw)
+    }
+
+    /// Creates an `Interface` that is valid so long as the `raw` COM interface pointer is valid.
+    ///
+    /// # Safety
+    ///
+    /// The `raw` pointer must be a valid COM interface pointer. In other words, it must point to a vtable
+    /// beginning with the `IUnknown` function pointers and match the vtable of `Interface`.
+    unsafe fn from_raw_borrowed<'a>(raw: &'a *mut core::ffi::c_void) -> &'a Self {
+        std::mem::transmute_copy(&raw)
+    }
+
     /// Attempts to create a [`Weak`] reference to this object.
     fn downgrade(&self) -> Result<Weak<Self>> {
         self.cast::<IWeakReferenceSource>().and_then(|source| Weak::downgrade(&source))

--- a/crates/libs/windows/src/core/interface.rs
+++ b/crates/libs/windows/src/core/interface.rs
@@ -33,11 +33,19 @@ pub unsafe trait Interface: Sized {
         unsafe { self.query(&T::IID, &mut result as *mut _ as _).and_some(result) }
     }
 
-    /// Turn this interface into a raw pointer
+    /// Returns the raw COM interface pointer. The resulting pointer continues to be owned by the `Interface` implementation.
     #[inline(always)]
     fn as_raw(&self) -> *mut core::ffi::c_void {
         // SAFETY: implementors of this trait must guarantee that the implementing type has a pointer in-memory representation
         unsafe { core::mem::transmute_copy(self) }
+    }
+
+    /// Returns the raw COM interface pointer and releases ownership. It the caller's responsibility to release the COM interface pointer.
+    fn into_raw(self) -> *mut core::ffi::c_void {
+        // SAFETY: implementors of this trait must guarantee that the implementing type has a pointer in-memory representation
+        let raw = self.as_raw();
+        std::mem::forget(self);
+        raw
     }
 
     /// Attempts to create a [`Weak`] reference to this object.

--- a/crates/libs/windows/src/core/unknown.rs
+++ b/crates/libs/windows/src/core/unknown.rs
@@ -7,6 +7,18 @@ use super::*;
 #[repr(transparent)]
 pub struct IUnknown(core::ptr::NonNull<core::ffi::c_void>);
 
+impl IUnknown {
+    /// Creates an `IUnknown` value by taking ownership of the `raw` pointer.
+    pub unsafe fn from_raw_owned(raw: *mut core::ffi::c_void) -> Self {
+        std::mem::transmute(raw)
+    }
+
+    /// Creates a borrowed `IUnknown` that is valid so long as the `raw` pointer is valid.
+    pub unsafe fn from_raw_borrowed<'a>(raw: &'a *mut core::ffi::c_void) -> &'a Self {
+        std::mem::transmute(raw)
+    }
+}
+
 #[doc(hidden)]
 #[repr(C)]
 pub struct IUnknownVtbl {

--- a/crates/libs/windows/src/core/unknown.rs
+++ b/crates/libs/windows/src/core/unknown.rs
@@ -8,12 +8,22 @@ use super::*;
 pub struct IUnknown(core::ptr::NonNull<core::ffi::c_void>);
 
 impl IUnknown {
-    /// Creates an `IUnknown` value by taking ownership of the `raw` pointer.
-    pub unsafe fn from_raw_owned(raw: *mut core::ffi::c_void) -> Self {
+    /// Creates an `IUnknown` value by taking ownership of the `raw` COM interface pointer.
+    ///
+    /// # Safety
+    ///
+    /// The `raw` pointer must be owned by the caller and represent a valid COM interface pointer. In other words,
+    /// it must point to a vtable beginning with the `IUnknown` function pointers.
+    pub unsafe fn from_raw(raw: *mut core::ffi::c_void) -> Self {
         std::mem::transmute(raw)
     }
 
-    /// Creates a borrowed `IUnknown` that is valid so long as the `raw` pointer is valid.
+    /// Creates a borrowed `IUnknown` that is valid so long as the `raw` COM interface pointer is valid.
+    ///
+    /// # Safety
+    ///
+    /// The `raw` pointer must be a valid COM interface pointer. In other words, it must point to a vtable
+    /// beginning with the `IUnknown` function pointers.
     pub unsafe fn from_raw_borrowed<'a>(raw: &'a *mut core::ffi::c_void) -> &'a Self {
         std::mem::transmute(raw)
     }

--- a/crates/libs/windows/src/core/unknown.rs
+++ b/crates/libs/windows/src/core/unknown.rs
@@ -7,28 +7,6 @@ use super::*;
 #[repr(transparent)]
 pub struct IUnknown(core::ptr::NonNull<core::ffi::c_void>);
 
-impl IUnknown {
-    /// Creates an `IUnknown` value by taking ownership of the `raw` COM interface pointer.
-    ///
-    /// # Safety
-    ///
-    /// The `raw` pointer must be owned by the caller and represent a valid COM interface pointer. In other words,
-    /// it must point to a vtable beginning with the `IUnknown` function pointers.
-    pub unsafe fn from_raw(raw: *mut core::ffi::c_void) -> Self {
-        std::mem::transmute(raw)
-    }
-
-    /// Creates a borrowed `IUnknown` that is valid so long as the `raw` COM interface pointer is valid.
-    ///
-    /// # Safety
-    ///
-    /// The `raw` pointer must be a valid COM interface pointer. In other words, it must point to a vtable
-    /// beginning with the `IUnknown` function pointers.
-    pub unsafe fn from_raw_borrowed<'a>(raw: &'a *mut core::ffi::c_void) -> &'a Self {
-        std::mem::transmute(raw)
-    }
-}
-
 #[doc(hidden)]
 #[repr(C)]
 pub struct IUnknownVtbl {

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
+    "implement",
+    "interface",
     "Win32_Foundation",
     "Win32_System_WinRT",
 ]

--- a/crates/tests/core/tests/unknown.rs
+++ b/crates/tests/core/tests/unknown.rs
@@ -1,0 +1,54 @@
+#![allow(non_snake_case)]
+
+use windows::core::*;
+
+#[interface("f7ea748b-8121-41c1-aaee-406ba6f148a9")]
+unsafe trait ITest: IUnknown {
+    unsafe fn Test(&self) -> u32;
+}
+
+#[implement(ITest)]
+struct Test {
+    drop: *mut u32,
+}
+
+impl ITest_Impl for Test {
+    unsafe fn Test(&self) -> u32 {
+        *self.drop
+    }
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        unsafe {
+            *self.drop += 1;
+        }
+    }
+}
+
+#[test]
+fn test() {
+    unsafe {
+        let mut dropped = 0;
+        let test: ITest = Test { drop: &mut dropped }.into();
+
+        {
+            let raw_borrowed: *mut std::ffi::c_void = test.as_raw();
+            let unknown_borrowed: &IUnknown = IUnknown::from_raw_borrowed(&raw_borrowed);
+            assert_eq!(unknown_borrowed.as_raw(), test.as_raw());
+            let test_query: ITest = unknown_borrowed.cast().unwrap();
+            assert_eq!(test_query.Test(), 0);
+        }
+        {
+            let raw_owned: *mut std::ffi::c_void = std::mem::transmute(test.clone());
+            let unknown_owned: IUnknown = IUnknown::from_raw_owned(raw_owned);
+            assert_eq!(unknown_owned.as_raw(), test.as_raw());
+            let test_query: ITest = unknown_owned.cast().unwrap();
+            assert_eq!(test_query.Test(), 0);
+        }
+
+        assert_eq!(test.Test(), 0);
+        drop(test);
+        assert_eq!(dropped, 1);
+    }
+}

--- a/crates/tests/core/tests/unknown.rs
+++ b/crates/tests/core/tests/unknown.rs
@@ -40,8 +40,8 @@ fn test() {
             assert_eq!(test_query.Test(), 0);
         }
         {
-            let raw_owned: *mut std::ffi::c_void = std::mem::transmute(test.clone());
-            let unknown_owned: IUnknown = IUnknown::from_raw_owned(raw_owned);
+            let raw_owned: *mut std::ffi::c_void = test.clone().into_raw();
+            let unknown_owned: IUnknown = IUnknown::from_raw(raw_owned);
             assert_eq!(unknown_owned.as_raw(), test.as_raw());
             let test_query: ITest = unknown_owned.cast().unwrap();
             assert_eq!(test_query.Test(), 0);

--- a/crates/tests/core/tests/unknown.rs
+++ b/crates/tests/core/tests/unknown.rs
@@ -27,7 +27,7 @@ impl Drop for Test {
 }
 
 #[test]
-fn test() {
+fn test_unknown() {
     unsafe {
         let mut dropped = 0;
         let test: ITest = Test { drop: &mut dropped }.into();
@@ -45,6 +45,31 @@ fn test() {
             assert_eq!(unknown_owned.as_raw(), test.as_raw());
             let test_query: ITest = unknown_owned.cast().unwrap();
             assert_eq!(test_query.Test(), 0);
+        }
+
+        assert_eq!(test.Test(), 0);
+        drop(test);
+        assert_eq!(dropped, 1);
+    }
+}
+
+#[test]
+fn test_test() {
+    unsafe {
+        let mut dropped = 0;
+        let test: ITest = Test { drop: &mut dropped }.into();
+
+        {
+            let raw_borrowed: *mut std::ffi::c_void = test.as_raw();
+            let test_borrowed: &ITest = ITest::from_raw_borrowed(&raw_borrowed);
+            assert_eq!(test_borrowed.as_raw(), test.as_raw());
+            assert_eq!(test_borrowed.Test(), 0);
+        }
+        {
+            let raw_owned: *mut std::ffi::c_void = test.clone().into_raw();
+            let unknown_owned: ITest = ITest::from_raw(raw_owned);
+            assert_eq!(unknown_owned.as_raw(), test.as_raw());
+            assert_eq!(unknown_owned.Test(), 0);
         }
 
         assert_eq!(test.Test(), 0);

--- a/crates/tests/core/tests/unknown.rs
+++ b/crates/tests/core/tests/unknown.rs
@@ -54,7 +54,7 @@ fn test_unknown() {
 }
 
 #[test]
-fn test_test() {
+fn test_pointer_conversion_functions() {
     unsafe {
         let mut dropped = 0;
         let test: ITest = Test { drop: &mut dropped }.into();


### PR DESCRIPTION
Fixes: #1975