### PR TITLE
Add WMI sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,7 @@ jobs:
           cargo clippy -p sample_simple &&
           cargo clippy -p sample_spellchecker &&
           cargo clippy -p sample_uiautomation &&
+          cargo clippy -p sample_wmi &&
           cargo clippy -p sample_xml &&
           cargo clippy -p windows_aarch64_gnullvm &&
           cargo clippy -p windows_aarch64_msvc &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
           cargo test --target ${{ matrix.target }} -p sample_simple &&
           cargo test --target ${{ matrix.target }} -p sample_spellchecker &&
           cargo test --target ${{ matrix.target }} -p sample_uiautomation &&
+          cargo test --target ${{ matrix.target }} -p sample_wmi &&
           cargo test --target ${{ matrix.target }} -p sample_xml &&
           cargo test --target ${{ matrix.target }} -p windows_aarch64_gnullvm &&
           cargo test --target ${{ matrix.target }} -p windows_aarch64_msvc &&

--- a/crates/libs/windows/src/core/strings/bstr.rs
+++ b/crates/libs/windows/src/core/strings/bstr.rs
@@ -5,7 +5,7 @@ use bindings::*;
 pub struct BSTR(*const u16);
 
 impl BSTR {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(core::ptr::null_mut())
     }
 

--- a/crates/samples/wmi/Cargo.toml
+++ b/crates/samples/wmi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sample_wmi"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies.windows]
+path = "../../libs/windows"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_Ole",
+    "Win32_System_Wmi",
+    "Win32_System_Rpc",
+    "Win32_Security",
+]

--- a/crates/samples/wmi/src/main.rs
+++ b/crates/samples/wmi/src/main.rs
@@ -1,0 +1,36 @@
+use windows::{core::*, Win32::Security::*, Win32::System::Com::*, Win32::System::Ole::*, Win32::System::Wmi::*};
+
+fn main() -> Result<()> {
+    unsafe {
+        CoInitializeEx(None, COINIT_MULTITHREADED)?;
+
+        CoInitializeSecurity(PSECURITY_DESCRIPTOR::default(), -1, None, None, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, None, EOAC_NONE, None)?;
+
+        let locator: IWbemLocator = CoCreateInstance(&WbemLocator, None, CLSCTX_INPROC_SERVER)?;
+
+        let server = locator.ConnectServer(&BSTR::from("root\\cimv2"), &BSTR::new(), &BSTR::new(), &BSTR::new(), 0, &BSTR::new(), None)?;
+
+        // TODO: workaround for https://github.com/microsoft/win32metadata/issues/1265
+        let query = server.ExecQuery(&BSTR::from("WQL"), &BSTR::from("select Caption from Win32_LogicalDisk"), WBEM_FLAG_FORWARD_ONLY.0 | WBEM_FLAG_RETURN_IMMEDIATELY.0, None)?;
+
+        loop {
+            let mut row = [None; 1];
+            let mut returned = 0;
+            // TODO: workaround for https://github.com/microsoft/win32metadata/issues/1266
+            query.Next(-1, &mut row, &mut returned).ok()?;
+
+            if let Some(row) = &row[0] {
+                let mut value = Default::default();
+                row.Get(w!("Caption"), 0, &mut value, std::ptr::null_mut(), std::ptr::null_mut())?;
+                println!("{}", VarFormat(&value, None, 0, 0, 0)?);
+
+                // TODO: workaround for https://github.com/microsoft/windows-rs/issues/539
+                VariantClear(&mut value)?;
+            } else {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adding a basic WMI sample as it's a common request. This sample shows how to perform a WQL (like SQL) query using the WMI API. This sample also takes advantage of various improvements made since the 0.40 release.

Fixes: #2040