### PR TITLE
Harden win32 array support to avoid conflicting metadata

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -940,22 +940,20 @@ impl<'a> Gen<'a> {
             let name = self.param_name(param.def);
 
             if let ArrayInfo::Fixed(fixed) = param.array_info {
-                if fixed > 0 && self.reader.param_free_with(param.def).is_none() {
-                    let ty = param.ty.deref();
-                    let ty = self.type_default_name(&ty);
-                    let len = Literal::u32_unsuffixed(fixed as _);
-                    let ty = if self.reader.param_flags(param.def).output() {
-                        quote! { &mut [#ty; #len] }
-                    } else {
-                        quote! { &[#ty; #len] }
-                    };
-                    if self.reader.param_flags(param.def).optional() {
-                        tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
-                    } else {
-                        tokens.combine(&quote! { #name: #ty, });
-                    }
-                    continue;
+                let ty = param.ty.deref();
+                let ty = self.type_default_name(&ty);
+                let len = Literal::u32_unsuffixed(fixed as _);
+                let ty = if self.reader.param_flags(param.def).output() {
+                    quote! { &mut [#ty; #len] }
+                } else {
+                    quote! { &[#ty; #len] }
+                };
+                if self.reader.param_flags(param.def).optional() {
+                    tokens.combine(&quote! { #name: ::core::option::Option<#ty>, });
+                } else {
+                    tokens.combine(&quote! { #name: #ty, });
                 }
+                continue;
             }
 
             if let ArrayInfo::RelativeLen(_) = param.array_info {

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -553,6 +553,11 @@ impl<'a> Reader<'a> {
                         params[position].array_info = ArrayInfo::Removed;
                     }
                 }
+                ArrayInfo::Fixed(_) => {
+                    if self.param_free_with(params[position].def).is_some() {
+                        params[position].array_info = ArrayInfo::Removed;
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
@@ -3004,8 +3004,8 @@ impl IBackgroundCopyJobHttpOptions {
     pub unsafe fn RemoveClientCertificate(&self) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).RemoveClientCertificate)(::windows::core::Interface::as_raw(self)).ok()
     }
-    pub unsafe fn GetClientCertificate(&self, pstorelocation: &mut BG_CERT_STORE_LOCATION, pstorename: &mut ::windows::core::PWSTR, ppcerthashblob: &mut *mut u8, psubjectname: &mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetClientCertificate)(::windows::core::Interface::as_raw(self), ::core::mem::transmute(pstorelocation), ::core::mem::transmute(pstorename), ::core::mem::transmute(ppcerthashblob.as_ptr()), ::core::mem::transmute(psubjectname)).ok()
+    pub unsafe fn GetClientCertificate(&self, pstorelocation: &mut BG_CERT_STORE_LOCATION, pstorename: &mut ::windows::core::PWSTR, ppcerthashblob: *mut *mut u8, psubjectname: &mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetClientCertificate)(::windows::core::Interface::as_raw(self), ::core::mem::transmute(pstorelocation), ::core::mem::transmute(pstorename), ::core::mem::transmute(ppcerthashblob), ::core::mem::transmute(psubjectname)).ok()
     }
     pub unsafe fn SetCustomHeaders<'a, P0>(&self, requestheaders: P0) -> ::windows::core::Result<()>
     where
@@ -3093,8 +3093,8 @@ impl IBackgroundCopyJobHttpOptions2 {
     pub unsafe fn RemoveClientCertificate(&self) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base__.RemoveClientCertificate)(::windows::core::Interface::as_raw(self)).ok()
     }
-    pub unsafe fn GetClientCertificate(&self, pstorelocation: &mut BG_CERT_STORE_LOCATION, pstorename: &mut ::windows::core::PWSTR, ppcerthashblob: &mut *mut u8, psubjectname: &mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base__.GetClientCertificate)(::windows::core::Interface::as_raw(self), ::core::mem::transmute(pstorelocation), ::core::mem::transmute(pstorename), ::core::mem::transmute(ppcerthashblob.as_ptr()), ::core::mem::transmute(psubjectname)).ok()
+    pub unsafe fn GetClientCertificate(&self, pstorelocation: &mut BG_CERT_STORE_LOCATION, pstorename: &mut ::windows::core::PWSTR, ppcerthashblob: *mut *mut u8, psubjectname: &mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base__.GetClientCertificate)(::windows::core::Interface::as_raw(self), ::core::mem::transmute(pstorelocation), ::core::mem::transmute(pstorename), ::core::mem::transmute(ppcerthashblob), ::core::mem::transmute(psubjectname)).ok()
     }
     pub unsafe fn SetCustomHeaders<'a, P0>(&self, requestheaders: P0) -> ::windows::core::Result<()>
     where
@@ -3201,8 +3201,8 @@ impl IBackgroundCopyJobHttpOptions3 {
     pub unsafe fn RemoveClientCertificate(&self) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base__.base__.RemoveClientCertificate)(::windows::core::Interface::as_raw(self)).ok()
     }
-    pub unsafe fn GetClientCertificate(&self, pstorelocation: &mut BG_CERT_STORE_LOCATION, pstorename: &mut ::windows::core::PWSTR, ppcerthashblob: &mut *mut u8, psubjectname: &mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base__.base__.GetClientCertificate)(::windows::core::Interface::as_raw(self), ::core::mem::transmute(pstorelocation), ::core::mem::transmute(pstorename), ::core::mem::transmute(ppcerthashblob.as_ptr()), ::core::mem::transmute(psubjectname)).ok()
+    pub unsafe fn GetClientCertificate(&self, pstorelocation: &mut BG_CERT_STORE_LOCATION, pstorename: &mut ::windows::core::PWSTR, ppcerthashblob: *mut *mut u8, psubjectname: &mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base__.base__.GetClientCertificate)(::windows::core::Interface::as_raw(self), ::core::mem::transmute(pstorelocation), ::core::mem::transmute(pstorename), ::core::mem::transmute(ppcerthashblob), ::core::mem::transmute(psubjectname)).ok()
     }
     pub unsafe fn SetCustomHeaders<'a, P0>(&self, requestheaders: P0) -> ::windows::core::Result<()>
     where


### PR DESCRIPTION
The underlying issue is explained here: https://github.com/microsoft/win32metadata/issues/1263

This change just detects such cases earlier in the pipeline to ensure a more consistent type-system during code gen. 

Fixes: #2031
